### PR TITLE
Add the option to exempt issues and prs from staleness

### DIFF
--- a/.github/workflows/60-days-stale-check.yml
+++ b/.github/workflows/60-days-stale-check.yml
@@ -17,4 +17,6 @@ jobs:
         only-labels: 'engineering'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
+        exempt-pr-labels: 'never-stale'
+        exempt-issue-labels: 'never-stale'
 

--- a/.github/workflows/triage-stale-check.yml
+++ b/.github/workflows/triage-stale-check.yml
@@ -16,3 +16,5 @@ jobs:
         days-before-stale: 7
         days-before-close: 10
         stale-pr-label: 'stale'
+        exempt-pr-labels: 'never-stale'
+        exempt-issue-labels: 'never-stale'


### PR DESCRIPTION
### Why:

This adds the option to have long-running PRs and issues that should never be marked as stale.


### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging.
