### PR TITLE
Add info on protecting the branch

### DIFF
--- a/content/github/administering-a-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository.md
+++ b/content/github/administering-a-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository.md
@@ -25,3 +25,5 @@ If you allow auto-merge for pull requests in your repository, people with write 
 {% data reusables.repositories.sidebar-settings %}
 1. Under "Merge button", select or deselect **Allow auto-merge**.
   ![Checkbox to allow or disallow auto-merge](/assets/images/help/pull_requests/allow-auto-merge-checkbox.png)
+
+1. Under "Branches", enable at least the following branch protection rules: "Require pull request reviews before merging" and "Require status checks to pass before merging".

--- a/content/github/administering-a-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository.md
+++ b/content/github/administering-a-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository.md
@@ -26,4 +26,4 @@ If you allow auto-merge for pull requests in your repository, people with write 
 1. Under "Merge button", select or deselect **Allow auto-merge**.
   ![Checkbox to allow or disallow auto-merge](/assets/images/help/pull_requests/allow-auto-merge-checkbox.png)
 
-1. Under "Branches", enable at least the following branch protection rules: "Require pull request reviews before merging" and "Require status checks to pass before merging".
+1. Under "Branches", enable at least the branch protection rule: "Require status checks to pass before merging" and specify which status checks are required.


### PR DESCRIPTION
### Why:

I've tried to use auto-merge, but the button did not appear even though I was running CI jobs on my PR and enabled "Allow auto-merge". Also, I protected the branch by setting "Require status checks to pass before merging". However, only after **also** setting "Require pull request reviews before merging", the button appeared!

### What's being changed:

Update documentation.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).
