### PR TITLE
fix up redirect paths for Windows

### DIFF
--- a/middleware/archived-enterprise-versions.js
+++ b/middleware/archived-enterprise-versions.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const slash = require('slash')
 const { latest, deprecated, firstVersionDeprecatedOnNewSite, lastVersionWithoutStubbedRedirectFiles } = require('../lib/enterprise-server-releases')
 const patterns = require('../lib/patterns')
 const versionSatisfiesRange = require('../lib/version-satisfies-range')
@@ -69,7 +70,7 @@ module.exports = async (req, res, next) => {
 // for <2.13: /2.12/user/articles/viewing-contributions-on-your-profile
 function getProxyPath (reqPath, requestedVersion) {
   const proxyPath = versionSatisfiesRange(requestedVersion, `>=${firstVersionDeprecatedOnNewSite}`)
-    ? path.join('/', requestedVersion, reqPath)
+    ? slash(path.join('/', requestedVersion, reqPath))
     : reqPath.replace(/^\/enterprise/, '')
 
   return `https://github.github.com/help-docs-archived-enterprise-versions${proxyPath}`
@@ -97,7 +98,7 @@ function getFallbackRedirects (req, requestedVersion) {
     // ]
     .filter(oldPath => oldPath.startsWith('/enterprise') && patterns.enterpriseNoVersion.test(oldPath))
     // add in the current language and version
-    .map(oldPath => path.join('/', req.context.currentLanguage, oldPath.replace('/enterprise/', `/enterprise/${requestedVersion}/`)))
+    .map(oldPath => slash(path.join('/', req.context.currentLanguage, oldPath.replace('/enterprise/', `/enterprise/${requestedVersion}/`))))
     // ignore paths that match the requested path
     .filter(oldPath => oldPath !== req.path)
 }


### PR DESCRIPTION

### Why:
resolves: #313 

### What's being changed:

wrap `path.join` with `slash()` calls

### Check off the following:
- [ ] All of the tests are passing.
- [ ] I have reviewed my changes in staging.
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
