### PR TITLE
docs(Creating a GitHub App from a manifest): `POST /app-manifests/:code/conversions` -> `POST /app-manifests/{code}/conversions`

### DIFF
--- a/content/developers/apps/creating-a-github-app-from-a-manifest.md
+++ b/content/developers/apps/creating-a-github-app-from-a-manifest.md
@@ -179,7 +179,7 @@ You must complete this step of the GitHub App Manifest flow within one hour.
 {% data reusables.pre-release-program.api-preview-warning %}
 {% endif %}
 
-    POST /app-manifests/:code/conversions
+    POST /app-manifests/{code}/conversions
 
 For more information about the endpoint's response, see [Create a GitHub App from a manifest](/rest/reference/apps#create-a-github-app-from-a-manifest).
 


### PR DESCRIPTION
### Why:

I found a left-over route that uses the no longer used `:param` notation

![image](https://user-images.githubusercontent.com/39992/114470865-71bbb180-9ba4-11eb-8a9e-30c99fae0021.png)


### What's being changed:

![image](https://user-images.githubusercontent.com/39992/114470893-80a26400-9ba4-11eb-9e97-ef4f6b836b6b.png)


### Check off the following:

- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)