### PR TITLE
Remove unnecessary quotes

### DIFF
--- a/content/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors.md
+++ b/content/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors.md
@@ -48,7 +48,7 @@ You can use {% data variables.product.prodname_desktop %} to create a commit wit
   >
   >
   Co-authored-by: <em>name</em> &lt;<em>name@example.com</em>&gt;
-  Co-authored-by: <em>another-name</em> &lt;<em>another-name@example.com</em>&gt;"
+  Co-authored-by: <em>another-name</em> &lt;<em>another-name@example.com</em>&gt;
   ```
 
 The new commit and message will appear on {% data variables.product.product_location %} the next time you push. For more information, see "[Pushing changes to a remote repository](/articles/pushing-commits-to-a-remote-repository/)."


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Unnecessary quotes in documentation.

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

Removing a bunch of quotes from the file below:

- `content/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors.md`

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
