### PR TITLE
Improvements to text of webhooks articles

### DIFF
--- a/content/actions/reference/events-that-trigger-workflows.md
+++ b/content/actions/reference/events-that-trigger-workflows.md
@@ -171,6 +171,8 @@ on:
 
 You can configure your workflow to run when webhook events are generated on {% data variables.product.product_name %}. Some events have more than one activity type that triggers the event. If more than one activity type triggers the event, you can specify which activity types will trigger the workflow to run. For more information, see "[Webhooks](/webhooks)." 
 
+Not all webhooks events trigger workflows. For the complete list of available webhook events and their payloads, see "[Webhook events and payloads](/developers/webhooks-and-events/webhook-events-and-payloads)." 
+
 #### `check_run`
 
 Runs your workflow anytime the `check_run` event occurs. {% data reusables.developer-site.multiple_activity_types %} For information about the REST API, see "[Check runs](/rest/reference/checks#runs)."

--- a/content/actions/reference/events-that-trigger-workflows.md
+++ b/content/actions/reference/events-that-trigger-workflows.md
@@ -169,7 +169,7 @@ on:
 
 ### Webhook events
 
-You can configure your workflow to run when webhook events are created on {% data variables.product.product_name %}. Some events have more than one activity type that triggers the event. If more than one activity type triggers the event, you can specify which activity types will trigger the workflow to run. For more information, see "[Webhooks](/webhooks)." 
+You can configure your workflow to run when webhook events are generated on {% data variables.product.product_name %}. Some events have more than one activity type that triggers the event. If more than one activity type triggers the event, you can specify which activity types will trigger the workflow to run. For more information, see "[Webhooks](/webhooks)." 
 
 #### `check_run`
 

--- a/content/developers/webhooks-and-events/about-webhooks.md
+++ b/content/developers/webhooks-and-events/about-webhooks.md
@@ -22,7 +22,7 @@ You can create up to {% if enterpriseServerVersions contains currentVersion or c
 
 Each event corresponds to a certain set of actions that can happen to your organization and/or repository. For example, if you subscribe to the `issues` event you'll receive detailed payloads every time an issue is opened, closed, labeled, etc.
 
-See "[Webhook event payloads](/webhooks/event-payloads)" for the list of available webhook events and their payloads.
+For a complete list of available webhook events and their payloads, see "[Webhook events and payloads](/developers/webhooks-and-events/webhook-events-and-payloads)."
 
 ### Ping event
 


### PR DESCRIPTION
### Why:

**Closes #4625 **

### What's being changed:

Suggested replacements and additions done, as requested by @hubwriter . Summary of changes made are as below:

1.  The last sentence in the _content/developers/webhooks-and-events/about-webhooks#events_ directory was changed from : 
`See "Webhook event payloads" for the list of available webhook events and their payloads.` 
to
`For a complete list of available webhook events and their payloads, see "[Webhook events and payloads](/developers/webhooks-and-events/webhook-events-and-payloads)."`

2.   In the first paragraph, of the _content/actions/reference/events-that-trigger-workflows#webhook-events_ directory, `when webhook events are created` was changed to `when webhook events are generated`.

3.   In the above same directory, after the existing first paragraph (i.e. before the "check_run" subsection) added a new paragraph:
`Not all webhooks events trigger workflows. For the complete list of available webhook events and their payloads, see "[Webhook events and payloads](/developers/webhooks-and-events/webhook-events-and-payloads)." `

### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
