### PR TITLE
chore: run autoupdate branch on cron schedule

### DIFF
--- a/.github/workflows/autoupdate-branch.yml
+++ b/.github/workflows/autoupdate-branch.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '*/30 * * * *' # every 30 minutes
 jobs:
   autoupdate:
     name: autoupdate


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

If something lands on the default branch while the repo sync is running, it seems to get it stuck in a "behind" state that the auto-merge job can't handle. By adding an additional cron job for this workflow, it should be able to catch and update the repo-sync branch when it happens

### What's being changed:

Adding a cron job to the existing `autoupdate branch` job with an arbitrary 30 minute cycle.

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
