### PR TITLE
ubuntu-latest Actions Runner is now ubuntu-20.04

### DIFF
--- a/data/reusables/github-actions/supported-github-runners.md
+++ b/data/reusables/github-actions/supported-github-runners.md
@@ -1,8 +1,8 @@
 | Virtual environment | YAML workflow label |
 | --------------------|---------------------|
 | Windows Server 2019 | `windows-latest` or `windows-2019` |
-| Ubuntu 20.04 | `ubuntu-20.04` |
-| Ubuntu 18.04 | `ubuntu-latest` or `ubuntu-18.04` |
+| Ubuntu 20.04 | `ubuntu-latest` or `ubuntu-20.04` |
+| Ubuntu 18.04 | `ubuntu-18.04` |
 | Ubuntu 16.04 | `ubuntu-16.04` |
 | macOS Big Sur 11.0 | `macos-11.0` |
 | macOS Catalina 10.15 | `macos-latest` or `macos-10.15` |


### PR DESCRIPTION

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Per https://github.blog/changelog/2020-10-29-github-actions-ubuntu-latest-workflows-will-use-ubuntu-20-04/ , the `ubuntu-latest` runner version is now `ubuntu-20.04`, not `ubuntu-18.04`, with a rollout starting on 2020-11-30 (a month and a half ago).

Fixes: https://github.com/github/docs/issues/2110

### What's being changed:

The `supported-github-runners.md` piece of shared data has the table rows adjusted slightly.

### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
