### PR TITLE
Dependabot: Remove PRs from "schedule.interval"

### DIFF
--- a/content/github/administering-a-repository/configuration-options-for-dependency-updates.md
+++ b/content/github/administering-a-repository/configuration-options-for-dependency-updates.md
@@ -122,7 +122,7 @@ updates:
 
 ### `schedule.interval`
 
-**Required** You must define how often to check for new versions and raise pull requests for version updates to each package manager. By default, this is at 5am UTC. To modify this, use [`schedule.time`](#scheduletime) and [`schedule.timezone`](#scheduletimezone).
+**Required** You must define how often to check for new versions for each package manager. By default, this is at 5am UTC. To modify this, use [`schedule.time`](#scheduletime) and [`schedule.timezone`](#scheduletimezone).
 
 - `daily`—runs on every weekday, Monday to Friday.
 - `weekly`—runs once each week. By default, this is on Monday. To modify this, use [`schedule.day`](#scheduleday).


### PR DESCRIPTION

Fixes https://github.com/github/docs-content/issues/3772.

### Changes

| Staging | Source | Notes |
| --- | --- | --- |
| "[Configuration options for dependency updates](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#scheduleinterval)" | Source | `schedule.interval` does _not_ determine pull request frequency (as verified [on Slack](https://github.slack.com/archives/CJTN025GX/p1612802468180700)) |
|  | Source | |
|  | Source | |
|  | Source | |