### PR TITLE
It can be misunderstood in human language.

### DIFF
--- a/content/github/administering-a-repository/classifying-your-repository-with-topics.md
+++ b/content/github/administering-a-repository/classifying-your-repository-with-topics.md
@@ -19,7 +19,7 @@ To browse the most used topics, go to https://github.com/topics/.
 
 {% if currentVersion == "free-pro-team@latest" %}You can contribute to {% data variables.product.product_name %}'s set of featured topics in the [github/explore](https://github.com/github/explore) repository. {% endif %}
 
-Repository admins can add any topics they'd like to a repository. Helpful topics to classify a repository include the repository's intended purpose, subject area, community, or language.{% if currentVersion == "free-pro-team@latest" %} Additionally, {% data variables.product.product_name %} analyzes public repository content and generates suggested topics that repository admins can accept or reject. Private repository content is not analyzed and does not receive topic suggestions.{% endif %}
+Repository admins can add any topics they'd like to a repository. Helpful topics to classify a repository include the repository's intended purpose, subject area, community, or programming language.{% if currentVersion == "free-pro-team@latest" %} Additionally, {% data variables.product.product_name %} analyzes public repository content and generates suggested topics that repository admins can accept or reject. Private repository content is not analyzed and does not receive topic suggestions.{% endif %}
 
 Public and private repositories can have topics, although you will only see private repositories that you have access to in topic search results.
 


### PR DESCRIPTION
It can be misunderstood as meaning human language, so I think it would be good to clarify.
I want to prevent non-technical topics from appearing on the topics/featured page.
thank you.

<!--
HUBBERS BEWARE! THE GITHUB/DOCS REPO IS PUBLIC TO THE ENTIRE INTERNET. OPEN AN ISSUE IN GITHUB/DOCS-CONTENT https://github.com/github/docs-content/issues/new/choose INSTEAD.
-->

<!--
Hello! Thanks for your interest in contributing to this project.

Before opening a PR, please see our [CONTRIBUTING.md](https://github.com/github/docs/blob/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

Thanks again! :octocat:
-->

### Why:
The reason for the modification is not to mean that the code is related to Korean,
This is because it is intended to be used to inform the person who wrote the code that they can speak Korean.

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [ ] All of the tests are passing.
- [ ] I have reviewed my changes in staging.
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
