### PR TITLE
Missing "&copy;" in small-footer #1744

### DIFF
--- a/includes/small-footer.html
+++ b/includes/small-footer.html
@@ -3,7 +3,7 @@
     <ul class="d-flex list-style-none flex-wrap flex-justify-center flex-xl-justify-start">
       <li class="d-flex mr-xl-3 text-gray">
         {% octicon "mark-github" height="20" class="mr-2 mr-xl-3" %}
-        <span>{{ "now" | date: "%Y" }} GitHub, Inc.</span>
+        <span>&copy; {{ "now" | date: "%Y" }} GitHub, Inc.</span>
       </li>
       <li class="ml-3"><a href="/github/site-policy/github-terms-of-service">{% data ui.footer.terms %} </a></li>
       <li class="ml-3"><a href="/github/site-policy/github-privacy-statement">{% data ui.footer.privacy %} </a></li>


### PR DESCRIPTION
### Why:

https://github.com/github/docs/issues/1744

### What's being changed:

Copyright symbol missing in https://docs.github.com

![Capture3](https://user-images.githubusercontent.com/67098758/101056567-eeae9d00-35ac-11eb-9d78-70bd505f0645.PNG)


### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
