### PR TITLE
Add scheduled reminder limitiations.

### DIFF
--- a/content/github/setting-up-and-managing-organizations-and-teams/managing-scheduled-reminders-for-your-team.md
+++ b/content/github/setting-up-and-managing-organizations-and-teams/managing-scheduled-reminders-for-your-team.md
@@ -13,6 +13,14 @@ versions:
 
 Team maintainers and organization owners can set scheduled reminders for any pull requests that a team has been requested to review. Before you can create a scheduled reminder for your team, an organization owner must authorize your Slack workspace. For more information, see "[Managing scheduled reminders for your organization](/github/setting-up-and-managing-organizations-and-teams/managing-scheduled-reminders-for-your-organization)."
 
+{% note %}
+
+**Note**: There are some limitations when setting up scheduled reminders:
+- At an organization level, there's a limit of five repositories.
+- At a repository level, you will only receive notifications for the oldest 20 pull requests.
+
+{% endnote %}
+
 ### Creating a scheduled reminder for a team
 {% data reusables.profile.access_profile %}
 {% data reusables.profile.access_org %}


### PR DESCRIPTION
### Why:

**Closes https://github.com/github/docs-content/issues/3064.**

### What's being changed:

Update the section [About scheduled reminders for teams](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/managing-scheduled-reminders-for-your-team#about-scheduled-reminders-for-teams), adding known limitations.

| Staging | Source | Notes |
| --- | --- | --- |
| [About scheduled reminders for teams](https://docs-3551--b4mboo-2021-02-08-u.herokuapp.com/en/github/setting-up-and-managing-organizations-and-teams/managing-scheduled-reminders-for-your-team#about-scheduled-reminders-for-teams) | [Source](https://github.com/github/docs/pull/3551/files#diff-4ebcd6cb9b0ec01805fd8f5dfe9cc56d0f9514b28c271c7e23946b852674c73d) | Add note with limitations. |


### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
