### PR TITLE
Make sure the "Waiting for review" label is sticky

### DIFF
--- a/.github/workflows/triage-stale-check.yml
+++ b/.github/workflows/triage-stale-check.yml
@@ -27,6 +27,7 @@ jobs:
           stale-pr-message: 'This is a gentle bump for the docs team that this PR is waiting for review.'
           days-before-pr-stale: 14
           days-before-pr-close: -1 # Never close
+          remove-stale-when-updated: false
           only-labels: 'waiting for review'
           # The hope is that by setting the stale-pr-label to the same label
           # as the label that the stale check looks for, this will result in


### PR DESCRIPTION
As we continue to work on our workflows to make sure that PRs aren't closed when waiting for Docs team members, we found another issue where the actions/stale workflow removed the "waiting for review" label from a few PRs that were "waiting for review"

This should prevent that from happening again and I'll monitor the results when it runs again.

Furthermore, I'm going to manually re-add those "waiting for review" labels.

We'll get this just right in a matter of time! Hopefully this is the last piece. 