### PR TITLE
authentication-in-a-workflow: Fixed pt-BR typo

### DIFF
--- a/translations/pt-BR/content/actions/reference/authentication-in-a-workflow.md
+++ b/translations/pt-BR/content/actions/reference/authentication-in-a-workflow.md
@@ -14,7 +14,7 @@ versions:
 {% data reusables.actions.enterprise-beta %}
 {% data reusables.actions.enterprise-github-hosted-runners %}
 
-Qualquer pessoa com acesso de `gravar` em um repositório pode criar, ler e usar secredos.
+Qualquer pessoa com acesso de `gravar` em um repositório pode criar, ler e usar segredos.
 
 ### Sobre o segredo `GITHUB_TOKEN`
 


### PR DESCRIPTION
Replaced 'secredos' with 'segredos'