### PR TITLE
Update getting-started-with-the-rest-api.md

### DIFF
--- a/content/rest/guides/getting-started-with-the-rest-api.md
+++ b/content/rest/guides/getting-started-with-the-rest-api.md
@@ -36,7 +36,7 @@ following command:
 ```shell
 $ curl https://api.github.com/zen
 
-> Keep it logically awesome.
+> Mind your words, they are important.
 ```
 
 The response will be a random selection from our design philosophies.


### PR DESCRIPTION
The correct response for `curl https://api.github.com/zen`.
