### PR TITLE
Minor typo, was "older", should be "order"

### DIFF
--- a/content/github/committing-changes-to-your-project/changing-a-commit-message.md
+++ b/content/github/committing-changes-to-your-project/changing-a-commit-message.md
@@ -36,7 +36,7 @@ You can change the default text editor for Git by changing the `core.editor` set
 
 {% endtip %}
 
-### Amending older or multiple commit messages
+### Amending order or multiple commit messages
 
 If you have already pushed the commit to {% data variables.product.product_location %}, you will have to force push a commit with an amended message.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why: Minor typo, wrong word.

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed: Single word in the help header

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [Y] All of the tests are passing.
- [N] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [N] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [Y] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
