### PR TITLE
added upper-case-solution

### DIFF
--- a/data/reusables/pages/create-repo-name.md
+++ b/data/reusables/pages/create-repo-name.md
@@ -1,3 +1,3 @@
-1. Type a name for your repository and an optional description. If you're creating a user or organization site, your repository must be named `<user>.github.io` or `<organization>.github.io`. If `<user>` or `<organization>` contain uppercase letters, you need to lowercase them.
+1. Type a name for your repository and an optional description. If you're creating a user or organization site, your repository must be named `<user>.github.io` or `<organization>.github.io`. If `<user>` or `<organization>` contains uppercase letters, you need to lowercase them.
 For more information, see "[About {% data variables.product.prodname_pages %}](/articles/about-github-pages#types-of-github-pages-sites)."
    ![Create repository field](/assets/images/help/pages/create-repository-name-pages.png)

--- a/data/reusables/pages/create-repo-name.md
+++ b/data/reusables/pages/create-repo-name.md
@@ -1,2 +1,3 @@
-1. Type a name for your repository and an optional description. If you're creating a user or organization site, your repository must be named `<user>.github.io` or `<organization>.github.io`. For more information, see "[About {% data variables.product.prodname_pages %}](/articles/about-github-pages#types-of-github-pages-sites)."
+1. Type a name for your repository and an optional description. If you're creating a user or organization site, your repository must be named `<user>.github.io` or `<organization>.github.io`. If `<user>` or `<organization>` contain uppercase letters, you need to lowercase them.
+For more information, see "[About {% data variables.product.prodname_pages %}](/articles/about-github-pages#types-of-github-pages-sites)."
    ![Create repository field](/assets/images/help/pages/create-repository-name-pages.png)

--- a/data/reusables/pages/create-repo-name.md
+++ b/data/reusables/pages/create-repo-name.md
@@ -1,3 +1,3 @@
-1. Type a name for your repository and an optional description. If you're creating a user or organization site, your repository must be named `<user>.github.io` or `<organization>.github.io`. If `<user>` or `<organization>` contains uppercase letters, you need to lowercase them.
+1. Type a name for your repository and an optional description. If you're creating a user or organization site, your repository must be named `<user>.github.io` or `<organization>.github.io`. If your user or organization name contains uppercase letters, you must lowercase the letters.
 For more information, see "[About {% data variables.product.prodname_pages %}](/articles/about-github-pages#types-of-github-pages-sites)."
    ![Create repository field](/assets/images/help/pages/create-repository-name-pages.png)


### PR DESCRIPTION
### Why:

Closes #8269 

### What's being changed:

Just a small additional text that informs users, that they need to select the lowercase variant of `user` or `organization` when creating the repo.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).
