### PR TITLE
Updated the DevContainer

### DIFF
--- a/content/codespaces/customizing-your-codespace/configuring-codespaces-for-your-project.md
+++ b/content/codespaces/customizing-your-codespace/configuring-codespaces-for-your-project.md
@@ -56,9 +56,7 @@ Reference your Dockerfile in your `devcontainer.json` file by using the `dockerf
 
 ```json
 {
-  ...
   "build": { "dockerfile": "Dockerfile" },
-  ...
 }
 ```
 


### PR DESCRIPTION
Removed the "..." from the example DevContainer.json example file, as this will cause a build error (to the unknowning end-user).

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Closes [issue link]

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- NOTE: Changes to this file should also be applied to './test-windows.yml'

name: Node.js Tests

# **What it does**: Runs our tests.
# **Why we have it**: We want our tests to pass before merging code.
# **Who does it impact**: Docs engineering, open-source engineering contributors.

on:
  workflow_dispatch:
  push:
    branches:
      - main
  pull_request:

env:
  CI: true

jobs:
  test:
    # Run on self-hosted if the private repo or ubuntu-latest if the public repo
    # See pull # 17442 in the private repo for context
    runs-on: ${{ fromJson('["ubuntu-latest", "self-hosted"]')[github.repository == 'github/docs-internal'] }}
    timeout-minutes: 60
    strategy:
      fail-fast: false
      matrix:
        # The same array lives in test-windows.yml, so make any updates there too.
        test-group: [content, graphql, meta, rendering, routing, unit, linting]
    steps:
      # Each of these ifs needs to be repeated at each step to make sure the required check still runs
      # Even if if doesn't do anything
      - name: Check out repo
        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
        with:
          # Enables cloning the Early Access repo later with the relevant PAT
          persist-credentials: 'false'

      - name: Setup node
        uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f
        with:
          node-version: 16.x
          cache: npm

      - name: Install dependencies
        run: npm ci

      - if: ${{ github.repository == 'github/docs-internal' }}
        name: Clone early access
        run: npm run heroku-postbuild
        env:
          DOCUBOT_REPO_PAT: ${{ secrets.DOCUBOT_REPO_PAT }}
          GIT_BRANCH: ${{ github.head_ref || github.ref }}

      - if: ${{ github.repository != 'github/docs-internal' }}
        name: Run build script
        run: npm run build

      - name: Run tests
        run: npx jest tests/${{ matrix.test-group }}/
        env:
          NODE_OPTIONS
