### PR TITLE
Update about-archiving-repositories.md

### DIFF
--- a/content/github/creating-cloning-and-archiving-repositories/about-archiving-repositories.md
+++ b/content/github/creating-cloning-and-archiving-repositories/about-archiving-repositories.md
@@ -20,7 +20,7 @@ versions:
 
 Once a repository is archived, you cannot add or remove collaborators or teams. Contributors with access to the repository can only fork or star your project.
 
-When a repository is archived, its issues, pull requests, code, labels, milestones, projects, wiki, releases, commits, tags, branches, reactions, and comments become read-only. To make changes in an archived repository, you must unarchive the repository first.
+When a repository is archived, its issues, pull requests, code, labels, milestones, projects, wiki, releases, commits, tags, branches, reactions, code scanning alerts, and comments become read-only. To make changes in an archived repository, you must unarchive the repository first.
 
 You can search for archived repositories. For more information, see "[Searching for repositories](/articles/searching-for-repositories/#search-based-on-whether-a-repository-is-archived)." You can also search for issues and pull requests within archived repositories. For more information, see "[Searching issues and pull requests](/articles/searching-issues-and-pull-requests/#search-based-on-whether-a-repository-is-archived)."  
 


### PR DESCRIPTION
### Why:

Fixes #166 .

### What's being changed:

Updated the description on what happens when a repository is archived to indicate that code scanning alerts are also marked as read-only.

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
