### PR TITLE
Remove 'public' clarification for repos eligible for community files

### DIFF
--- a/content/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file.md
+++ b/content/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file.md
@@ -1,6 +1,6 @@
 ---
 title: Creating a default community health file
-intro: 'You can create default community health files, such as CONTRIBUTING and CODE_OF_CONDUCT. Default files will be used for any public repository owned by the account that does not contain its own file of that type.'
+intro: 'You can create default community health files, such as CONTRIBUTING and CODE_OF_CONDUCT. Default files will be used for any repository owned by the account that does not contain its own file of that type.'
 redirect_from:
   - /articles/creating-a-default-community-health-file-for-your-organization
   - /github/building-a-strong-community/creating-a-default-community-health-file-for-your-organization
@@ -16,12 +16,12 @@ topics:
 
 You can add default community health files to the root of a public repository called `.github` that is owned by an organization{% if currentVersion == "free-pro-team@latest" or currentVersion == "github-ae@latest" or currentVersion ver_gt "enterprise-server@2.19" %} or user account{% endif %}.
 
-{% data variables.product.product_name %} will use and display default files for any public repository owned by the account that does not have its own file of that type in any of the following places:
+{% data variables.product.product_name %} will use and display default files for any repository owned by the account that does not have its own file of that type in any of the following places:
 - the root of the repository
 - the `.github` folder
 - the `docs` folder
 
-For example, anyone who creates an issue or pull request in a public repository that does not have its own CONTRIBUTING file will see a link to the default CONTRIBUTING file. If a repository has any files in its own `.github/ISSUE_TEMPLATE` folder{% if currentVersion == "free-pro-team@latest" or currentVersion == "github-ae@latest" or currentVersion ver_gt "enterprise-server@2.19" %}, including issue templates or a *config.yml* file,{% endif %} none of the contents of the default `.github/ISSUE_TEMPLATE` folder will be used.
+For example, anyone who creates an issue or pull request in a repository that does not have its own CONTRIBUTING file will see a link to the default CONTRIBUTING file. If a repository has any files in its own `.github/ISSUE_TEMPLATE` folder{% if currentVersion == "free-pro-team@latest" or currentVersion == "github-ae@latest" or currentVersion ver_gt "enterprise-server@2.19" %}, including issue templates or a *config.yml* file,{% endif %} none of the contents of the default `.github/ISSUE_TEMPLATE` folder will be used.
 
 Default files are not included in clones, packages, or downloads of individual repositories because they are stored only in the `.github` repository.
 


### PR DESCRIPTION
### Why:

Closes https://github.com/github/communities/issues/429

### What's being changed:

It looks like there was some historical ambiguity about whether private repos should inherit the `org/.github` repo's community health files (Code of Conduct, Issue templates, etc.) Thanks to @smashwilson's investigation, we now know that the actual behavior is that private repos **do** inherit. This PR updates the docs to reflect that.

We explored making the feature consistent with the docs because it was generating confusion, but we don't have a strong product reason at the moment for enforcing that the community files are only inherited by public repositories. So we're conforming the docs to the behavior!

### Check off the following:

- [x] I have reviewed my changes in staging (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
