### PR TITLE
Convert templates to new format - will work automagically on Feb 19

### DIFF
--- a/.github/ISSUE_TEMPLATE/improve-existing-docs.yaml
+++ b/.github/ISSUE_TEMPLATE/improve-existing-docs.yaml
@@ -2,60 +2,38 @@
 name: Improve existing docs
 about: Make a suggestion to improve our existing documentation.
 labels: content
-inputs:
-- type: description
+body:
+- type: markdown
   attributes:
     value: |
       HUBBERS BEWARE! THE GITHUB/DOCS REPO IS PUBLIC TO THE ENTIRE INTERNET. OPEN AN ISSUE IN GITHUB/DOCS-CONTENT INSTEAD.
 
       For questions, ask in Discussions: https://github.com/github/docs/discussions
 - type: checkboxes
-  label: Code of Conduct
   attributes:
-    label: 'I agree to follow the Code of Conduct: https://github.com/github/docs/blob/main/CODE_OF_CONDUCT.md'
-    required: true
-    multi-select: false
-    free-text: false
-    choices:
-      - label: I agree
-- type: dropdown
-  label: Contributing
-  attributes:
-    choices:
-      - description: 'I have read the Contributing guide: https://github.com/github/docs/blob/main/CONTRIBUTING.md'
-        required: true
-        multi-select: false
-        free-text: false
-        choices:
-          - description: I agree
-            value: I agree
-- type: dropdown
-  label: Similar issue
-  attributes:
-    choices:
-      - description: 'There is not a similar issue that has been already opened: https://github.com/github/docs/issues'
-        required: true
-        multi-select: false
-        free-text: false
-        choices:
-          - description: No similar issues
-            value: No similar issues
+    label: Contributing Guidelines
+    options:
+    - label: 'I agree to follow the [Code of Conduct](https://github.com/github/docs/blob/main/CODE_OF_CONDUCT.md)'
+      required: true
+    - label: 'I have read the [Contributing Guide](https://github.com/github/docs/blob/main/CONTRIBUTING.md)'
+      required: true
+    - label: 'There is not a similar issue that has been [already opened](https://github.com/github/docs/issues)'
+      required: true
 - type: textarea
   attributes:
-    label: which article
-    description: What article on docs.github.com is affected?
-    required: true
+    label: Which article?
+    description: What article on [docs.github.com](https://docs.github.com) is affected?
     placeholder: Add a link to the article you'd like to see updated
-    value:
-- type: textarea
-  attributes:
-    label: desired updates
-    description: What part(s) of the article would you like to see updated?
+  validations:
     required: true
-    placeholder: Give as much detail as you can to help us understand the change you want to see. Why should the docs be changed? What use cases does it support? What is the expected outcome?
 - type: textarea
   attributes:
-    label: additional info
-    description: Additional information
-    required: false
+    label: Desired Updates
+    description: What part(s) of the article would you like to see updated?
+    placeholder: Give as much detail as you can to help us understand the change you want to see. Why should the docs be changed? What use cases does it support? What is the expected outcome?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional Information
     placeholder: Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/improve-the-site.yaml
+++ b/.github/ISSUE_TEMPLATE/improve-the-site.yaml
@@ -2,53 +2,33 @@
 name: Suggest ideas and updates for the Docs website
 about: Make a suggestions or report a problem on the docs.github.com website.
 labels: engineering
-inputs:
-- type: description
+body:
+- type: markdown
   attributes:
     value: |
       HUBBERS BEWARE! Please confirm you're on the github/docs-internal repo and not the github/docs repo before proceeding, unless you want to make your work public to the entire internet. The github/docs repo is open source and public to the entire internet.
 
       For questions, ask in Discussions: https://github.com/github/docs/discussions
 - type: checkboxes
-  label: Code of Conduct
   attributes:
-    label: 'I agree to follow the Code of Conduct: https://github.com/github/docs/blob/main/CODE_OF_CONDUCT.md'
-    required: true
-    multi-select: false
-    free-text: false
-    choices:
-      - label: I agree
-- type: dropdown
-  label: Contributing
-  attributes:
-    choices:
-      - description: 'I have read the Contributing guide: https://github.com/github/docs/blob/main/CONTRIBUTING.md'
-        required: true
-        multi-select: false
-        free-text: false
-        choices:
-          - description: I agree
-            value: I agree
-- type: dropdown
-  label: Similar issue
-  attributes:
-    choices:
-      - description: 'There is not a similar issue that has been already opened: https://github.com/github/docs/issues'
-        required: true
-        multi-select: false
-        free-text: false
-        choices:
-          - description: No similar issues
-            value: No similar issues
+    label: Contributing Guidelines
+    options:
+    - label: 'I agree to follow the [Code of Conduct](https://github.com/github/docs/blob/main/CODE_OF_CONDUCT.md)'
+      required: true
+    - label: 'I have read the [Contributing Guide](https://github.com/github/docs/blob/main/CONTRIBUTING.md)'
+      required: true
+    - label: 'There is not a similar issue that has been [already opened](https://github.com/github/docs/issues)'
+      required: true
 - type: textarea
   attributes:
-    label: suggestion
+    label: Suggestion
     description: What changes are you suggesting?
-    required: true
     placeholder: Explain, in writing, with as much detail as possible, what changes you're suggesting and why. Provide supporting information using screenshots and URLs where possible, to help us understand your suggested changes.
+  validations:
+    required: true
 - type: textarea
   attributes:
-    label: additional info
-    description: Additional information
-    required: false
+    label: Additional Information
     placeholder: Any additional information, configuration, or data that might be necessary to reproduce the issue.
+  validations:
+    required: true


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

This PR fixes up the proposed YAML templates for Issue Forms. If you merge this PR into the branch `janiceilene-patch-1`, then merge that branch into main **sometime after February 19**, then things should start ✨ automagically working ✨

### What's being changed:

### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
