### PR TITLE
docs(github-actions: ja-JP): Fix text of example-github-runner.md

### DIFF
--- a/translations/ja-JP/data/reusables/github-actions/example-github-runner.md
+++ b/translations/ja-JP/data/reusables/github-actions/example-github-runner.md
@@ -12,7 +12,7 @@ runs-on: windows-latest
 
 {% raw %}
 ```yaml
-runs-on: windows-latest
+runs-on: macos-latest
 ```
 {% endraw %}
 


### PR DESCRIPTION
### Why:
I found a mistake in the text in the Japanese documentation.
(Setting value of `runs-on` is incorrect.)
I've fixed it and sent a pull request.

### What's being changed:
Fix setting value of `runs-on` at Japanese documentation.

### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
