### PR TITLE
Fix typo in Resources in the rest API

### DIFF
--- a/content/rest/overview/resources-in-the-rest-api.md
+++ b/content/rest/overview/resources-in-the-rest-api.md
@@ -240,7 +240,7 @@ Error code name | Description
 -----------|-----------|
 `missing` | A resource does not exist.
 `missing_field` | A required field on a resource has not been set.
-`invalid` | The formatting of a field is invalid.  Review the documentation for the for more specific information.
+`invalid` | The formatting of a field is invalid.  Review the documentation for more specific information.
 `already_exists` | Another resource has the same value as this field.  This can happen in resources that must have some unique key (such as label names).
 `unprocessable` | The inputs provided were invalid.
 


### PR DESCRIPTION
I suggest changing the wording of this sentence "The formatting of a field is invalid.  Review the documentation for the for more specific information." so that it would read "The formatting of a field is invalid.  Review the documentation for more specific information".

### Why:

There was an issue opened about this typo - https://github.com/github/docs/issues/2289

### What's being changed:

There is a typo on the line 243 - "Review the documentation **for** the **for** more specific information". I propose changing it to "Review the documentation **for** more specific information".