### PR TITLE
Not all Dependabot languages support private repos

### DIFF
--- a/content/organizations/keeping-your-organization-secure/managing-security-and-analysis-settings-for-your-organization.md
+++ b/content/organizations/keeping-your-organization-secure/managing-security-and-analysis-settings-for-your-organization.md
@@ -114,6 +114,8 @@ By default, {% data variables.product.prodname_dependabot %} can't update depend
 
 If your code depends on packages in a private registry, you can allow {% data variables.product.prodname_dependabot %} to update the versions of these dependencies by configuring this at the repository level. You do this by adding authentication details to the _dependabot.yml_ file for the repository. For more information, see "[Configuration options for dependency updates](/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-private-registries)."
 
+Not all languages supported by {% data variables.product.prodname_dependabot %} support private dependencies. [Please check the list here.]( https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem)
+
 To allow {% data variables.product.prodname_dependabot %} to access a private {% data variables.product.prodname_dotcom %} repository:
 
 1. Go to the security and analysis settings for your organization. For more information, see "[Displaying the security and analysis settings](#displaying-the-security-and-analysis-settings)."


### PR DESCRIPTION
Ran into this (a quite frustrating one, given that Ruby isn't supported, which is what GitHub is built in.)

Didn't follow the review guidelines, sorry.
