### PR TITLE
Update configuring-dotnet-cli-for-use-with-github-packages.md

### DIFF
--- a/content/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.md
+++ b/content/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.md
@@ -76,7 +76,7 @@ If your instance has subdomain isolation disabled:
 
 {% data reusables.package_registry.package-registry-with-github-tokens %}
 
-If running in a GitHub Action, use the following command to authenticate to GitHub Packages without storing a token in a nuget.config file in the repository:
+If authenticating to GitHub Packages in a GitHub Actions workflow, use the following command instead of storing a token in a nuget.config file in the repository:
 
 ```shell
 dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://{% if currentVersion == "free-pro-team@latest" %}nuget.pkg.github.com{% else %}nuget.HOSTNAME{% endif %}/OWNER/index.json"

--- a/content/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.md
+++ b/content/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.md
@@ -76,7 +76,7 @@ If your instance has subdomain isolation disabled:
 
 {% data reusables.package_registry.package-registry-with-github-tokens %}
 
-If authenticating to GitHub Packages in a GitHub Actions workflow, use the following command instead of storing a token in a nuget.config file in the repository:
+Use the following command to authenticate to {% data variables.product.prodname_registry %} in a {% data variables.product.prodname_actions %} workflow instead of storing a token in a nuget.config file in the repository:
 
 ```shell
 dotnet nuget add source --username USERNAME --password {%raw%}${{ secrets.GITHUB_TOKEN }}{% endraw %} --store-password-in-clear-text --name github "https://{% if currentVersion == "free-pro-team@latest" %}nuget.pkg.github.com{% else %}nuget.HOSTNAME{% endif %}/OWNER/index.json"

--- a/content/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.md
+++ b/content/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.md
@@ -79,7 +79,7 @@ If your instance has subdomain isolation disabled:
 If authenticating to GitHub Packages in a GitHub Actions workflow, use the following command instead of storing a token in a nuget.config file in the repository:
 
 ```shell
-dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://{% if currentVersion == "free-pro-team@latest" %}nuget.pkg.github.com{% else %}nuget.HOSTNAME{% endif %}/OWNER/index.json"
+dotnet nuget add source --username USERNAME --password {%raw%}${{ secrets.GITHUB_TOKEN }}{% endraw %} --store-password-in-clear-text --name github "https://{% if currentVersion == "free-pro-team@latest" %}nuget.pkg.github.com{% else %}nuget.HOSTNAME{% endif %}/OWNER/index.json"
 ```
 
 ### Publishing a package

--- a/content/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.md
+++ b/content/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.md
@@ -76,6 +76,12 @@ If your instance has subdomain isolation disabled:
 
 {% data reusables.package_registry.package-registry-with-github-tokens %}
 
+If running in a GitHub Action, use the following command to authenticate to GitHub Packages without storing a token in a nuget.config file in the repository:
+
+```shell
+dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://{% if currentVersion == "free-pro-team@latest" %}nuget.pkg.github.com{% else %}nuget.HOSTNAME{% endif %}/OWNER/index.json"
+```
+
 ### Publishing a package
 
 You can publish a package to {% data variables.product.prodname_registry %} by authenticating with a *nuget.config* file{% if currentVersion == "free-pro-team@latest" or currentVersion ver_gt "enterprise-server@2.22" %}, or by using the `--api-key` command line option with your {% data variables.product.prodname_dotcom %} personal access token (PAT){% endif %}.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

The article doesn't otherwise mention how to authenticate to GitHub Packages in a GitHub Actions workflow - it just links to a generic [GITHUB_TOKEN page](https://docs-3935--patch-2.herokuapp.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token). The `dotnet nuget add source` command allows for authenticating to GitHub packages without having to source control a GitHub token.

I thought this simple one-liner would be very helpful in consuming GitHub Packages in a an effecient manner instead of having to sift through [Stack Overflow](https://stackoverflow.com/a/62809861/4270353) posts on how to do this.

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Adding an example command that can be used to authenticate to GitHub Packages in a GitHub Action without committing a secret to source control: 

```shell
dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/OWNER/index.json"
```

(If this link still works) The change can be found on the Heroku page [here](https://docs-3935--patch-2.herokuapp.com/en/packages/guides/configuring-dotnet-cli-for-use-with-github-packages#authenticating-to-github-packages
): 
![image](https://user-images.githubusercontent.com/19912012/108902952-5db2f500-75e2-11eb-856e-262549fe9ec0.png)


### Check off the following:
- [X] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [X] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [X] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
