### PR TITLE
doc: Added distinction for profile README support

### DIFF
--- a/content/github/setting-up-and-managing-your-github-profile/customizing-your-profile/managing-your-profile-readme.md
+++ b/content/github/setting-up-and-managing-your-github-profile/customizing-your-profile/managing-your-profile-readme.md
@@ -70,6 +70,8 @@ The profile README is removed from your {% data variables.product.prodname_dotco
 
 The method you choose depends upon your needs, but if you're unsure, we recommend making your repository private. For steps on how to make your repository private, see ["Changing a repository's visibility."](/github/administering-a-repository/setting-repository-visibility#changing-a-repositorys-visibility)
 
+The profile README doesn't support Github Organizations as of now, and only works only for personal profiles.
+
 ## Further reading
 
 - [About READMEs](/github/creating-cloning-and-archiving-repositories/about-readmes)


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

The profile README feature is supported only for personal profiles as of now. Added a distinction for that

### What's being changed

Added
```
The profile README doesn't support Github Organizations as of now, and only works only for personal profiles.
```

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).
