### PR TITLE
Add hint that docker repository names (git org + git repo name) must be all lowercase

### DIFF
--- a/content/actions/guides/publishing-docker-images.md
+++ b/content/actions/guides/publishing-docker-images.md
@@ -89,7 +89,7 @@ The `build-push-action` options required for {% data variables.product.prodname_
 * `username`: You can use the {% raw %}`${{ github.actor }}`{% endraw %} context to automatically use the username of the user that triggered the workflow run. For more information, see "[Context and expression syntax for GitHub Actions](/actions/reference/context-and-expression-syntax-for-github-actions#github-context)."
 * `password`: You can use the automatically-generated `GITHUB_TOKEN` secret for the password. For more information, see "[Authenticating with the GITHUB_TOKEN](/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token)."
 * `registry`: Must be set to `docker.pkg.github.com`.
-* `repository`: Must be set in the format `OWNER/REPOSITORY/IMAGE_NAME`. For example, for an image named `octo-image` stored on {% data variables.product.prodname_dotcom %} at `http://github.com/octo-org/octo-repo`, the `repository` option should be set to `octo-org/octo-repo/octo-image`.
+* `repository`: Must be set in the format `OWNER/REPOSITORY/IMAGE_NAME`. For example, for an image named `octo-image` stored on {% data variables.product.prodname_dotcom %} at `http://github.com/octo-org/octo-repo`, the `repository` option should be set to `octo-org/octo-repo/octo-image`.  If your organization or repository contains capital letters, you **must** convert them to lowercase.
 
 {% raw %}
 ```yaml


### PR DESCRIPTION
The documentation fails to mention that OWNER or REPOSITORY substitution with a name that contains a capital letter will fail.

```
Logging in to registry docker.pkg.github.com
WARNING! Using -*** the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /github/home/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
Building image [docker.pkg.github.com/Arduino-CI/action/:latest]
invalid argument "docker.pkg.github.com/Arduino-CI/action/:latest" for "-t, --tag" flag: invalid reference format: repository name must be lowercase
See 'docker build --help'.
Error: exit status 125
```

> `invalid reference format: repository name must be lowercase`

see https://github.com/Arduino-CI/action/runs/1508611501#step:4:23
