### PR TITLE
Actions: Local actions are automatically allowed

### DIFF
--- a/data/reusables/actions/allow-specific-actions-intro.md
+++ b/data/reusables/actions/allow-specific-actions-intro.md
@@ -6,7 +6,9 @@ When you select the **Allow select actions**, there are additional options that 
 
   To restrict access to specific tags or commit SHAs of an action, use the same `<OWNER>/<REPO>@<TAG OR SHA>` syntax used in the workflow to select the action. For example, `actions/javascript-action@v1.0.1` to select a tag or `actions/javascript-action@172239021f7ba04fe7327647b213799853a9eb89` to select a SHA. For more information, see "[Finding and customizing actions](/actions/learn-github-actions/finding-and-customizing-actions#using-release-management-for-your-custom-actions)."
 
-  You can use the `*` wildcard character to match patterns. For example, to allow all actions in organizations that start with `space-org`, you can specify `space-org*/*`. To add all actions in repositories that start with octocat, you can use `*/octocat*@*`. For more information about using the `*` wildcard, see "[Workflow syntax for GitHub Actions](/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)." 
+  You can use the `*` wildcard character to match patterns. For example, to allow all actions in organizations that start with `space-org`, you can specify `space-org*/*`. To add all actions in repositories that start with octocat, you can use `*/octocat*@*`. For more information about using the `*` wildcard, see "[Workflow syntax for GitHub Actions](/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)".
+
+  Actions whose repositories are in the same organization or user account (local actions) are automatically allowed. For example, the action `space-org/action` is allowed in `space-org/project` without adding it to the list.
 
   {% if currentVersion == "free-pro-team@latest" %}
   {% note %}


### PR DESCRIPTION
### Why:

The "Allow select action" mode does not require to add actions from the same owner/org to be added to the list. Tested with regular account, not org - please double-check. Is this actually by design?

### What's being changed:

Add paragraph to point out that local actions are implicitly allowed.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#allowing-specific-actions-to-run

### Check off the following:
- [ ] All of the tests are passing.
- [ ] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
