### PR TITLE
Fixed bullet points not having full stops at the end

### DIFF
--- a/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/apply-for-a-student-developer-pack.md
+++ b/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/apply-for-a-student-developer-pack.md
@@ -14,10 +14,10 @@ versions:
 ### Requirements
 
 To be eligible for the {% data variables.product.prodname_student_pack %}, you must:
-- Be currently enrolled in a degree or diploma granting course of study such as a high school, secondary school, college, university, homeschool, or similar educational institution
-- Have a verifiable school-issued email address or upload documents that prove your current student status
+- Be currently enrolled in a degree or diploma granting course of study such as a high school, secondary school, college, university, homeschool, or similar educational institution.
+- Have a verifiable school-issued email address or upload documents that prove your current student status.
 - Have a [{% data variables.product.prodname_dotcom %} user account](/articles/signing-up-for-a-new-github-account)
-- Be at least 13 years old
+- Be at least 13 years old.
 
 Documents that prove your current student status include a picture of your school ID with current enrollment date, class schedule, transcript, and affiliation or enrollment verification letter.
 


### PR DESCRIPTION
### Why:

**Closes #3997**

### What's being changed:

Added full stops to the end of the bullet points explaining requirements. 

### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
