### PR TITLE
Fix the `artifact` word, changing from `artefact`

### DIFF
--- a/translations/pt-BR/content/actions/guides/storing-workflow-data-as-artifacts.md
+++ b/translations/pt-BR/content/actions/guides/storing-workflow-data-as-artifacts.md
@@ -44,7 +44,7 @@ Os artefatos expiram automaticamente após 90 dias, mas você pode recuperar arm
 
 Faz-se o upload dos artefatos durante a execução de um fluxo de trabalho e você pode visualizar o nome e o tamanho do artefato na UI. Quando se faz o download de um artefato usando a UI {% data variables.product.product_name %}, todos os arquivos cujo upload foi feito individualmente como parte do get do artefato zipado em um arquivo único. Isso significa que a cobrança é calculada com base no tamanho do artefato subido e não com base no tamanho do arquivo zip.
 
-O {% data variables.product.product_name %} fornece duas ações que você pode usar para fazer upload e baixar artefatos de compilação. Para mais informações veja o {% if currentVersion == "free-pro-team@latest" %}[actions/upload-artifact](https://github.com/actions/upload-artifact) e [download-artefact](https://github.com/actions/download-artifact) ações{% else %} `actions/upload-artefact` e `download-artefact` ações em {% data variables.product.product_location %}{% endif %}.
+O {% data variables.product.product_name %} fornece duas ações que você pode usar para fazer upload e baixar artefatos de compilação. Para mais informações veja o {% if currentVersion == "free-pro-team@latest" %}[actions/upload-artifact](https://github.com/actions/upload-artifact) e [download-artifact](https://github.com/actions/download-artifact) ações{% else %} `actions/upload-artifact` e `download-artifact` ações em {% data variables.product.product_location %}{% endif %}.
 
 Para compartilhar dados entre trabalhos:
 
@@ -136,7 +136,7 @@ Após a conclusão da execução de um fluxo de trabalho, você pode fazer o dow
 
 #### Fazer o download dos artefatos durante a execução de um fluxo de trabalho
 
-A ação [`actions/download-artefact`](https://github.com/actions/download-artifact) pode ser usada para fazer o download de artefatos previamente carregados durante a execução de um fluxo de trabalho.
+A ação [`actions/download-artifact`](https://github.com/actions/download-artifact) pode ser usada para fazer o download de artefatos previamente carregados durante a execução de um fluxo de trabalho.
 
 {% note %}
 
@@ -166,7 +166,7 @@ Para mais informações sobre a sintaxe, consulte a ação {% if currentVersion 
 
 ### Transmitir dados entre trabalhos em um fluxo
 
-Você pode usar as ações `upload-artifact` e `download-artifact` para compartilhar os dados entre os trabalhos em um fluxo de trabalho. Este exemplo de fluxo de trabalho ilustra como transmitir dados entre trabalhos em um mesmo fluxo. Para mais informações veja o {% if currentVersion == "free-pro-team@latest" %}[actions/upload-artifact](https://github.com/actions/upload-artifact) e [download-artefact](https://github.com/actions/download-artifact) ações{% else %} `actions/upload-artefact` e `download-artefact` ações em {% data variables.product.product_location %}{% endif %}.
+Você pode usar as ações `upload-artifact` e `download-artifact` para compartilhar os dados entre os trabalhos em um fluxo de trabalho. Este exemplo de fluxo de trabalho ilustra como transmitir dados entre trabalhos em um mesmo fluxo. Para mais informações veja o {% if currentVersion == "free-pro-team@latest" %}[actions/upload-artifact](https://github.com/actions/upload-artifact) e [download-artifact](https://github.com/actions/download-artifact) ações{% else %} `actions/upload-artifact` e `download-artifact` ações em {% data variables.product.product_location %}{% endif %}.
 
 Os trabalhos que são dependentes de artefatos de um trabalho anterior devem aguardar a finalização do trabalho dependente. Esse fluxo de trabalho usa a palavra-chave `needs` para garantir que `job_1`, `job_2` e `job_3` sejam executados sequencialmente. Por exemplo, `job_2` requer `job_1` usando a sintaxe `needs: job_1`.
 


### PR DESCRIPTION
On Brazilian portuguese the `artifact` word is `artefato`, but for technical docs, we don't translate that.

> All the files on `translations/**` folder cannot be changed, but the translations are incorrect on the page.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->
**Closes [issue link]**

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
