### PR TITLE
Add info about API intros

### DIFF
--- a/contributing/content-model.md
+++ b/contributing/content-model.md
@@ -355,6 +355,8 @@ The top of every page has an intro that provides context and sets expectations, 
 #### How to write an intro
 - Article intros are one to two sentences long.
 - Map topic and category intros are one sentence long.
+- API reference intros are one sentence long.
+  - The intro for an API page should define the feature so that a user knows whether the feature meets their needs without reading the entire article.
 - Intros contain a high-level summary of the page’s content, developing the idea presented in a title with more detail. 
   - Use approachable synonyms of words in the page’s title to help readers understand the article’s purpose differently. Avoid repeating words from the title when possible. 
 - Intros are relatively evergreen and high-level, so they can scale with future changes to the content on the page without needing to be frequently updated.


### PR DESCRIPTION
### Why:

This PR adds two lines about writing intros for API pages since they are a bit different from how we outline intros for other articles.

Slightly related issue: https://github.com/github/docs-content/issues/4445

### What's being changed:

Adds two bullet points to the "[How to write an intro](https://github.com/github/docs/blob/main/contributing/content-model.md#how-to-write-an-intro)" section of the content model.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
This PR adds a bit more direction to the writer experience, but I do not think it has writer impact that warrants the `writer impact` label. 