### PR TITLE
Flatten prerequisites for RubyGems registry

### DIFF
--- a/content/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry.md
@@ -28,13 +28,15 @@ shortTitle: RubyGems registry
   $ gem --version
   ```
 
-  - You must have bundler 1.6.4 or higher. To find your Bundler version:
+- You must have bundler 1.6.4 or higher. To find your Bundler version:
+
   ```shell
   $ bundle --version
   Bundler version 1.13.7
   ```
 
-  - Install keycutter to manage multiple credentials. To install keycutter:
+- Install keycutter to manage multiple credentials. To install keycutter:
+
   ```shell
   $ gem install keycutter
   ```


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

### Why:

Closes #8499

### What's being changed:

| before | after |
|-|-|
| ![docs github com_en_packages_working-with-a-github-packages-registry_working-with-the-rubygems-registry](https://user-images.githubusercontent.com/10229505/126852331-3b16d1e6-f195-47da-9c2b-c7453b01739c.png) | ![github com_tnir_docs_blob_tnir_rubygems-registry_content_packages_working-with-a-github-packages-registry_working-with-the-rubygems-registry md](https://user-images.githubusercontent.com/10229505/126852435-bd366ddd-975d-4fdf-8194-1970a7f4c65d.png) |

Staging: https://docs-8500--tnirrubygems-regist.herokuapp.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [n/a] This pull request impacts the contribution experience
  - [n/a] I have added the 'writer impact' label
  - [n/a] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")
