### PR TITLE
Add raw tags for issue_comment example

### DIFF
--- a/content/actions/reference/events-that-trigger-workflows.md
+++ b/content/actions/reference/events-that-trigger-workflows.md
@@ -327,6 +327,7 @@ The `issue_comment` event occurs for comments on both issues and pull requests. 
 
 For example, you can choose to run the `pr_commented` job when comment events occur in a pull request, and the `issue_commented` job when comment events occur in an issue.
 
+{% raw %}
 ```yaml
 on: issue_comment
 
@@ -349,6 +350,7 @@ jobs:
       - run: |
           echo "Comment on issue #${{ github.event.issue.number }}"
 ```
+{% endraw %}
 
 #### `issues`
 


### PR DESCRIPTION
### Why:

Fixes: #1096

A code block had Actions context examples, but were being stripped out when rendering because of the Liquid processing. This PR adds `raw` tags around the code block so that they won't be processed. 

Stage preview: https://docs-1373--lucascostiissue-com.herokuapp.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#issue_comment

### Check off the following:
- [ ] All of the tests are passing.
- [x] I have reviewed my changes in staging.
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
