### PR TITLE
Fix formatting in article About Status Checks

### DIFF
--- a/content/github/collaborating-with-issues-and-pull-requests/about-status-checks.md
+++ b/content/github/collaborating-with-issues-and-pull-requests/about-status-checks.md
@@ -55,16 +55,16 @@ To skip or request checks for your commit, add one of the following trailer line
 
 - To _skip checks_ for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add two empty lines followed by `skip-checks: true`":
   ```shell
-  $ git commit -m "Update README"
+  $ git commit -m "Update README
   >
   >
-  skip-checks: true
+  skip-checks: true"
   ```
 - To _request_ checks for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add two empty lines followed by `request-checks: true`:
   ```shell
-  $ git commit -m "Refactor usability tests"
+  $ git commit -m "Refactor usability tests
   >
   >
-  request-checks: true
+  request-checks: true"
   ```
   

--- a/content/github/collaborating-with-issues-and-pull-requests/about-status-checks.md
+++ b/content/github/collaborating-with-issues-and-pull-requests/about-status-checks.md
@@ -53,16 +53,16 @@ When a repository is set to automatically request checks for pushes, you can cho
 
 To skip or request checks for your commit, add one of the following trailer lines to the end of your commit message:
 
-- To _skip checks_ for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add two empty lines followed by `skip-checks: true`:
+- To _skip checks_ for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add two empty lines followed by `skip-checks: true`":
   ```shell
-  $ git commit -m "Update README.
+  $ git commit -m "Update README"
   >
   >
   skip-checks: true
   ```
-  - To _request_ checks for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add two empty lines followed by `request-checks: true`:
+- To _request_ checks for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add two empty lines followed by `request-checks: true`:
   ```shell
-  $ git commit -m "Refactor usability tests.
+  $ git commit -m "Refactor usability tests"
   >
   >
   request-checks: true

--- a/content/github/collaborating-with-issues-and-pull-requests/about-status-checks.md
+++ b/content/github/collaborating-with-issues-and-pull-requests/about-status-checks.md
@@ -53,14 +53,14 @@ When a repository is set to automatically request checks for pushes, you can cho
 
 To skip or request checks for your commit, add one of the following trailer lines to the end of your commit message:
 
-- To _skip checks_ for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add two empty lines followed by `skip-checks: true`":
+- To _skip checks_ for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, before the closing quotation, add two empty lines followed by `skip-checks: true`:
   ```shell
   $ git commit -m "Update README
   >
   >
   skip-checks: true"
   ```
-- To _request_ checks for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add two empty lines followed by `request-checks: true`:
+- To _request_ checks for a commit, type your commit message and a short, meaningful description of your changes. After your commit description, before the closing quotation, add two empty lines followed by `request-checks: true`:
   ```shell
   $ git commit -m "Refactor usability tests
   >


### PR DESCRIPTION
### Why:

Because the article was formatted incorrectly.

**Closes #6026**.

### What's being changed:

- Including closing quotes;
- Added `"` at the end of `followed by skip-checks: true`
- Including one indent less in the topic "Skipping and requesting checks for individual commits"

NOTE: I followed what was recommended in Issue #6026, thanks.
