### PR TITLE
Update creating-a-personal-access-token.md

### DIFF
--- a/content/github/authenticating-to-github/creating-a-personal-access-token.md
+++ b/content/github/authenticating-to-github/creating-a-personal-access-token.md
@@ -26,7 +26,7 @@ Personal access tokens (PATs) are an alternative to using passwords for authenti
 4. Click **Generate new token**.
    ![Generate new token button](/assets/images/help/settings/generate_new_token.png)
 5. Give your token a descriptive name.
-   ![Token description field](/assets/images/help/settings/token_description.png)
+   ![Token description field](https://res.cloudinary.com/ramizackaryshamir/image/upload/v1603818860/pullrequest-meetyourcreator-ramizackaryshamir-lines_28-29_htggx1.png)
 6. Select the scopes, or permissions, you'd like to grant this token. To use your token to access repositories from the command line, select **repo**.
    ![Selecting token scopes](/assets/images/help/settings/token_scopes.gif)
 7. Click **Generate token**.


### PR DESCRIPTION
What is the current behavior?

Image screenshot for step 6 'Give your token a descriptive name' is incorrect. This can cause confusion for new contributors, especially since all the other screenshot images are correct.

What changes are you suggesting?

Replace the current and incorrect image screenshot with the correct one being submitted.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
