### PR TITLE
Add missing closing bracket to mutation structure

### DIFF
--- a/content/graphql/guides/forming-calls-with-graphql.md
+++ b/content/graphql/guides/forming-calls-with-graphql.md
@@ -103,6 +103,7 @@ Mutations are structured like this:
 <pre>mutation {
   <em>mutationName</em>(input: {<em>MutationNameInput!</em>}) {
     <em>MutationNamePayload</em>
+  }
 }</pre>
 
 The input object in this example is `MutationNameInput`, and the payload object is `MutationNamePayload`.


### PR DESCRIPTION
### Why:

I noticed this was missing a balanced bracket! Quick one-liner to make this syntax correct.

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Adds a closing bracket to the selections for the mutation payload to correct the GraphQL syntax.

| [Before](https://docs.github.com/en/free-pro-team@latest/graphql/guides/forming-calls-with-graphql#about-mutations) | [After](https://docs-2656--eliperkins-patch-1.herokuapp.com/en/free-pro-team@latest/graphql/guides/forming-calls-with-graphql#about-mutations) |
| --- | --- |
| ![Screen Shot 2021-01-07 at 10 53 34 AM](https://user-images.githubusercontent.com/1051453/103914508-eed41800-50d7-11eb-910a-fe440b77246c.png) | ![Screen Shot 2021-01-07 at 11 02 50 AM](https://user-images.githubusercontent.com/1051453/103914505-ee3b8180-50d7-11eb-8c3b-85a62f60be47.png) |


### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
