### PR TITLE
Added ready-to-use command

### DIFF
--- a/content/github/using-git/adding-a-remote.md
+++ b/content/github/using-git/adding-a-remote.md
@@ -43,6 +43,7 @@ $ git remote add origin https://{% data variables.command_line.codeblock %}/octo
 
 To fix this, you can
 
+* Use this command instead git remote set-url origin https://{% data variables.command_line.codeblock %}/octocat/Spoon-Knife
 * Use a different name for the new remote
 * [Rename the existing remote](/articles/renaming-a-remote)
 * [Delete the existing remote](/articles/removing-a-remote)


### PR DESCRIPTION
When error comes : remote origin already exists.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why: The error "fatal : remote origin already exists." is common and one should have ready-to-use command for its resolution at doc page.

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed: I have added one simple command to update remote url. So that user does not have to go to other pages/ search web for the error's resolution.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] All of the tests are passing.
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
