### PR TITLE
Add raw tags to code blocks

### DIFF
--- a/content/actions/learn-github-actions/managing-complex-workflows.md
+++ b/content/actions/learn-github-actions/managing-complex-workflows.md
@@ -20,6 +20,7 @@ If your workflows use sensitive data, such as passwords or certificates, you can
 
 This example action demonstrates how to reference an existing secret as an environment variable, and send it as a parameter to an example command.
 
+{% raw %}
 ```yaml
 jobs:
   example-job:
@@ -30,6 +31,7 @@ jobs:
         run: |
           example-command "$SUPER_SECRET"
 ```
+{% endraw %}
 
 For more information, see "[Creating and storing encrypted secrets](/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)."
 
@@ -62,6 +64,7 @@ For more information, see [`jobs.<job_id>.needs`](/actions/reference/workflow-sy
 
 You can use a build matrix if you want your workflow to run tests across multiple combinations of operating systems, platforms, and languages. The build matrix is created using the `strategy` keyword, which receives the build options as an array. For example, this build matrix will run the job multiple times, using different versions of Node.js:
 
+{% raw %}
 ```yaml
 jobs:
   build:
@@ -74,6 +77,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 ```
+{% endraw %}
 
 For more information, see [`jobs.<job_id>.strategy.matrix`](/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix).
 
@@ -83,6 +87,7 @@ For more information, see [`jobs.<job_id>.strategy.matrix`](/actions/reference/w
 
 This example demonstrates how to cache the ` ~/.npm` directory:
 
+{% raw %}
 ```yaml
 jobs:
   example-job:
@@ -97,6 +102,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
 ```
+{% endraw %}
 
 For more information, see "[Caching dependencies to speed up workflows](/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows)."
 


### PR DESCRIPTION
Fixes: https://github.com/github/docs/issues/287

### Why:

Code blocks with context/expression syntax were included without escaping them in `{% raw %}` tags. This meant that the liquid processing stripped out those mentions. 

### What's being changed:

Added `{% raw %}` tags to the affected clode blocks.

Stage preview: https://docs-305--lucascosticomplex-wo.herokuapp.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
