### PR TITLE
Renaming the default branch can break remote themes

### DIFF
--- a/content/github/administering-a-repository/renaming-a-branch.md
+++ b/content/github/administering-a-repository/renaming-a-branch.md
@@ -13,6 +13,8 @@ You can rename a branch in a repository on {% data variables.product.product_loc
 
 If you rename a branch, {% data variables.product.prodname_dotcom %} will automatically redirect links on {% if currentVersion == "free-pro-team@latest" %}{% data variables.product.prodname_dotcom_the_website %}{% else %}{% data variables.product.product_location_enterprise %}{% endif %} that contain the old branch name to the equivalent link on the renamed branch. {% data variables.product.prodname_dotcom %} will also update branch protection policies, as well as the base branch for open pull requests and draft releases.
 
+Note that if you use [remote themes](/working-with-github-pages/adding-a-theme-to-your-github-pages-site-using-jekyll), you will need to explicitly nominate the branch if it is not `master`; e.g., `remote_theme: my_repo/my_theme@main`.
+
 ### Renaming a branch
 
 {% data reusables.repositories.navigate-to-repo %}


### PR DESCRIPTION
... because https://github.com/benbalter/jekyll-remote-theme assumes that 'master' is the default.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why: Renaming a branch can break remote themes

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->
**Closes [issue link]**

### What's being changed:

A note is being added to explain this.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
