### PR TITLE
Markdown grammar fixes

### DIFF
--- a/content/developers/apps/setting-up-your-development-environment-to-create-a-github-app.md
+++ b/content/developers/apps/setting-up-your-development-environment-to-create-a-github-app.md
@@ -220,7 +220,7 @@ end
 
 #### Define a route handler
 
-An empty route is included in the template code. This code handles all `POST` requests to the `/event_handler` route. You'll won't write this event handler in this quickstart, but see the other [quickstart guides](/apps/quickstart-guides/) for examples of how to extend this template app.
+An empty route is included in the template code. This code handles all `POST` requests to the `/event_handler` route. You won't write this event handler in this quickstart, but see the other [quickstart guides](/apps/quickstart-guides/) for examples of how to extend this template app.
 
 ``` ruby
 post '/event_handler' do


### PR DESCRIPTION
### Why:

There was grammar errors.

### What's being changed:

A word in the documentation guide.

### Check off the following:
- [ ] All of the tests are passing.
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
