### PR TITLE
Restore redirects in a GitHub Pages article

### DIFF
--- a/content/github/working-with-github-pages/creating-a-github-pages-site.md
+++ b/content/github/working-with-github-pages/creating-a-github-pages-site.md
@@ -2,6 +2,9 @@
 title: Creating a GitHub Pages site
 intro: 'You can create a {% data variables.product.prodname_pages %} site in a new or existing repository.'
 redirect_from:
+  - /articles/creating-pages-manually/
+  - /articles/creating-project-pages-manually/
+  - /articles/creating-project-pages-from-the-command-line/
   - /articles/creating-project-pages-using-the-command-line/
   - /articles/creating-a-github-pages-site
 product: '{% data reusables.gated-features.pages %}'


### PR DESCRIPTION
Fixes an issue raised in #1071. 

This PR restores three legacy redirects that were inadvertently lost during a large content restructure in 2019.