### PR TITLE
Update removing-sensitive-data-from-a-repository.md

### DIFF
--- a/content/github/authenticating-to-github/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository.md
+++ b/content/github/authenticating-to-github/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository.md
@@ -155,5 +155,5 @@ There are a few simple tricks to avoid committing things you don't want committe
 
 ## Further reading
 
-- [`git filter-branch` man page](https://git-scm.com/docs/git-filter-branch)
+- [`git filter-branch` main page](https://git-scm.com/docs/git-filter-branch)
 - [Pro Git: Git Tools - Rewriting History](https://git-scm.com/book/en/Git-Tools-Rewriting-History)


### PR DESCRIPTION
### What's being changed:

We were working with your remove sensitive data docs and found a typo in the Further Reading section. Changed `man` to `main`.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [X] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
