### PR TITLE
fix tag version

### DIFF
--- a/.github/workflows/triage-issue-comments.yml
+++ b/.github/workflows/triage-issue-comments.yml
@@ -33,7 +33,7 @@ jobs:
             return 'false'
           }
     - name: Label issues with new comments with 'triage'
-      uses: andymckay/labeler@v1.0.2
+      uses: andymckay/labeler@1.0.2
       if: (steps.is-internal-contributor.outputs.result == 'false')
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Label new issues with 'triage'
-      uses: andymckay/labeler@v1.0.2
+      uses: andymckay/labeler@1.0.2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         add-labels: "triage"

--- a/.github/workflows/triage-pull-requests.yml
+++ b/.github/workflows/triage-pull-requests.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Label new pull requests with 'triage'
-      uses: andymckay/labeler@v1.0.2
+      uses: andymckay/labeler@1.0.2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         add-labels: "triage"


### PR DESCRIPTION
I recently added some new workflows, but I was referencing the wrong tag version for the [andymckay/labeler](https://github.com/andymckay/labeler/tags) action. I verified that all the other actions are using the correct tag. 

The tag should be `1.0.2` not `v1.0.2`.

/cc @zeke 