### PR TITLE
chore: Upgrade actions/cache to v2.1.3

### DIFF
--- a/.github/allowed-actions.js
+++ b/.github/allowed-actions.js
@@ -4,7 +4,7 @@
 // can be added it this list.
 
 module.exports = [
-  'actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16', //actions/cache@v2.1.2
+  'actions/cache@0781355a23dac32fd3bac414512f4b903437991a', //actions/cache@v2.1.3
   'actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f', //actions/checkout@v2.3.4
   'actions/github-script@626af12fe9a53dc2972b48385e7fe7dec79145c9', //actions/script@v3.0.0
   'actions/labeler@5f867a63be70efff62b767459b009290364495eb', //actions/labeler@v2.2.0

--- a/.github/workflows/dry-run-sync-algolia-search-indices.yml
+++ b/.github/workflows/dry-run-sync-algolia-search-indices.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         node-version: 14.x
     - name: cache node modules
-      uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
+      uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -42,7 +42,7 @@ jobs:
           echo "::set-output name=dir::$(npm config get cache)"
 
       - name: Cache node modules
-        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -16,7 +16,7 @@ jobs:
           echo "::set-output name=dir::$(npm config get cache)"
 
       - name: Cache node modules
-        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/sync-algolia-search-indices.yml
+++ b/.github/workflows/sync-algolia-search-indices.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: 14.x
     - name: cache node modules
-      uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
+      uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/test-translations.yml
+++ b/.github/workflows/test-translations.yml
@@ -27,7 +27,7 @@ jobs:
           echo "::set-output name=dir::$(npm config get cache)"
 
       - name: Cache node modules
-        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -65,7 +65,7 @@ jobs:
           echo "::set-output name=dir::$(npm config get cache)"
 
       - name: Cache node modules
-        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -32,7 +32,7 @@ jobs:
           echo "::set-output name=dir::$(npm config get cache)"
 
       - name: Cache node modules
-        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           echo "::set-output name=dir::$(npm config get cache)"
 
       - name: Cache node modules
-        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
+        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

New version was released to fix some minor issues and resolve a dependency that had a CVE (but wasn't directly affected) https://github.com/actions/cache/releases/tag/v2.1.3

### What's being changed:

Hashes used by the CI jobs and test

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
