### PR TITLE
Use COPY instead of ADD

### DIFF
--- a/Dockerfile.openapi_decorator
+++ b/Dockerfile.openapi_decorator
@@ -10,9 +10,9 @@ USER node
 
 COPY --chown=node:node package.json /openapi-check
 COPY --chown=node:node package-lock.json /openapi-check
-ADD --chown=node:node script /openapi-check/script
-ADD --chown=node:node lib /openapi-check/lib
-ADD --chown=node:node content /openapi-check/content
+COPY --chown=node:node script /openapi-check/script
+COPY --chown=node:node lib /openapi-check/lib
+COPY --chown=node:node content /openapi-check/content
 
 RUN npm ci -D
 


### PR DESCRIPTION
### What's being changed:

Small change in Dockerfile syntax, will make it use `COPY` instead of using `ADD` as long as we are dealing with local files.