### PR TITLE
Update configuring-user-provisioning-for-your-enterprise.md to include SCIM URL

### DIFF
--- a/content/admin/authentication/managing-identity-and-access-for-your-enterprise/configuring-user-provisioning-for-your-enterprise.md
+++ b/content/admin/authentication/managing-identity-and-access-for-your-enterprise/configuring-user-provisioning-for-your-enterprise.md
@@ -84,7 +84,7 @@ You must have administrative access on your IdP to configure the application for
 
   | Value | Other names | Description | Example |
   | :- | :- | :- | :- |
-  | URL | Tenant URL | URL to the SCIM provisioning API for your enterprise on {% data variables.product.prodname_ghe_managed %} | <nobr><code>{% data variables.product.api_url_pre %}</nobr></code> |
+  | URL | Tenant URL | URL to the SCIM provisioning API for your enterprise on {% data variables.product.prodname_ghe_managed %} | <nobr><code>{% data variables.product.api_url_pre %}/scim/v2</nobr></code> |
   | Shared secret | Personal access token, secret token | Token for application on your IdP to perform provisioning tasks on behalf of an enterprise owner | Personal access token you created in step 1 |
 
 {% endif %}


### PR DESCRIPTION
### Why:

Fixes the tenant URL to enable SCIM provisioning. Currently, it does not contain `/scim/v2` that prevents the customers from setting up SCIM provisioning successfully. 

https://github.com/github/docs-content/issues/4693

### What's being changed:

Tenant URL example for SCIM provisioning. 

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
