### PR TITLE
use `pull_request_target`

### DIFF
--- a/.github/workflows/repo-freeze-check.yml
+++ b/.github/workflows/repo-freeze-check.yml
@@ -1,7 +1,7 @@
 name: Repo Freeze Check
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/repo-freeze-check.yml
+++ b/.github/workflows/repo-freeze-check.yml
@@ -1,6 +1,7 @@
 name: Repo Freeze Check
 
 on:
+  workflow_dispatch:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
### Why:
From:

> In order to protect public repositories for malicious users we run all pull request workflows raised from repository forks with a read-only token and no access to secrets. This makes common workflows like labeling or commenting on pull requests very difficult.

We need workflows that run on forks to be able to read the `FREEZE` secret in the github/docs repo. This updates the workflow to use the `pull_request_target` event, which allows using the base repos secrets in a workflow.

Added `workflow_dispatch` for good measure. We can use this to run this workflow on a different branch to test it out.