### PR TITLE
Update Codescanning Webhook Docs to Include Default Sender Field

### DIFF
--- a/content/developers/webhooks-and-events/webhook-events-and-payloads.md
+++ b/content/developers/webhooks-and-events/webhook-events-and-payloads.md
@@ -162,7 +162,7 @@ Also, the `User-Agent` for the requests will have the prefix `GitHub-Hookshot/`.
 {% data reusables.webhooks.repo_desc %}
 {% data reusables.webhooks.org_desc %}
 {% data reusables.webhooks.app_desc %}
-`sender` | `object` | If the `action` is `reopened_by_user` or `closed_by_user`, the `sender` object will be the user that triggered the event. The `sender` object is empty for all other actions.
+`sender` | `object` | If the `action` is `reopened_by_user` or `closed_by_user`, the `sender` object will be the user that triggered the event. The `sender` object is the GitHub organization for all other actions.
 
 #### Webhook payload example
 
@@ -426,7 +426,7 @@ Key | Type | Description
 
 {% note %}
 
-**Note:** This event replaces the deprecated `integration_installation` event.  
+**Note:** This event replaces the deprecated `integration_installation` event.
 
 {% endnote %}
 


### PR DESCRIPTION
### Why:

We're adding GitHub as the default sender field in the code-scanning alert payload.

### What's being changed:

Hi there 👋 

I'm from the codescanning Team at GitHub and we're doing a slight update. Previously:


sender | object | If the action is reopened_by_user or closed_by_user, the sender object will be the user that triggered the event. The sender object is empty for all other actions.
-- | -- | --

See here for more info: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#code_scanning_alert

Now, we'll include a default sender object instead of having that field be empty and want the docs to reflect the default field value.

Related Links:

payload example PR: https://github.com/octokit/webhooks/pull/366#issue-569875931

cc/ @bogdanap @anaarmas @krukow



### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
