### PR TITLE
Change example dates to match accompanying image on troubleshooting-commits-on-your-timeline.md

### DIFF
--- a/content/github/setting-up-and-managing-your-github-profile/troubleshooting-commits-on-your-timeline.md
+++ b/content/github/setting-up-and-managing-your-github-profile/troubleshooting-commits-on-your-timeline.md
@@ -39,20 +39,20 @@ You can use the `git show` command with the `--pretty=fuller` flag to check if t
 $ git show <em>Your commit SHA number</em> --pretty=fuller
 commit <em>Your commit SHA number</em>
 Author:     octocat <em>user email</em>
-AuthorDate: Wed Jul 13 02:02:30 2016 +0900
+AuthorDate: Tue Apr 03 02:02:30 2018 +0900
 Commit:     Sally Johnson <em>user email</em>
-CommitDate: Wed Jul 20 06:25:08 2016 +0900
+CommitDate: Tue Apr 10 06:25:08 2018 +0900
 ```
 
 If the author and commit date are different, you can manually change the commit date in the URL to see the commit details.
 
 For example:
-- This URL uses the author date of `2016-07-13`:
+- This URL uses the author date of `2018-04-03`:
 
-  `https://github.com/your-organization-or-personal-account/your-repository/commits?author=octocat&since=2016-07-13T00:00:00Z&until=2016-07-13T23:59:59Z`
-- This URL uses the commit date of `2016-07-19`:
+  `https://github.com/your-organization-or-personal-account/your-repository/commits?author=octocat&since=2018-04-03T00:00:00Z&until=2018-04-03T23:59:59Z`
+- This URL uses the commit date of `2018-04-10`:
 
-  `https://github.com/your-organization-or-personal-account/your-repository/commits?author=octocat&since=2016-07-19T00:00:00Z&until=2016-07-19T23:59:59Z`
+  `https://github.com/your-organization-or-personal-account/your-repository/commits?author=octocat&since=2018-04-10T00:00:00Z&until=2018-04-10T23:59:59Z`
 
 When you open the URL with the modified commit date, you can see the commit details.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

The examples on `troubleshooting-commits-on-your-timeline.md` had inconsistent dates; it talked about Jul 20 first, then used Jul 19 on the URLs, then the accompanying image showed Apr 10 (of another year).

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

I changed the dates to match the .png:
![image](https://user-images.githubusercontent.com/11304439/104048771-93328900-51c2-11eb-9080-ece7f6a3f505.png)

I didn't modify any localization files, but given the change is language-agnostic I can add it if desired.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
