### PR TITLE
Docker file missing entryscript exec permissions

### DIFF
--- a/content/actions/creating-actions/creating-a-docker-container-action.md
+++ b/content/actions/creating-actions/creating-a-docker-container-action.md
@@ -54,6 +54,9 @@ FROM alpine:3.10
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 
+# Modifies the permission of the copied file into the Docker image
+RUN chmod +x entrypoint.sh
+
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]
 ```


### PR DESCRIPTION
Example fails due to error on entryscript.sh permissions when executed in the Docker image.
Needs to be added on the Docker file: "RUN chmod +x /entryscript.sh"

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
