### PR TITLE
Remove references to global webhooks REST API preview

### DIFF
--- a/content/rest/overview/api-previews.md
+++ b/content/rest/overview/api-previews.md
@@ -114,17 +114,6 @@ Include nested team content in [team](/rest/reference/teams) payloads.
 
 {% endif %}
 
-{% if currentVersion == "github-ae@latest" or enterpriseServerVersions contains currentVersion %}
-
-### Global webhooks
-
-Enables [global webhooks](/rest/reference/enterprise-admin#global-webhooks/) for  [organization](/webhooks/event-payloads/#organization) and [user](/webhooks/event-payloads/#user) event types. This API preview is only available for {% data variables.product.prodname_ghe_server %}.
-
-**Custom media type:** `superpro-preview`
-**Announced:** [2017-12-12](/rest/reference/enterprise-admin#global-webhooks)
-
-{% endif %}
-
 {% if enterpriseServerVersions contains currentVersion and currentVersion ver_lt "enterprise-server@2.20" %}
 ### Repository transfer
 

--- a/translations/de-DE/content/rest/overview/api-previews.md
+++ b/translations/de-DE/content/rest/overview/api-previews.md
@@ -99,16 +99,6 @@ Include nested team content in [team](/rest/reference/teams) payloads.
 
 {% endif %}
 
-{% if currentVersion == "github-ae@latest" or enterpriseServerVersions contains currentVersion %}
-
-### Global webhooks
-
-Enables [global webhooks](/rest/reference/enterprise-admin#global-webhooks/) for  [organization](/webhooks/event-payloads/#organization) and [user](/webhooks/event-payloads/#user) event types. This API preview is only available for {% data variables.product.prodname_ghe_server %}.
-
-**Custom media type:** `superpro-preview` **Announced:** [2017-12-12](/rest/reference/enterprise-admin#global-webhooks)
-
-{% endif %}
-
 {% if enterpriseServerVersions contains currentVersion and currentVersion ver_lt "enterprise-server@2.20" %}
 ### Repository transfer
 

--- a/translations/es-XL/content/rest/overview/api-previews.md
+++ b/translations/es-XL/content/rest/overview/api-previews.md
@@ -115,16 +115,6 @@ Incluir contenido anidado del equipo en cargas útiles del [equipo](/v3/teams/)
 
 {% endif %}
 
-{% if currentVersion != "free-pro-team@latest" %}
-
-### Webhooks globales
-
-Habilita los [webhooks globales](/v3/enterprise-admin/global_webhooks/) para una [organización](/webhooks/event-payloads/#organization) y para los tipos de evento del [usuario](/webhooks/event-payloads/#user). Esta vista previa de la API solo está disponible para {% data variables.product.prodname_ghe_server %}.
-
-**Tipo de medios personalizados:** `superpro-preview` **Anunciado en:**[2017-12-12](/v3/enterprise-admin/global_webhooks)
-
-{% endif %}
-
 {% if currentVersion != "free-pro-team@latest" and currentVersion ver_lt "enterprise-server@2.20" %}
 ### Transferencia de repositorio
 

--- a/translations/ja-JP/content/rest/overview/api-previews.md
+++ b/translations/ja-JP/content/rest/overview/api-previews.md
@@ -99,16 +99,6 @@ API を介して[インテグレーション](/early-access/integrations/)を管
 
 {% endif %}
 
-{% if currentVersion == "github-ae@latest" or enterpriseServerVersions contains currentVersion %}
-
-### グローバル webhook
-
-[Organization](/webhooks/event-payloads/#organization) および[ユーザ](/webhooks/event-payloads/#user)イベントタイプの[グローバル webhook](/rest/reference/enterprise-admin#global-webhooks/) を有効にします。 この API プレビューは {% data variables.product.prodname_ghe_server %} でのみ使用できます。
-
-**カスタムメディアタイプ:** `superpro-preview` **発表日:** [2017-12-12](/rest/reference/enterprise-admin#global-webhooks)
-
-{% endif %}
-
 {% if enterpriseServerVersions contains currentVersion and currentVersion ver_lt "enterprise-server@2.20" %}
 ### リポジトリ移譲
 

--- a/translations/ko-KR/content/rest/overview/api-previews.md
+++ b/translations/ko-KR/content/rest/overview/api-previews.md
@@ -99,16 +99,6 @@ Include nested team content in [team](/rest/reference/teams) payloads.
 
 {% endif %}
 
-{% if currentVersion == "github-ae@latest" or enterpriseServerVersions contains currentVersion %}
-
-### Global webhooks
-
-Enables [global webhooks](/rest/reference/enterprise-admin#global-webhooks/) for  [organization](/webhooks/event-payloads/#organization) and [user](/webhooks/event-payloads/#user) event types. This API preview is only available for {% data variables.product.prodname_ghe_server %}.
-
-**Custom media type:** `superpro-preview` **Announced:** [2017-12-12](/rest/reference/enterprise-admin#global-webhooks)
-
-{% endif %}
-
 {% if enterpriseServerVersions contains currentVersion and currentVersion ver_lt "enterprise-server@2.20" %}
 ### Repository transfer
 

--- a/translations/ko-KR/data/reusables/pre-release-program/superpro-preview.md
+++ b/translations/ko-KR/data/reusables/pre-release-program/superpro-preview.md
@@ -1,9 +1,0 @@
-{% note %}
-
-**Note:** The [Global Webhooks API](/rest/reference/enterprise-admin#global-webhooks) is currently available for developers to preview. To access the API during the preview period, you must provide a custom [media type](/rest/overview/media-types) in the `Accept` header:
-
-```
-application/vnd.github.superpro-preview+json
-```
-
-{% endnote %}

--- a/translations/pt-BR/content/rest/overview/api-previews.md
+++ b/translations/pt-BR/content/rest/overview/api-previews.md
@@ -35,7 +35,7 @@ Exerça um maior controle sobre as [implantações](/rest/reference/repos#deploy
 Gerencie as [reações](/rest/reference/reactions) de commits, problemas e comentários.
 
 **Tipo de mídia personalizado:** `squirrel-girl-preview` **Anunciado em:** [2016-05-12](https://developer.github.com/changes/2016-05-12-reactions-api-preview/) **Atualização em:**
-[ 2016-07](https://developer.github.com/changes/2016-06-07-reactions-api-update/)</p> 
+[ 2016-07](https://developer.github.com/changes/2016-06-07-reactions-api-update/)</p>
 
 
 
@@ -52,7 +52,7 @@ Obter uma [lista de eventos](/rest/reference/issues#timeline) para um problema o
 
 Cria, lista, atualiza e exclui ambientes para hooks pre-receive.
 
-**Tipo de mídia personalizada:** `eye-scream-preview` **Anunciado em:** [2015-07-29](/rest/reference/enterprise-admin#pre-receive-environments) 
+**Tipo de mídia personalizada:** `eye-scream-preview` **Anunciado em:** [2015-07-29](/rest/reference/enterprise-admin#pre-receive-environments)
 
 {% endif %}
 
@@ -63,7 +63,7 @@ Cria, lista, atualiza e exclui ambientes para hooks pre-receive.
 
 Gerencie as [integrações](/early-access/integrations/) através da API.
 
-**Tipo de mídia personalizada:** `machine-man-preview` **Anunciado em:** [2016-09-14](https://developer.github.com/changes/2016-09-14-Integrations-Early-Access/) 
+**Tipo de mídia personalizada:** `machine-man-preview` **Anunciado em:** [2016-09-14](https://developer.github.com/changes/2016-09-14-Integrations-Early-Access/)
 
 {% endif %}
 
@@ -73,7 +73,7 @@ Gerencie as [integrações](/early-access/integrations/) através da API.
 
 Gerencie [projetos](/rest/reference/projects).
 
-**Tipo de mídia personalizada:** `inertia-preview` **Anunciado em:** [2016-09-14](https://developer.github.com/changes/2016-09-14-projects-api/) **Atualização em:** [ 2016-10-27](https://developer.github.com/changes/2016-10-27-changes-to-projects-api/)</p> 
+**Tipo de mídia personalizada:** `inertia-preview` **Anunciado em:** [2016-09-14](https://developer.github.com/changes/2016-09-14-projects-api/) **Atualização em:** [ 2016-10-27](https://developer.github.com/changes/2016-10-27-changes-to-projects-api/)</p>
 
 
 
@@ -90,7 +90,7 @@ Gerencie [projetos](/rest/reference/projects).
 
 Os usuários podem [bloquear outros usuários](/rest/reference/users#blocking). As organizações também podem [bloquear usuários](/rest/reference/orgs#blocking).
 
-**Tipo de mídia personalizado:** `giant-sentry-fist-preview` **Anunciado em:** [2011-05-31](https://github.com/blog/862-block-the-bullies) **Atualização 1:** [2016-04-04](https://github.com/blog/2146-organizations-can-now-block-abusive-users) **Atualização 2:** [2016-08-17](https://github.com/blog/2229-see-the-users-you-ve-blocked-on-your-settings-page) 
+**Tipo de mídia personalizado:** `giant-sentry-fist-preview` **Anunciado em:** [2011-05-31](https://github.com/blog/862-block-the-bullies) **Atualização 1:** [2016-04-04](https://github.com/blog/2146-organizations-can-now-block-abusive-users) **Atualização 2:** [2016-08-17](https://github.com/blog/2229-see-the-users-you-ve-blocked-on-your-settings-page)
 
 {% endif %}
 
@@ -121,18 +121,6 @@ Inclua o conteúdo aninhado das cargas da [equipe](/rest/reference/teams).
 
 {% endif %}
 
-{% if currentVersion == "github-ae@latest" or enterpriseServerVersions contains currentVersion %}
-
-
-
-### Webhooks globais
-
-Habilita [webhooks globais](/rest/reference/enterprise-admin#global-webhooks/) para  [organizações](/webhooks/event-payloads/#organization) e tipos de evento do [usuário](/webhooks/event-payloads/#user). Esta visualização da API só está disponível para {% data variables.product.prodname_ghe_server %}.
-
-**Tipo de mídia personalizada:** `superpro-preview` **Anunciado em:** [2017-12-12](/rest/reference/enterprise-admin#global-webhooks)
-
-{% endif %}
-
 {% if enterpriseServerVersions contains currentVersion and currentVersion ver_lt "enterprise-server@2.20" %}
 
 
@@ -140,7 +128,7 @@ Habilita [webhooks globais](/rest/reference/enterprise-admin#global-webhooks/) p
 
 Transfira um [repositório](/rest/reference/repos) para uma organização ou usuário.
 
-**Tipo de mídia personalizada:** `nightshade-preview` **Anunciado em:** [2017-11-09](https://developer.github.com/changes/2017-11-09-repository-transfer-api-preview) 
+**Tipo de mídia personalizada:** `nightshade-preview` **Anunciado em:** [2017-11-09](https://developer.github.com/changes/2017-11-09-repository-transfer-api-preview)
 
 {% endif %}
 
@@ -151,7 +139,7 @@ Transfira um [repositório](/rest/reference/repos) para uma organização ou usu
 
 Agora você pode adicionar um motivo ao[bloquear um problema](/rest/reference/issues#lock-an-issue).
 
-**Tipo de mídia personalizada:** `sailor-v-preview` **Anunciado em:** [2018-01-10](https://developer.github.com/changes/2018-01-10-lock-reason-api-preview) 
+**Tipo de mídia personalizada:** `sailor-v-preview` **Anunciado em:** [2018-01-10](https://developer.github.com/changes/2018-01-10-lock-reason-api-preview)
 
 {% endif %}
 
@@ -189,7 +177,7 @@ Recuperar informações do [hovercard de alguém](/rest/reference/users#get-cont
 
 Permite que um aplicativo GitHub execute verificações externas no código de um repositório. Veja as [execuções de verificação](/rest/reference/checks#runs) e [Conjuntos de verificação](/rest/reference/checks#suites) das APIs para obter mais informações.
 
-**Tipo de mídia personalizada:** `antiope-preview` **Anunciado:** [2018-05-07](https://developer.github.com/changes/2018-05-07-new-checks-api-public-beta/) 
+**Tipo de mídia personalizada:** `antiope-preview` **Anunciado:** [2018-05-07](https://developer.github.com/changes/2018-05-07-new-checks-api-public-beta/)
 
 {% endif %}
 
@@ -283,7 +271,7 @@ Você pode usar dois novos pontos de extremidade na [API de commits](/rest/refer
 
 Agora os proprietários dos aplicativos GitHub podem desinstalar um aplicativo usando a [API de aplicativos](/rest/reference/apps#delete-an-installation-for-the-authenticated-app).
 
-**Tipos de mídia personalizada:** `gambit-preview` 
+**Tipos de mídia personalizada:** `gambit-preview`
 
 {% endif %}
 
@@ -310,7 +298,7 @@ Você pode usar um novo ponto de extremidade para [atualizar um branch de pull r
 
 Você pode usar um novo conjunto de pontos de extremidade para [habilitar e desabilitar as correções de segurança automatizadas](/rest/reference/repos#enable-automated-security-fixes).
 
-**Tipo de mídia personalizada:** `london-preview` **Anunciado:** [2019-06-04](https://developer.github.com/changes/2019-06-04-automated-security-fixes/) 
+**Tipo de mídia personalizada:** `london-preview` **Anunciado:** [2019-06-04](https://developer.github.com/changes/2019-06-04-automated-security-fixes/)
 
 {% endif %}
 
@@ -329,7 +317,7 @@ Você pode usar um novo ponto de extremidade para [Criar um repositório usando 
 
 Você pode gerenciar os tokens de forma mais segura para aplicativos OAuth usando os tokens OAuth como parâmetros de entrada em vez dos parâmetros de caminho com os novos pontos de extremidade da [API dos aplicativos OAuth](/rest/reference/apps#oauth-applications).
 
-**Tipos de mídia personalizada:** `doutor-strange-preview` **Anunciado:** [2019-11-05](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/) 
+**Tipos de mídia personalizada:** `doutor-strange-preview` **Anunciado:** [2019-11-05](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/)
 
 {% endif %}
 
@@ -340,6 +328,6 @@ Você pode gerenciar os tokens de forma mais segura para aplicativos OAuth usand
 
 Você pode definir e recuperar a visibilidade de um repositório na [API de repositórios](/rest/reference/repos).
 
-**Tipos de mídia personalizada:** `nebula-preview` **Anunciado:** [2019-11-25](https://developer.github.com/changes/2019-12-03-internal-visibility-changes/) 
+**Tipos de mídia personalizada:** `nebula-preview` **Anunciado:** [2019-11-25](https://developer.github.com/changes/2019-12-03-internal-visibility-changes/)
 
 {% endif %}

--- a/translations/ru-RU/data/reusables/pre-release-program/superpro-preview.md
+++ b/translations/ru-RU/data/reusables/pre-release-program/superpro-preview.md
@@ -1,9 +1,0 @@
-{% note %}
-
-**Note:** The [Global Webhooks API](/rest/reference/enterprise-admin#global-webhooks) is currently available for developers to preview. To access the API during the preview period, you must provide a custom [media type](/rest/overview/media-types) in the `Accept` header:
-
-```
-application/vnd.github.superpro-preview+json
-```
-
-{% endnote %}

--- a/translations/zh-CN/content/rest/overview/api-previews.md
+++ b/translations/zh-CN/content/rest/overview/api-previews.md
@@ -99,16 +99,6 @@ API 预览允许您试用新的 API 以及对现有 API 方法的更改（在它
 
 {% endif %}
 
-{% if currentVersion == "github-ae@latest" or enterpriseServerVersions contains currentVersion %}
-
-### 全局 web 挂钩
-
-为[组织](/webhooks/event-payloads/#organization)和[用户](/webhooks/event-payloads/#user)事件类型启用[全局 web 挂钩](/rest/reference/enterprise-admin#global-webhooks/)。 此 API 预览仅适用于 {% data variables.product.prodname_ghe_server %}。
-
-**自定义媒体类型：** `superpro-preview` **公布日期：** [2017-12-12](/rest/reference/enterprise-admin#global-webhooks)
-
-{% endif %}
-
 {% if enterpriseServerVersions contains currentVersion and currentVersion ver_lt "enterprise-server@2.20" %}
 ### 仓库转让
 


### PR DESCRIPTION
### Why:

I graduated this preview way back on 18 Sep 2019 in https://github.com/github/github/pull/124420 but the docs were not updated.

### What's being changed:

I'm removing references to the "superpro" REST API preview. Is there a convenient way of updating all the masses of references in `lib/rest/static/`? I haven't updated that manually.

### Check off the following:
- [x] All of the tests are passing.
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
