### PR TITLE
A helpful link redirecting to copilot.github.com

### DIFF
--- a/content/github/copilot/index.md
+++ b/content/github/copilot/index.md
@@ -1,6 +1,6 @@
 ---
 title: GitHub Copilot
-intro: 'You can use {% data variables.product.prodname_dotcom %} Copilot to assist with your programming in Visual Studio Code.'
+intro: 'You can use {% data variables.product.prodname_dotcom %} Copilot to assist with your programming in Visual Studio Code.[Learn More](https://copilot.github.com)'
 versions:
   fpt: '*'
 children:


### PR DESCRIPTION
**About this- #8928**
Page which was updated- https://docs.github.com/en/github/copilot
### Why:
Page was Unhelpful to most people
Closes [issue link]

### What's being changed:
Added a link

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
