### PR TITLE
Manual repo sync to fix the Actions error

### DIFF
--- a/.github/allowed-actions.js
+++ b/.github/allowed-actions.js
@@ -31,7 +31,7 @@ module.exports = [
   'rachmari/actions-add-new-issue-to-column@1a459ef92308ba7c9c9dc2fcdd72f232495574a9',
   'rachmari/labeler@832d42ec5523f3c6d46e8168de71cd54363e3e2e',
   'repo-sync/github-sync@3832fe8e2be32372e1b3970bbae8e7079edeec88',
-  'repo-sync/pull-request@58af525d19d3c2b4f744d3348c6823b6340a4921',
+  'repo-sync/pull-request@33777245b1aace1a58c87a29c90321aa7a74bd7d',
   'rtCamp/action-slack-notify@e17352feaf9aee300bf0ebc1dfbf467d80438815',
   'tjenkinson/gh-action-auto-merge-dependency-updates@cee2ac0'
 ]

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -45,7 +45,7 @@ jobs:
         github_token: ${{ secrets.OCTOMERGER_PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
 
     - name: Create pull request
-      uses: repo-sync/pull-request@58af525d19d3c2b4f744d3348c6823b6340a4921
+      uses: repo-sync/pull-request@33777245b1aace1a58c87a29c90321aa7a74bd7d
       env:
         GITHUB_TOKEN: ${{ secrets.OCTOMERGER_PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}
       with:

--- a/tests/links-and-images/developer-links-and-images.js
+++ b/tests/links-and-images/developer-links-and-images.js
@@ -9,6 +9,8 @@ const { getVersionedPathWithLanguage } = require('../../lib/path-utils')
 const renderContent = require('../../lib/render-content')
 const checkImages = require('../../lib/check-images')
 const checkLinks = require('../../lib/check-developer-links')
+const enterpriseServerVersions = Object.keys(require('../../lib/all-versions'))
+  .filter(version => version.startsWith('enterprise-server@'))
 const { getOldVersionFromNewVersion } = require('../../lib/old-versions-utils')
 
 // schema-derived data to add to context object
@@ -64,6 +66,7 @@ describe('page rendering', () => {
         page.version = pageVersion
         context.page = page
         context.currentVersion = pageVersion
+        context.enterpriseServerVersions = enterpriseServerVersions
 
         const relevantPermalink = page.permalinks.find(permalink => permalink.pageVersion === pageVersion)
 

--- a/tests/links-and-images/links-and-images.js
+++ b/tests/links-and-images/links-and-images.js
@@ -5,6 +5,8 @@ const getApplicableVersions = require('../../lib/get-applicable-versions')
 const renderContent = require('../../lib/render-content')
 const checkImages = require('../../lib/check-images')
 const checkLinks = require('../../lib/check-links')
+const enterpriseServerVersions = Object.keys(require('../../lib/all-versions'))
+  .filter(version => version.startsWith('enterprise-server@'))
 const flat = require('flat')
 const { last } = require('lodash')
 
@@ -56,6 +58,7 @@ describe('page rendering', () => {
         page.version = pageVersion
         context.page = page
         context.currentVersion = pageVersion
+        context.enterpriseServerVersions = enterpriseServerVersions
 
         // collect elements of the page that may contain links
         const pageContent = page.intro + page.permissions + page.markdown


### PR DESCRIPTION
### Why:

I introduced an Actions error into the repo sync process a few hours ago.

### What's being changed:

The Actions error will be resolved by updating to the latest `repo-sync/pull-request` action in this manual one-time repo sync.

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
