### PR TITLE
Libraries: replace `octokit/rest.js` with `octokit/octokit.js`

### DIFF
--- a/content/rest/overview/libraries.md
+++ b/content/rest/overview/libraries.md
@@ -19,7 +19,7 @@ topics:
   <div class="octokit-links"><br/>
      <div class="octokit-language"> <span>Ruby → </span><a href="https://github.com/octokit/octokit.rb">octokit.rb</a></div><br/>
      <div class="octokit-language"><span>.NET → </span> <a href="https://github.com/octokit/octokit.net">octokit.net</a></div><br/>
-     <div class="octokit-language"><span>JavaScript → </span> <a href="https://github.com/octokit/rest.js">octokit/rest.js</a></div><br/>
+     <div class="octokit-language"><span>JavaScript → </span> <a href="https://github.com/octokit/octokit.js">octokit/octokit.js</a></div><br/>
   </div>
 </div>
 


### PR DESCRIPTION
### Why:

https://github.com/octokit/octokit.js/ is the new all-batteries included JavaScript SDK for GitHub. https://github.com/octokit/rest.js continues to exist, but mostly for legacy reasons.

### What's being changed:

Link to https://github.com/octokit/rest.js has been replaced by https://github.com/octokit/octokit.js

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (eg. a "before and after video")

<!-- Description of the writer impact here -->
