### PR TITLE
Missing German Translation from English to German

### DIFF
--- a/translations/de-DE/content/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request.md
+++ b/translations/de-DE/content/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request.md
@@ -11,7 +11,8 @@ versions:
 
 ### Informationen zum Zusammenführen von Pull Requests
 
-Mit einem Pull Request schlägst Du vor, dass Änderungen, die Du an einem Head-Branch gemacht hast, in einen Basis-Branch zusammengeführt werden sollten. {% data reusables.pull_requests.about-protected-branches %} Es kann jedoch Einschränkungen geben, wann Du einen Pull Request zu einem bestimmten Branch zusammenführen kannst. For example, you may only be able to merge a pull request into the default branch if required status checks are passing. Weitere Informationen findest Du unter „[Informationen zu geschützten Branches](/github/administering-a-repository/about-protected-branches).“
+Mit einem Pull Request schlägst Du vor, dass Änderungen, die Du an einem Head-Branch gemacht hast, in einen Basis-Branch zusammengeführt werden sollten. {% data reusables.pull_requests.about-protected-branches %} Es kann jedoch Einschränkungen geben, wann Du einen Pull Request zu einem bestimmten Branch zusammenführen kannst. Zum Beispiel kannst du eine Pull Request möglicherweise nur dann zu einem Branch einbinden, wenn die erforderlichen Status Rechte übereinstimmen.
+Weitere Informationen findest Du unter „[Informationen zu geschützten Branches](/github/administering-a-repository/about-protected-branches).“
 
 Wenn beim Pull Request Mergekonflikte vorliegen oder Du die Änderungen vor dem Zusammenführen testen möchtest, kannst Du [den Pull Request lokal auschecken](/articles/checking-out-pull-requests-locally) und ihn über die Befehlszeile zusammenführen.
 

--- a/translations/de-DE/content/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request.md
+++ b/translations/de-DE/content/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request.md
@@ -11,7 +11,7 @@ versions:
 
 ### Informationen zum Zusammenführen von Pull Requests
 
-Mit einem Pull Request schlägst Du vor, dass Änderungen, die Du an einem Head-Branch gemacht hast, in einen Basis-Branch zusammengeführt werden sollten. {% data reusables.pull_requests.about-protected-branches %} Es kann jedoch Einschränkungen geben, wann Du einen Pull Request zu einem bestimmten Branch zusammenführen kannst. Zum Beispiel kannst du eine Pull Request möglicherweise nur dann zu einem Branch einbinden, wenn die erforderlichen Status Rechte übereinstimmen.
+Mit einem Pull Request schlägst Du vor, dass Änderungen, die Du an einem Head-Branch gemacht hast, in einen Basis-Branch zusammengeführt werden sollten. {% data reusables.pull_requests.about-protected-branches %} Es kann jedoch Einschränkungen geben, wann Du einen Pull Request zu einem bestimmten Branch zusammenführen willst. Zum Beispiel kannst du eine Pull Request möglicherweise nur dann zu einem Branch einbinden, wenn die erforderlichen Status Rechte übereinstimmen.
 Weitere Informationen findest Du unter „[Informationen zu geschützten Branches](/github/administering-a-repository/about-protected-branches).“
 
 Wenn beim Pull Request Mergekonflikte vorliegen oder Du die Änderungen vor dem Zusammenführen testen möchtest, kannst Du [den Pull Request lokal auschecken](/articles/checking-out-pull-requests-locally) und ihn über die Befehlszeile zusammenführen.

--- a/translations/de-DE/content/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request.md
+++ b/translations/de-DE/content/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request.md
@@ -11,7 +11,7 @@ versions:
 
 ### Informationen zum Zusammenführen von Pull Requests
 
-Mit einem Pull Request schlägst Du vor, dass Änderungen, die Du an einem Head-Branch gemacht hast, in einen Basis-Branch zusammengeführt werden sollten. {% data reusables.pull_requests.about-protected-branches %} Es kann jedoch Einschränkungen geben, wenn Du einen Pull Request zu einem bestimmten Branch zusammenführen willst. Zum Beispiel kannst du einen Pull Request möglicherweise nur dann mit einem Branch einbinden, wenn die erforderlichen Status Rechte übereinstimmen.
+Mit einem Pull Request schlägst Du vor, dass Änderungen, die Du an einem Head-Branch gemacht hast, in einen Basis-Branch zusammengeführt werden sollten. {% data reusables.pull_requests.about-protected-branches %} Es kann jedoch Einschränkungen geben, wenn Du einen Pull Request zu einem bestimmten Branch zusammenführen willst. Zum Beispiel kannst du einen Pull Request möglicherweise nur dann mit einem Branch einbinden, wenn die erforderlichen Status Rechte mit deinen übereinstimmen.
 Weitere Informationen findest Du unter „[Informationen zu geschützten Branches](/github/administering-a-repository/about-protected-branches).“
 
 Wenn beim Pull Request Mergekonflikte vorliegen oder Du die Änderungen vor dem Zusammenführen testen möchtest, kannst Du [den Pull Request lokal auschecken](/articles/checking-out-pull-requests-locally) und ihn über die Befehlszeile zusammenführen.

--- a/translations/de-DE/content/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request.md
+++ b/translations/de-DE/content/github/collaborating-with-issues-and-pull-requests/merging-a-pull-request.md
@@ -11,7 +11,7 @@ versions:
 
 ### Informationen zum Zusammenführen von Pull Requests
 
-Mit einem Pull Request schlägst Du vor, dass Änderungen, die Du an einem Head-Branch gemacht hast, in einen Basis-Branch zusammengeführt werden sollten. {% data reusables.pull_requests.about-protected-branches %} Es kann jedoch Einschränkungen geben, wann Du einen Pull Request zu einem bestimmten Branch zusammenführen willst. Zum Beispiel kannst du eine Pull Request möglicherweise nur dann zu einem Branch einbinden, wenn die erforderlichen Status Rechte übereinstimmen.
+Mit einem Pull Request schlägst Du vor, dass Änderungen, die Du an einem Head-Branch gemacht hast, in einen Basis-Branch zusammengeführt werden sollten. {% data reusables.pull_requests.about-protected-branches %} Es kann jedoch Einschränkungen geben, wenn Du einen Pull Request zu einem bestimmten Branch zusammenführen willst. Zum Beispiel kannst du einen Pull Request möglicherweise nur dann mit einem Branch einbinden, wenn die erforderlichen Status Rechte übereinstimmen.
 Weitere Informationen findest Du unter „[Informationen zu geschützten Branches](/github/administering-a-repository/about-protected-branches).“
 
 Wenn beim Pull Request Mergekonflikte vorliegen oder Du die Änderungen vor dem Zusammenführen testen möchtest, kannst Du [den Pull Request lokal auschecken](/articles/checking-out-pull-requests-locally) und ihn über die Befehlszeile zusammenführen.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:
Because of its missing translation from English to German at this corrected part of the text.

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:
The English explanation of a Github merge was changed to german.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
