### PR TITLE
Fix POST->GET for listing GitHub App installations

### DIFF
--- a/content/developers/apps/building-github-apps/authenticating-with-github-apps.md
+++ b/content/developers/apps/building-github-apps/authenticating-with-github-apps.md
@@ -134,14 +134,14 @@ To list the installations for an authenticated app, include the JWT [generated a
 
 {% if currentVersion ver_lt "enterprise-server@2.22" %}
 ```shell
-$ curl -i -X POST \
+$ curl -i -X GET \
 -H "Authorization: Bearer YOUR_JWT" \
 -H "Accept: application/vnd.github.machine-man-preview+json" \
 {% data variables.product.api_url_pre %}/app/installations
 ```
 {% else %}
 ```shell
-$ curl -i -X POST \
+$ curl -i -X GET \
 -H "Authorization: Bearer YOUR_JWT" \
 -H "Accept: application/vnd.github.v3+json" \
 {% data variables.product.api_url_pre %}/app/installations


### PR DESCRIPTION
### Why:

Closes https://github.com/github/docs/issues/6919

### What's being changed:

An API call for listing GitHub App installations erroneously documented it as a `POST` request, where is should be a `GET` request. There is no ability to use `POST` on that endpoint

Stage link: https://docs-7206--auth-gh-apps-post-t.herokuapp.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-an-installation

### Check off the following:

- [x] I have reviewed my changes in staging (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

