### PR TITLE
Link to GitHub webhook event types

### DIFF
--- a/content/actions/reference/context-and-expression-syntax-for-github-actions.md
+++ b/content/actions/reference/context-and-expression-syntax-for-github-actions.md
@@ -98,7 +98,7 @@ The `github` context contains information about the workflow run and the event t
 | `github.action_path` | `string` | The path where your action is located. You can use this path to easily access files located in the same repository as your action. This attribute is only supported in composite run steps actions. |
 | `github.actor` | `string` | The login of the user that initiated the workflow run. |
 | `github.base_ref` | `string` | The `base_ref` or target branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either `pull_request` or `pull_request_target`. |
-| `github.event` | `object` | The full event webhook payload. For more information, see "[Events that trigger workflows](/articles/events-that-trigger-workflows/)." You can access individual properties of the event using this context. |
+| `github.event` | `object` | The full [event webhook payload](/developers/webhooks-and-events/events/github-event-types). For more information, see "[Events that trigger workflows](/articles/events-that-trigger-workflows/)." You can access individual properties of the event using this context. |
 | `github.event_name` | `string` | The name of the event that triggered the workflow run. |
 | `github.event_path` | `string` | The path to the full event webhook payload on the runner. |
 | `github.head_ref` | `string` | The `head_ref` or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either `pull_request` or `pull_request_target`. |


### PR DESCRIPTION
### Why:

Closes #8295

### What's being changed:

The GitHub Actions reference documentation for the `github` context's `event` field now benefits from a direct link to the documentation describing the different GitHub webhook event types. No longer must one wonder how to figure out which fields are supported.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
