### PR TITLE
fix linux xclip command

### DIFF
--- a/content/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account.md
+++ b/content/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account.md
@@ -87,7 +87,7 @@ After adding a new SSH key to your {% data variables.product.product_name %} acc
   $ sudo apt-get install xclip
   # Downloads and installs xclip. If you don't have `apt-get`, you might need to use another installer (like `yum`)
 
-  $ xclip -sel clip &lt; ~/.ssh/id_rsa.pub
+  $ xclip ~/.ssh/id_rsa.pub &gt; clip
   # Copies the contents of the id_rsa.pub file to your clipboard
   ```
   {% tip %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. Explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

The docs listed incorrect usage for the xclip CLI.

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Single line edit for the command to copy contents of `id_rsa.pub` to clipboard for linux users utilizing `xclip` CLI.

### Check off the following:
- [x] All of the tests are passing.
- [ ] I have reviewed my changes in staging.
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
