### PR TITLE
Expanding pascalgn/automerge-action SHA

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
     if: (contains(github.event.pull_request.labels.*.name, 'automerge') || contains(github.event.pull_request.labels.*.name, 'autosquash')) && (github.repository == 'github/docs-internal' || github.repository == 'github/docs')
     steps:
       - name: automerge
-        uses: 'pascalgn/automerge-action@c9bd182'
+        uses: 'pascalgn/automerge-action@c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07'
         env:
           GITHUB_TOKEN: '${{ secrets.OCTOMERGER_PAT_WITH_REPO_AND_WORKFLOW_SCOPE }}'
           MERGE_METHOD_LABELS: 'automerge=merge,autosquash=squash'


### PR DESCRIPTION
Shorthand SHA will soon be unsupported, as indicated by the warning showing on every workflow run.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:
Short-hand SHA will soon cease to function if used in Actions (as shown by the warning in every run of the workflow)
<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:
Expanded the SHA for pascalgn/automerge-actions from `c9bd182` to `c9bd1823770819dc8fb8a5db2d11a3a95fbe9b07`
<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
