### PR TITLE
Restructure sentence to include .NET Framework

### DIFF
--- a/content/github/finding-security-vulnerabilities-and-errors-in-your-code/troubleshooting-the-codeql-workflow.md
+++ b/content/github/finding-security-vulnerabilities-and-errors-in-your-code/troubleshooting-the-codeql-workflow.md
@@ -66,7 +66,7 @@ For more information, see the workflow extract in "[Automatic build for a compil
    * Building using a distributed build system external to GitHub Actions, using a daemon process.
    * {% data variables.product.prodname_codeql %} isn't aware of the specific compiler you are using.
 
-  For C# projects using either `dotnet build` or `msbuild` which target .NET Core 2, you should specify `/p:UseSharedCompilation=false` in your workflow's `run` step, when you build your code. The `UseSharedCompilation` flag isn't necessary for .NET Core 3.0 and later.
+  For .NET Framework projects, and for C# projects using either `dotnet build` or `msbuild` that target .NET Core 2, you should specify `/p:UseSharedCompilation=false` in your workflow's `run` step, when you build your code. The `UseSharedCompilation` flag isn't necessary for .NET Core 3.0 and later.
   
   For example, the following configuration for C# will pass the flag during the first build step.
 


### PR DESCRIPTION
### Why:

Restructure a sentence to include .NET Framework as one of the examples as instructed #1308 

### What's being changed:

Updates [finding-security-vulnerabilities-and-errors-in-your-code/troubleshooting-the-codeql-workflow.md](https://github.com/github/docs/blob/main/content/github/finding-security-vulnerabilities-and-errors-in-your-code/troubleshooting-the-codeql-workflow.md)

In step 5 of the "No code found during the build" section, the following statement can also apply to .NET Framework projects:

> For C# projects using either dotnet build or msbuild which target .NET Core 2, you should specify /p:UseSharedCompilation=false in your workflow's run step, when you build your code. The UseSharedCompilation flag isn't necessary for .NET Core 3.0 and later.

Change this to:

> For .NET Framework projects, and for C# projects using either dotnet build or msbuild that target .NET Core 2, you should specify /p:UseSharedCompilation=false in your workflow's run step, when you build your code. The UseSharedCompilation flag isn't necessary for .NET Core 3.0 and later.
<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] All of the tests are passing.
- [X] I have reviewed my changes in staging.
- [X] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [X] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
