### PR TITLE
Revert "chore: flatten ifs for fkirc/skip-duplicate-actions"

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -20,18 +20,22 @@ jobs:
           paths: '[".github/workflows/browser-test.yml","assets/**", "content/**", "data/**", "includes/**", "javascripts/**", "jest-puppeteer.config.js", "jest.config.js", "layouts/**", "lib/**", "middleware/**", "package-lock.json", "package.json", "server.js", "translations/**", "webpack.config.js"]'
   build:
     needs: see_if_should_skip
-    if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      # Each of these ifs needs to be repeated at each step to make sure the required check still runs
+      # Even if if doesn't do anything
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Checkout
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
-      - name: Install
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Install
         uses: ianwalter/puppeteer@12728ddef82390d1ecd4732fb543f62177392fbb
         with:
           args: npm ci
 
-      - name: Test
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Test
         uses: ianwalter/puppeteer@12728ddef82390d1ecd4732fb543f62177392fbb
         with:
           args: npm run browser-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
 
   test:
     needs: see_if_should_skip
-    if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -39,20 +38,26 @@ jobs:
       matrix:
         test-group: [content, meta, rendering, routing, unit, links-and-images]
     steps:
-      - name: Check out repo
+      # Each of these ifs needs to be repeated at each step to make sure the required check still runs
+      # Even if if doesn't do anything
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Check out repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
-      - name: Setup node
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Setup node
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
         with:
           node-version: 14.x
 
-      - name: Get npm cache directory
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Get npm cache directory
         id: npm-cache
         run: |
           echo "::set-output name=dir::$(npm config get cache)"
 
-      - name: Cache node modules
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Cache node modules
         uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
@@ -60,13 +65,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install dependencies
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Install dependencies
         run: npm ci
 
-      - name: Run build script
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Run build script
         run: npm run build
 
-      - name: Run tests
+      - if: ${{ needs.see_if_should_skip.outputs.should_skip != 'true' }}
+        name: Run tests
         run: npx jest tests/${{ matrix.test-group }}/
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"


### PR DESCRIPTION
This reverts commit d9d17364e334fb33974836a44aea8fe7702fc381 ([this PR](https://github.com/github/docs/pull/1115)).

Over the past few days we've been running into this stall with our pull requests.

![Screen Shot 2020-11-16 at 9 08 36 AM](https://user-images.githubusercontent.com/2156688/99261982-68900980-27eb-11eb-9d03-a67f1edd3b03.png)

I can't explain why but I think it's because of [this PR](https://github.com/github/docs/pull/1115) so I want to revert it and see what happens.

This is what the test suite looks like now with the fix on this PR which seems to suggest that this does fix the problem. Furthermore, the test suite on this PR is running while it isn't on others that were opened roughly 15 minutes before this PR.

![Screen Shot 2020-11-16 at 9 14 09 AM](https://user-images.githubusercontent.com/2156688/99262593-2adfb080-27ec-11eb-8dd8-42add1bf60fd.png)


### Check off the following:
- [ ] All of the tests are passing.
- [ ] I have reviewed my changes in staging.

/cc @nschonni @github/docs-engineering 