### PR TITLE
Reword "name" and "about" issue template frontmatter (#7570)

### DIFF
--- a/.github/ISSUE_TEMPLATE/improve-existing-docs.md
+++ b/.github/ISSUE_TEMPLATE/improve-existing-docs.md
@@ -1,6 +1,6 @@
 ---
-name: Improve existing docs
-about: Make a suggestion to improve our existing documentation.
+name: Improve existing content
+about: Make a suggestion to improve the content in an existing article.
 title: ''
 labels:
 - content

--- a/.github/ISSUE_TEMPLATE/improve-the-site.md
+++ b/.github/ISSUE_TEMPLATE/improve-the-site.md
@@ -1,6 +1,6 @@
 ---
 name: Improve the docs.github.com site
-about: Make a suggestion to improve the technical implementation of docs.github.com.
+about: Make a suggestion or report a problem about the technical implementation of docs.github.com.
 title: ''
 labels: engineering
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/improve-the-site.md
+++ b/.github/ISSUE_TEMPLATE/improve-the-site.md
@@ -1,6 +1,6 @@
 ---
 name: Improve the docs.github.com site
-about: Make a suggestions or report a problem on the docs.github.com website.
+about: Make a suggestion to improve the technical implementation of docs.github.com.
 title: ''
 labels: engineering
 assignees: ''


### PR DESCRIPTION
### Why:

Closes #7570

### What's being changed:

Change `name` and `about` keys of the "content" and "engineering" issue templates to clarify the difference between the two.