### PR TITLE
Clarify release event trigger behaviour

### DIFF
--- a/content/actions/reference/events-that-trigger-workflows.md
+++ b/content/actions/reference/events-that-trigger-workflows.md
@@ -677,6 +677,12 @@ on:
     types: [published]
 ```
 
+{% note %}
+
+**Note:** The `prereleased` type will not trigger for pre releases getting published from draft releases. The `published` type however will. If you want a workflow to run when stable *and* pre releases are published, subscribe to `published` instead of `released` and `prereleased`.
+
+{% endnote %}
+
 #### `status`
 
 Runs your workflow anytime the status of a Git commit changes, which triggers the `status` event. For information about the REST API, see [Statuses](/rest/reference/repos#statuses).

--- a/content/actions/reference/events-that-trigger-workflows.md
+++ b/content/actions/reference/events-that-trigger-workflows.md
@@ -679,7 +679,7 @@ on:
 
 {% note %}
 
-**Note:** The `prereleased` type will not trigger for pre releases getting published from draft releases. The `published` type however will. If you want a workflow to run when stable *and* pre releases are published, subscribe to `published` instead of `released` and `prereleased`.
+**Note:** The `prereleased` type will not trigger for pre-releases published from draft releases, but the `published` type will trigger. If you want a workflow to run when stable *and* pre-releases publish, subscribe to `published` instead of `released` and `prereleased`.
 
 {% endnote %}
 


### PR DESCRIPTION
### Why:

As it turns out, the release event will not trigger with `prereleased` type for pre releases getting published from drafts, only with `published`. This adds a little note to clarify this behaviour.

**Closes https://github.com/github/docs/issues/5767**

### What's being changed:

I've added a small note:

> **Note:** The `prereleased` type will not trigger for pre releases getting published from draft releases. The `published` type however will. If you want a workflow to run when stable *and* pre releases are published, subscribe to `published` instead of `released` and `prereleased`.

### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [x] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (eg. a "before and after video")

<!-- Description of the writer impact here -->
