### PR TITLE
Fix the autoupdatebranch Action

### DIFF
--- a/.github/allowed-actions.js
+++ b/.github/allowed-actions.js
@@ -17,7 +17,7 @@ module.exports = [
   'actions/stale@44f9eae0adddf72dbf3eedfacc999f70afcec1a8',
   'crowdin/github-action@fd9429dd63d6c0f8a8cb4b93ad8076990bd6e688',
   'dawidd6/action-delete-branch@47743101a121ad657031e6704086271ca81b1911',
-  'docker://chinthakagodawita/autoupdate-action:4d72a15b5989091e07d6f4ce4cd3afb7b835ad1e68190937df778b702a547cdc',
+  'docker://chinthakagodawita/autoupdate-action::v1',
   'fkirc/skip-duplicate-actions@a12175f6209d4805b5a163d723270be2a0dc7b36',
   'github/codeql-action/analyze@v1',
   'github/codeql-action/init@v1',

--- a/.github/workflows/autoupdate-branch.yml
+++ b/.github/workflows/autoupdate-branch.yml
@@ -8,7 +8,7 @@ jobs:
     name: autoupdate
     runs-on: ubuntu-18.04
     steps:
-      - uses: docker://chinthakagodawita/autoupdate-action:4d72a15b5989091e07d6f4ce4cd3afb7b835ad1e68190937df778b702a547cdc
+      - uses: docker://chinthakagodawita/autoupdate-action::v1
         env:
           GITHUB_TOKEN: ${{ secrets.OCTOMERGER_PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
           PR_FILTER: labelled


### PR DESCRIPTION
When moving to shas for more security, it looks like we broke the Docker action.

This should get it working again. Ideally we move to a Sha somehow in the future but I'm unsure how to do that considering the unique format of this Action being served from Docker rather than GitHub.

Example of the Action breaking: https://github.com/github/docs/actions/runs/309155706/workflow

### Check off the following:
- [ ] All of the tests are passing.
