### PR TITLE
Use curly brackets to delimit a choice of literals

### DIFF
--- a/content/actions/reference/workflow-syntax-for-github-actions.md
+++ b/content/actions/reference/workflow-syntax-for-github-actions.md
@@ -47,7 +47,7 @@ on:
     types: [published, created, edited]
 ```
 
-## `on.<push|pull_request>.<branches|tags>`
+## `on.{push|pull_request}.{branches|tags}`
 
 When using the `push` and `pull_request` events, you can configure a workflow to run on specific branches or tags. For a `pull_request` event, only branches and tags on the base are evaluated. If you define only `tags` or only `branches`, the workflow won't run for events affecting the undefined Git ref.
 
@@ -114,7 +114,7 @@ on:
       - '!releases/**-alpha'
 ```
 
-## `on.<push|pull_request>.paths`
+## `on.{push|pull_request}.paths`
 
 When using the `push` and `pull_request` events, you can configure a workflow to run when at least one file does not match `paths-ignore` or at least one modified file matches the configured `paths`. Path filters are not evaluated for pushes to tags.
 
@@ -1355,7 +1355,7 @@ The characters `*`, `[`, and `!` are special characters in YAML. If you start a 
 - **/README.md
 ```
 
-For more information about branch, tag, and path filter syntax, see "[`on.<push|pull_request>.<branches|tags>`](#onpushpull_requestbranchestags)" and "[`on.<push|pull_request>.paths`](#onpushpull_requestpaths)."
+For more information about branch, tag, and path filter syntax, see "[`on.{push|pull_request}.{branches|tags}`](#onpushpull_requestbranchestags)" and "[`on.{push|pull_request}.paths`](#onpushpull_requestpaths)."
 
 ### Patterns to match branches and tags
 


### PR DESCRIPTION
Use curly brackets to delimit a choice of literals in workflow syntax docs. `<job_id>` and `<event_type>` are placeholders; `on`, `push` and `pull_request` are literals.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Closes [issue link]

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
