### PR TITLE
Update powershell example using Out-File.

### DIFF
--- a/content/actions/reference/workflow-commands-for-github-actions.md
+++ b/content/actions/reference/workflow-commands-for-github-actions.md
@@ -234,7 +234,7 @@ During the execution of a workflow, the runner generates temporary files that ca
 
 ```
 steps:
-  - run: echo "mypath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+  - run: echo "mypath" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 ```
 
 {% endwarning %}


### PR DESCRIPTION
<!--
HUBBERS BEWARE! THE GITHUB/DOCS REPO IS PUBLIC TO THE ENTIRE INTERNET. OPEN AN ISSUE IN GITHUB/DOCS-CONTENT https://github.com/github/docs-content/issues/new/choose INSTEAD.
-->

<!--
Hello! Thanks for your interest in contributing to this project.

Before opening a PR, please see our [CONTRIBUTING.md](https://github.com/github/docs/blob/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

Thanks again! :octocat:
-->

### Why:

The default for Out-File is to overwrite the file. This can cause confusion if you use the given example multiple times in the same step, as all previous entries will be lost.

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

Add `-Append` to the example for PowerShell using `Out-File` to avoid overwriting previous entries.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] All of the tests are passing.
- [ ] I have reviewed my changes in staging.
- [X] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [X] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
