### PR TITLE
Applying suggested changes in batch improvement

### DIFF
--- a/content/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request.md
+++ b/content/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request.md
@@ -13,7 +13,7 @@ versions:
 
 Other people can suggest specific changes to your pull request. You can apply these suggested changes directly in a pull request if you have write access to the repository. If the pull request was created from a fork and the author allowed edits from maintainers, you can also apply suggested changes if you have write access to the upstream repository. For more information, see "[Commenting on a pull request](/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request)" and "[Allowing changes to a pull request branch created from a fork](/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)."
 
-To quickly incorporate more than one suggested change into a single commit, you can also apply suggested changes as a batch. Applying one suggested change or a batch of suggested changes creates a single commit on the compare branch of the pull request.
+To quickly incorporate more than one suggested change into a single commit, you can also apply suggested changes as a batch. Applying one suggested change or a batch of suggested changes creates a single commit on the compare branch of the pull request. You may need to wait for the reviewer to finish before being able to add changes to a batch.
 
 Each person who suggested a change included in the commit will be a co-author of the commit. The person who applies the suggested changes will be a co-author and the committer of the commit. For more information about the term committer in Git, see "[Git Basics - Viewing the Commit History](https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History)" from the _Pro Git_ book site.
 


### PR DESCRIPTION
### Why:

It was not clear why I didn't see suggested changes in the "Files changed" tab.

### What's being changed:

```diff
+ You may need to wait for the reviewer to finish before being able to add changes to a batch.
```
Feel free to close this, just a quick suggestion and I'm not 100% sure it's correct.

### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
