### PR TITLE
Use the latest triage project board action

### DIFF
--- a/.github/workflows/triage-pull-requests.yml
+++ b/.github/workflows/triage-pull-requests.yml
@@ -15,7 +15,7 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         add-labels: "triage"
     - name: Triage to project board
-      uses: konradpabjan/actions-add-new-issue-to-column@v1.1
+      uses: rachmari/actions-add-new-issue-to-column@v1.1.1
       with:
         action-token: ${{ secrets.GITHUB_TOKEN }}
         project-url: "https://github.com/github/docs/projects/1"


### PR DESCRIPTION
This update uses a version of the action that allows adding both issues and pull requests to the project board. This aligns with the action version used in the other triaging workflows.