### PR TITLE
Note that some paths require special privileges for tree manipulation

### DIFF
--- a/content/rest/reference/git.md
+++ b/content/rest/reference/git.md
@@ -70,6 +70,8 @@ A Git tag is similar to a [Git reference](/rest/reference/git#refs), but the Git
 
 A Git tree object creates the hierarchy between files in a Git repository. You can use the Git tree object to create the relationship between directories and the files they contain. These endpoints allow you to read and write [tree objects](https://git-scm.com/book/en/v1/Git-Internals-Git-Objects#Tree-Objects) to your Git database on {% data variables.product.product_name %}.
 
+Important: Some paths require special priveleges to be manipulated using this API, such as `.github/workflows`.
+
 {% for operation in currentRestOperations %}
   {% if operation.subcategory == 'trees' %}{% include rest_operation %}{% endif %}
 {% endfor %}


### PR DESCRIPTION
### Why:

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->
**Closes [issue link]**

I've been troubleshooting for an hour and was about to write to community support, when I noticed [this thread](https://github.community/t/unable-to-create-update-workflow-files-using-the-api/14624). It perfectly describes my issue - and I can now change workflow files. 

I've created this PR to make a note for future users, such that they're aware that some APIs require more.

Sidenote: Can you please consider returning a 403 or 401 - rather than a 404?

### What's being changed:
Added note on Tree API reg. privileges.

### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
