### PR TITLE
Configure referrerPolicyo

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -23,6 +23,7 @@ module.exports = function (app) {
   app.use(require('./loaderio-verification'))
   app.use(require('./cors'))
   app.use(require('./csp'))
+  app.use(require('./referrer-policy'))
   app.use(require('helmet')())
   app.use(require('./robots'))
   app.use(require('./cookie-parser'))

--- a/middleware/referrer-policy.js
+++ b/middleware/referrer-policy.js
@@ -1,0 +1,8 @@
+// This module defines the Referrer-Policy HEADER behaviour
+// https://developer.mozilla.org/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns
+
+const { referrerPolicy } = require('helmet')
+
+module.exports = referrerPolicy({
+  policy: "strict-origin-when-cross-origin",
+})


### PR DESCRIPTION
[https://github.com/github/docs/pull/412#issue-501148404]() Set the default referrer-policy header to strict-origin-when-cross-origin

<!--
HUBBERS BEWARE! THE GITHUB/DOCS REPO IS PUBLIC TO THE ENTIRE INTERNET. OPEN AN ISSUE IN GITHUB/DOCS-CONTENT https://github.com/github/docs-content/issues/new/choose INSTEAD.
-->

<!--
Hello! Thanks for your interest in contributing to this project.

Before opening a PR, please see our [CONTRIBUTING.md](https://github.com/github/docs/blob/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

Thanks again! :octocat:
-->

### Why:

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
