### PR TITLE
Bring workflow in line with suggested usage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,9 @@ name: CodeQL analysis
 
 on:
   push:
+    branches: main
+  pull_request:
+    branches: main
     paths:
       - '**/*.js'
       - '.github/workflows/codeql.yml'


### PR DESCRIPTION
To reliably give comparisons on PRs we must be analyzing
all pushes of the possible target branches (here just `main`).

