### PR TITLE
fix some bugs in new workflow

### DIFF
--- a/.github/workflows/triage-unallowed-contributions.yml
+++ b/.github/workflows/triage-unallowed-contributions.yml
@@ -48,7 +48,7 @@ jobs:
               .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))
               .shift()
 
-            console.log(`Pull request reviews authored by the `github-action` bot: ${botReviews})
+            console.log(`Pull request reviews authored by the github-action bot: ${botReviews}`)
             return botReviews
 
       - name: Get files changed

--- a/.github/workflows/triage-unallowed-contributions.yml
+++ b/.github/workflows/triage-unallowed-contributions.yml
@@ -22,7 +22,7 @@ jobs:
             }).data
               .map(pull => pull.number)
               .shift()
-            
+
             if (pullNumber) {
               console.log(`Pull request number: ${pullNumber}`)
               return pullNumber
@@ -47,7 +47,7 @@ jobs:
 
             console.log(`Pull request reviews authored by the `github-action` bot: ${pullReviews})
             return pullReviews
-              
+
       - name: Get files changed
         uses: dorny/paths-filter@eb75a1edc117d3756a18ef89958ee59f9500ba58
         id: filter
@@ -115,7 +115,7 @@ jobs:
       # PR no longer contains unallowed changes, dismiss the previous review
       - name: Dismiss pull request review
         # Check that unallowed files aren't modified and that a
-        # CHANGES_REQUESTED review already exists 
+        # CHANGES_REQUESTED review already exists
         if: ${{ steps.filter.outputs.notAllowed == 'false' && steps.requested-change.outputs.result && fromJson(steps.requested-change.outputs.result).state == 'CHANGES_REQUESTED' }}
         uses: actions/github-script@626af12fe9a53dc2972b48385e7fe7dec79145c9
         with:

--- a/.github/workflows/triage-unallowed-contributions.yml
+++ b/.github/workflows/triage-unallowed-contributions.yml
@@ -48,7 +48,9 @@ jobs:
               .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))
               .shift()
 
-            console.log(`Pull request reviews authored by the github-action bot: ${botReviews}`)
+            if (botReviews) {
+              console.log(`Pull request reviews authored by the github-action bot: ${botReviews}`)
+            }
             return botReviews
 
       - name: Get files changed

--- a/.github/workflows/triage-unallowed-contributions.yml
+++ b/.github/workflows/triage-unallowed-contributions.yml
@@ -16,12 +16,20 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: |
-            const pulls = await github.repos.listPullRequestsAssociatedWithCommit({
+            const pullNumber = await github.repos.listPullRequestsAssociatedWithCommit({
               ...context.repo,
               commit_sha: context.sha
-            })
-
-            return pulls.data.map(pull => pull.number).shift()
+            }).data
+              .map(pull => pull.number)
+              .shift()
+            
+            if (pullNumber) {
+              console.log(`Pull request number: ${pullNumber}`)
+              return pullNumber
+            } else {
+              console.log(`When this workflow ran there was no associated pull request created. Pushing a new commit after you've created a pull request will automatically re-run this workflow, or you can manually re-run the workflow.`)
+              process.exit(1)
+            }
       - name: Check for existing requested changes
         id: requested-change
         uses: actions/github-script@626af12fe9a53dc2972b48385e7fe7dec79145c9
@@ -104,7 +112,9 @@ jobs:
       # When the most recent review was CHANGES_REQUESTED and the existing
       # PR no longer contains unallowed changes, dismiss the previous review
       - name: Dismiss pull request review
-        if: ${{ steps.filter.outputs.notAllowed == 'false' && fromJson(steps.requested-change.outputs.result).state == 'CHANGES_REQUESTED' }}
+        # Check that unallowed files aren't modified and that a
+        # CHANGES_REQUESTED review already exists 
+        if: ${{ steps.filter.outputs.notAllowed == 'false' && steps.requested-change.outputs.result && fromJson(steps.requested-change.outputs.result).state == 'CHANGES_REQUESTED' }}
         uses: actions/github-script@626af12fe9a53dc2972b48385e7fe7dec79145c9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/triage-unallowed-contributions.yml
+++ b/.github/workflows/triage-unallowed-contributions.yml
@@ -2,6 +2,8 @@ name: Check unallowed file changes
 
 on:
   push:
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   triage:

--- a/.github/workflows/triage-unallowed-contributions.yml
+++ b/.github/workflows/triage-unallowed-contributions.yml
@@ -27,7 +27,7 @@ jobs:
               console.log(`Pull request number: ${pullNumber}`)
               return pullNumber
             } else {
-              console.log(`When this workflow ran there was no associated pull request created. Pushing a new commit after you've created a pull request will automatically re-run this workflow, or you can manually re-run the workflow.`)
+              console.log(`When this workflow ran, the associated pull request was not yet created. Pushing a new commit after you've created a pull request will automatically re-run this workflow, or you can manually re-run the workflow.`)
               process.exit(1)
             }
       - name: Check for existing requested changes
@@ -40,12 +40,14 @@ jobs:
             const pullReviews = await github.pulls.listReviews({
               ...context.repo,
               pull_number: ${{steps.pull-number.outputs.result}}
-            })
-
-            return pullReviews.data
+            }).data
               .filter(review => review.user.login === 'github-actions[bot]')
               .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))
               .shift()
+
+            console.log(`Pull request reviews authored by the `github-action` bot: ${pullReviews})
+            return pullReviews
+              
       - name: Get files changed
         uses: dorny/paths-filter@eb75a1edc117d3756a18ef89958ee59f9500ba58
         id: filter

--- a/.github/workflows/triage-unallowed-contributions.yml
+++ b/.github/workflows/triage-unallowed-contributions.yml
@@ -16,11 +16,11 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: |
-            const pullNumber = await github.repos.listPullRequestsAssociatedWithCommit({
+            const pulls = await github.repos.listPullRequestsAssociatedWithCommit({
               ...context.repo,
               commit_sha: context.sha
             })
-              .data
+            const pullNumber = pulls.data
               .map(pull => pull.number)
               .shift()
 
@@ -42,13 +42,14 @@ jobs:
               ...context.repo,
               pull_number: ${{steps.pull-number.outputs.result}}
             })
-              .data
+
+            const botReviews = pullReviews.data
               .filter(review => review.user.login === 'github-actions[bot]')
               .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))
               .shift()
 
-            console.log(`Pull request reviews authored by the `github-action` bot: ${pullReviews})
-            return pullReviews
+            console.log(`Pull request reviews authored by the `github-action` bot: ${botReviews})
+            return botReviews
 
       - name: Get files changed
         uses: dorny/paths-filter@eb75a1edc117d3756a18ef89958ee59f9500ba58

--- a/.github/workflows/triage-unallowed-contributions.yml
+++ b/.github/workflows/triage-unallowed-contributions.yml
@@ -19,7 +19,8 @@ jobs:
             const pullNumber = await github.repos.listPullRequestsAssociatedWithCommit({
               ...context.repo,
               commit_sha: context.sha
-            }).data
+            })
+              .data
               .map(pull => pull.number)
               .shift()
 
@@ -40,7 +41,8 @@ jobs:
             const pullReviews = await github.pulls.listReviews({
               ...context.repo,
               pull_number: ${{steps.pull-number.outputs.result}}
-            }).data
+            })
+              .data
               .filter(review => review.user.login === 'github-actions[bot]')
               .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))
               .shift()


### PR DESCRIPTION
### Why:

It looks like there are two bugs in the new `.github/workflows/triage-unallowed-contributions.yml` workflow

1. When the check to dismiss a review runs but there are no reviews by `github-actions[bot]` the check fails in the `fromJSON` conditional check: https://github.com/github/docs/pull/2062/checks?check_run_id=1548110821
   - To fix this, we need to check that a review result actually exists before getting the properties of the object.
2. When a commit is pushed up and CI runs before the pull request is created, the check to get reviews for the pull request fails:  https://github.com/github/docs/pull/2088/checks?check_run_id=1553035730
    - To fix this, I've added an exit code when the pull request number is undefined and a comment that indicates why the test failed and how to re-run it. Open to other suggestions. There isn't a more direct way to get a pull request from a push event that I'm aware of. 

I added a bit more logging for the future just so we have some basic info.

### Check off the following:
- [ ] All of the tests are passing.
