### PR TITLE
Fix typo in octicon.js

### DIFF
--- a/tests/rendering/octicon.js
+++ b/tests/rendering/octicon.js
@@ -34,7 +34,7 @@ describe('octicon tag', () => {
       .toThrowError('Syntax Error in tag \'octicon\' - Valid syntax: octicon "<name>" <key="value">')
   })
 
-  it('throws an error with a non-existant octicon', async () => {
+  it('throws an error with a non-existent octicon', async () => {
     await expect(renderContent('{% octicon "pizza-patrol" %}')).rejects
       .toThrowError('Octicon pizza-patrol does not exist')
   })


### PR DESCRIPTION


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Typo

### What's being changed:

non-existant -> non-existent

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (eg. a "before and after video")

<!-- Description of the writer impact here -->
