### PR TITLE
fix: update role and add missing label for search

### DIFF
--- a/content/actions/index.md
+++ b/content/actions/index.md
@@ -66,7 +66,7 @@ versions:
   <h2 class="mb-2 font-mktg h1">Code examples</h2>
 
   <div class="pr-lg-3 mb-5 mt-3">
-    <input class="js-code-example-filter input-lg py-2 px-3 col-12 col-lg-8 form-control" placeholder="Search code examples" type="text" autocomplete="off" />
+    <input class="js-code-example-filter input-lg py-2 px-3 col-12 col-lg-8 form-control" placeholder="Search code examples" type="search" autocomplete="off" aria-label="Search code examples"/>
   </div>
 
   <div class="d-flex flex-wrap gutter">


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

pa11y is flagging the missing labeling on the Action example search page. When looking at the element flagged, noticed it was "text" rather than "search" as well

### What's being changed:

Add a `aria-label` since there doesn't appear to be another label element and `placeholder` values aren't accessible

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
