### PR TITLE
Adding note for Dependency Graph in Insights

### DIFF
--- a/content/organizations/collaborating-with-groups-in-organizations/viewing-insights-for-your-organization.md
+++ b/content/organizations/collaborating-with-groups-in-organizations/viewing-insights-for-your-organization.md
@@ -37,6 +37,13 @@ With organization activity insights you can view weekly, monthly, and yearly dat
   ![Choose repositories to view org insights](/assets/images/help/organizations/org-insights-repos.png)
 
 ## Viewing organization dependency insights
+
+{% note %}
+
+**Note:** Please make sure you have enabled the [Dependency Graph](/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#enabling-the-dependency-graph). 
+
+{% endnote %}
+
 With dependency insights you can view vulnerabilities, licenses, and other important information for the open source projects your organization depends on.
 
 {% data reusables.profile.access_org %}


### PR DESCRIPTION
### Why:

Improving the documentation for Dependency Insights.

### What's being changed:

This commit adds a small note reminding the user to enable Dependency Graph before they test Dependency Insights.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
