### PR TITLE
Rename Enterprise Administrator to Enterprise Server (actual product) for easier identification

### DIFF
--- a/content/admin/index.md
+++ b/content/admin/index.md
@@ -1,5 +1,5 @@
 ---
-title: Enterprise Administrators
+title: Enterprise Server
 redirect_from:
   - /enterprise/admin/hidden/migrating-from-github-fi/
   - /enterprise/admin


### PR DESCRIPTION
### Why:

Looking for something for GHES, several of the Field Services engineers and I noted that Enterprise Server was misnamed as "Administrator" - named for the user, not the product.


### What's being changed:

<img width="281" alt="Screen Shot 2020-10-30 at 1 02 47 PM" src="https://user-images.githubusercontent.com/31934692/97751881-4cccf980-1ab0-11eb-87ed-97009e24411a.png">


<img width="769" alt="Screen Shot 2020-10-30 at 12 57 40 PM" src="https://user-images.githubusercontent.com/31934692/97751444-92d58d80-1aaf-11eb-9f29-21e4faa93f22.png">


