### PR TITLE
Add default branch note to workflow_run event

### DIFF
--- a/content/actions/reference/events-that-trigger-workflows.md
+++ b/content/actions/reference/events-that-trigger-workflows.md
@@ -699,6 +699,8 @@ on:
 
 {% data reusables.webhooks.workflow_run_desc %}
 
+{% data reusables.github-actions.branch-requirement %}
+
 | Webhook event payload | Activity types | `GITHUB_SHA` | `GITHUB_REF` |
 | --------------------- | -------------- | ------------ | -------------|	
 | [`workflow_run`](/webhooks/event-payloads/#workflow_run) | - n/a | Last commit on default branch | Default branch |	


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Fixes: https://github.com/github/docs/issues/799

### What's being changed:

This adds the default branch note to the `workflow_run` event description. `workflow_run` triggered workflows only occur if the workflow file is on the default branch.

Preview: https://docs-2062--lucascostiworkflow.herokuapp.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_run

### Check off the following:
- [x] All of the tests are passing. The failing check is a buggy one, and has been reported to engineering.
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
