### PR TITLE
Add a week for triage

### DIFF
--- a/.github/workflows/triage-stale-check.yml
+++ b/.github/workflows/triage-stale-check.yml
@@ -13,8 +13,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: 'This PR is stale because it has been open 7 days with no activity and will be automatically closed in 3 days. To keep this PR open, update the PR by adding a comment or pushing a commit.'
-          days-before-stale: 7
-          days-before-close: 10
+          days-before-stale: 14
+          days-before-close: 17
           stale-pr-label: 'stale'
           exempt-pr-labels: 'never-stale'
           exempt-issue-labels: 'never-stale'


### PR DESCRIPTION
#2179 got tagged with this:

![image](https://user-images.githubusercontent.com/1559108/103139741-f7265f00-46a4-11eb-9ad5-f23c40b617c6.png)

The changes are still valid, and no requests for follow-up have been made to the author of that PR, so auto-closing it would not be appropriate. It looks like this bot's current settings aren't a good fit for this repo's work flows.

This PR adds a week to those deadlines to better fit the time required for triage.