### PR TITLE
Fix dependabot registries examples for maven-repositories with a token

### DIFF
--- a/content/code-security/supply-chain-security/configuration-options-for-dependency-updates.md
+++ b/content/code-security/supply-chain-security/configuration-options-for-dependency-updates.md
@@ -484,7 +484,8 @@ registries:
   maven-github:
     type: maven-repository
     url: https://maven.pkg.github.com/octocat
-    token: ${{secrets.MY_GITHUB_PERSONAL_TOKEN}}
+    username: "x-access-token"
+    password: "${{secrets.MY_GITHUB_PERSONAL_TOKEN}}"
   npm-npmjs:
     type: npm-registry
     url: https://registry.npmjs.org
@@ -812,7 +813,7 @@ registries:
 
 #### `maven-repository` 
 
-The `maven-repository` type supports username and password, or token.
+The `maven-repository` type supports username and password, or token (here the username has to be "x-access-token" and the password is the token).
 
 {% raw %}
 ```yaml
@@ -831,7 +832,8 @@ registries:
   maven-github:
     type: maven-repository
     url: https://maven.pkg.github.com/octocat
-    token: ${{secrets.MY_GITHUB_PERSONAL_TOKEN}}
+    username: "x-access-token"
+    password: "${{secrets.MY_GITHUB_PERSONAL_TOKEN}}"
 ```
 {% endraw %}
 


### PR DESCRIPTION
### Why:

For maven-repositories the "token" keyword doesn't work. I had to search through the dependabot issues and found this PR https://github.com/dependabot/dependabot-core/pull/3403/files#diff-48b048f6d8a8b732434e30d186e65de8e3303c03308c116f8e078697b372abecR312

which shows that you have to use username:"x-access-token" and as password the "token". This was not correct reflected in the documentation

https://github.com/github/docs/issues/5981

### What's being changed:

### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).

