### PR TITLE
remove `.git` for example folder

### DIFF
--- a/content/github/creating-cloning-and-archiving-repositories/duplicating-a-repository.md
+++ b/content/github/creating-cloning-and-archiving-repositories/duplicating-a-repository.md
@@ -23,13 +23,13 @@ Before you can duplicate a repository and push to your new copy, or _mirror_, of
   ```
 3. Mirror-push to the new repository.
   ```shell
-  $ cd <em>old-repository</em>.git
+  $ cd <em>old-repository</em>
   $ git push --mirror https://{% data variables.command_line.codeblock %}/<em>exampleuser</em>/<em>new-repository</em>.git
   ```
 4. Remove the temporary local repository you created earlier.
   ```shell
   $ cd ..
-  $ rm -rf <em>old-repository</em>.git
+  $ rm -rf <em>old-repository</em>
   ```
 
 ### Mirroring a repository that contains {% data variables.large_files.product_name_long %} objects
@@ -41,7 +41,7 @@ Before you can duplicate a repository and push to your new copy, or _mirror_, of
   ```
 3. Navigate to the repository you just cloned.
   ```shell
-  $ cd <em>old-repository</em>.git
+  $ cd <em>old-repository</em>
   ```
 4. Pull in the repository's {% data variables.large_files.product_name_long %} objects.
   ```shell
@@ -58,7 +58,7 @@ Before you can duplicate a repository and push to your new copy, or _mirror_, of
 7. Remove the temporary local repository you created earlier.
   ```shell
   $ cd ..
-  $ rm -rf <em>old-repository</em>.git
+  $ rm -rf <em>old-repository</em>
   ```
 
 ### Mirroring a repository in another location
@@ -72,7 +72,7 @@ If you want to mirror a repository in another location, including getting update
   ```
 3. Set the push location to your mirror.
   ```shell
-  $ cd <em>repository-to-mirror</em>.git
+  $ cd <em>repository-to-mirror</em>
   $ git remote set-url --push origin https://{% data variables.command_line.codeblock %}/<em>exampleuser</em>/<em>mirrored</em>
   ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:
Wrong example folder name after folder created by cloner

### What's being changed:
Just change from `cd old-example.git` to `cd old-example` and `rm -rf old-repository.git` to `rm -rf old-repository`

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [x] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
