### PR TITLE
Add new info - Git Credential Manager Core

### DIFF
--- a/content/github/using-git/caching-your-github-credentials-in-git.md
+++ b/content/github/using-git/caching-your-github-credentials-in-git.md
@@ -71,6 +71,14 @@ You can also install a native Git shell, such as [Git for Windows](https://git-f
 $ git config --global credential.helper wincred
 ```
 
+On newer versions of Git (2.28.0 and later), Git for Windows includes the replacement for the wincred credential helper. The new cross-platform replacement, [Git Credential Manager Core](https://github.com/microsoft/Git-Credential-Manager-Core), can be configured as the global (or system) credential helper with the following command:
+
+```shell
+$ git config --global credential.helper manager-core
+```
+
+Note that Git Credential Manager Core can use the credentials originally created with Git Credential Manager for Windows, so you do not have to re-authenticate. See the blog post in Further Reading below for more.
+
 {% endwindows %}
 
 {% linux %}
@@ -100,3 +108,4 @@ Turn on the credential helper so that Git will save your password in memory for 
 
 - "[Updating credentials from the OSX Keychain](/articles/updating-credentials-from-the-osx-keychain/)"
 - "[Creating a personal access token](/github/authenticating-to-github/creating-a-personal-access-token)"
+- "[Git Credential Manager Core: Building a universal authentication experience](https://github.blog/2020-07-02-git-credential-manager-core-building-a-universal-authentication-experience/)"


### PR DESCRIPTION
I only included the Windows portion, but the credential helper is also working (or planned to work) on MacOS, Linux, as well as Windows.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->
**Closes [issue link]**

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
