### PR TITLE
chore: Add title to Merge Notification CI job

### DIFF
--- a/.github/workflows/merged-notification.yml
+++ b/.github/workflows/merged-notification.yml
@@ -1,10 +1,11 @@
+name: Merged notification
 on:
   pull_request_target:
     types: ['closed']
 
 jobs:
   comment:
-    if: github.event.repository.private == false && github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch
+    if: github.repository == 'github/docs' && github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@626af12fe9a53dc2972b48385e7fe7dec79145c9


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

On the jobs page, because the workflow doesn't have a name, it just shows as the file name

![image](https://user-images.githubusercontent.com/1297909/98054319-a1ea7180-1e08-11eb-87dc-a9e10ba99abc.png)


### What's being changed:

Add a `name` value so that the job will be rendered under that string instead of the file name. Also swapped the testing from testing that if the job is running on a private repo, to compare to the repository name like the other jobs

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
