### PR TITLE
Uniform ed25519 usage across SSH docs

### DIFF
--- a/data/reusables/ssh/add-ssh-key-to-ssh-agent-commandline.md
+++ b/data/reusables/ssh/add-ssh-key-to-ssh-agent-commandline.md
@@ -1,3 +1,3 @@
 ```shell
-$ ssh-add ~/.ssh/id_rsa
+$ ssh-add ~/.ssh/id_ed25519
 ```

--- a/data/reusables/ssh/add-ssh-key-to-ssh-agent.md
+++ b/data/reusables/ssh/add-ssh-key-to-ssh-agent.md
@@ -1,1 +1,1 @@
-If you created your key with a different name, or if you are adding an existing key that has a different name, replace *id_rsa* in the command with the name of your private key file.
+If you created your key with a different name, or if you are adding an existing key that has a different name, replace *id_ed25519* in the command with the name of your private key file.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why: I was trying to add a new ssh key and noticed that github now accepts the more secure ed25519 encryption standard! However, in the documentation, some parts of the tutorial still used referenced the old RSA steps. So I wanted to help make the documentation more uniform and use ed25519. 

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:
![github change](https://user-images.githubusercontent.com/17329435/98298082-0d545080-1f7b-11eb-98cc-885d5614ccc8.jpg)


<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
