### PR TITLE
Update ubuntu runner version #2110

### DIFF
--- a/data/reusables/github-actions/ubuntu-runner-preview.md
+++ b/data/reusables/github-actions/ubuntu-runner-preview.md
@@ -1,5 +1,5 @@
 {% note %}
 
-**Note:** The Ubuntu 20.04 virtual environment is currently provided as a preview only. The `ubuntu-latest` YAML workflow label still uses the Ubuntu 18.04 virtual environment.
+**Note:** The Ubuntu 20.04 virtual environment is currently provided as a preview only.
 
 {% endnote %}


### PR DESCRIPTION
### Why:
- Specifying `ubuntu-latest` launch Ubuntu 20.04 but the docs states that is still Ubuntu 18.04
  #2110

### What's being changed:

Moved `ubuntu-latest` label to Ubuntu 20.04 instead of 18.04.

I just don't know if you still consider Ubuntu 20.04 as a preview.
