### PR TITLE
chore: Bump actions/stale to 3.0.13 for CVE issue

### DIFF
--- a/.github/allowed-actions.js
+++ b/.github/allowed-actions.js
@@ -10,7 +10,7 @@ module.exports = [
   'actions/labeler@5f867a63be70efff62b767459b009290364495eb', //actions/labeler@v2.2.0
   'actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d', //actions/setup-node@v1.4.4
   'actions/setup-ruby@5f29a1cd8dfebf420691c4c9a0e832e2fae5a526', //actions/setup-ruby@v1.1.2
-  'actions/stale@44f9eae0adddf72dbf3eedfacc999f70afcec1a8', //actions/stale@v3.0.12
+  'actions/stale@af4072615903a8b031f986d25b1ae3bf45ec44d4', //actions/stale@v3.0.13
   'crowdin/github-action@fd9429dd63d6c0f8a8cb4b93ad8076990bd6e688',
   'dawidd6/action-delete-branch@47743101a121ad657031e6704086271ca81b1911',
   'docker://chinthakagodawita/autoupdate-action:v1',

--- a/.github/workflows/60-days-stale-check.yml
+++ b/.github/workflows/60-days-stale-check.yml
@@ -7,9 +7,9 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@44f9eae0adddf72dbf3eedfacc999f70afcec1a8
+    - uses: actions/stale@af4072615903a8b031f986d25b1ae3bf45ec44d4
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }} 
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
         stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'
         days-before-stale: 60

--- a/.github/workflows/triage-stale-check.yml
+++ b/.github/workflows/triage-stale-check.yml
@@ -7,11 +7,11 @@ jobs:
   stale:
     if: github.repository == 'github/docs'
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/stale@44f9eae0adddf72dbf3eedfacc999f70afcec1a8
+    - uses: actions/stale@af4072615903a8b031f986d25b1ae3bf45ec44d4
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }} 
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR is stale because it has been open 7 days with no activity and will be automatically closed in 3 days. To keep this PR open, update the PR by adding a comment or pushing a commit.'
         days-before-stale: 7
         days-before-close: 10


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Google Project Zero released an advisory on the older versions of the Action because it would print things like the title to the console without escaping.

### What's being changed:

Bump the actions/stale hash to https://github.com/actions/stale/releases/tag/v3.0.13

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
