### PR TITLE
chore: Pull JS Linting to separate Action

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -1,0 +1,59 @@
+name: Lint JS
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches-ignore:
+      - translations
+
+jobs:
+  see_if_should_skip:
+    runs-on: ubuntu-latest
+
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@36feb0d8d062137530c2e00bd278d138fe191289
+        with:
+          cancel_others: 'false'
+          github_token: ${{ github.token }}
+          paths: '["**/*.js","package*.json",".github/workflows/js-lint.yml"]'
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: see_if_should_skip
+    if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
+
+      - name: Setup node
+        uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
+        with:
+          node-version: 14.x
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+
+      - name: Cache node modules
+        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npx standard
+
+      - name: Check dependencies
+        run: npm run check-deps

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           cancel_others: 'false'
           github_token: ${{ github.token }}
-          paths: '["**/*.js","package*.json",".github/workflows/js-lint.yml"]'
+          paths: '["**/*.js", "package*.json", ".github/workflows/js-lint.yml"]'
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,48 +28,7 @@ jobs:
           cancel_others: 'false'
           github_token: ${{ github.token }}
           paths: '[".github/workflows/test.yml",".node-version", ".npmrc", "app.json", "content/**", "data/**","lib/**", "Dockerfile", "feature-flags.json", "Gemfile", "Gemfile.lock", "middleware/**", "node_modules/**","package.json", "package-lock.json", "server.js", "tests/**", "translations/**", "Procfile", "webpack.config.js"]'
-  lint:
-    needs: see_if_should_skip
-    runs-on: ubuntu-latest
-    steps:
-      # Each of these ifs needs to be repeated at each step to make sure the required check still runs
-      # Even if if doesn't do anything
-      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
-        name: Check out repo
-        uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
 
-      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
-        name: Setup node
-        uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
-        with:
-          node-version: 14.x
-
-      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
-        name: Get npm cache directory
-        id: npm-cache
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
-
-      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
-        name: Cache node modules
-        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
-        with:
-          path: ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
-        name: Install dependencies
-        run: npm ci
-
-      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
-        name: Run linter
-        run: npx standard
-
-      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
-        name: Check dependencies
-        run: npm run check-deps
   test:
     needs: see_if_should_skip
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you've found a problem, you can open an issue using a [template](https://gith
 
 #### Solve an issue
 
-If you have a solution to one of the open issues, you will need to fork the repository and submit a PR using the [template](https://github.com/github/docs/blob/main/CONTRIBUTING.md#pull-request-template) that is visible automatically in the pull request body. For more details about this process, please check out [Getting Started with Contributing](/CONTRIBUTING.md). 
+If you have a solution to one of the open issues, you will need to fork the repository and submit a PR using the [template](https://github.com/github/docs/blob/main/CONTRIBUTING.md#pull-request-template) that is visible automatically in the pull request body. For more details about this process, please check out [Getting Started with Contributing](/CONTRIBUTING.md).
 
 #### Join us in discussions
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Reduce number of jobs, so the JS linting is only run if JS files are changed. I left the duplicate job run in the test-translations.yml, but it could also probably be removed if the branch filters are updated here

### What's being changed:

A separate linting job that uses the pinned version of `standard` rather than a floating version from `npx` run only when JS files are changed. Relocated the previous `--fix` version of the script to a separate target

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
