### PR TITLE
Fix typo in tax docs: Inland -> Internal

### DIFF
--- a/content/sponsors/receiving-sponsorships-through-github-sponsors/tax-information-for-github-sponsors.md
+++ b/content/sponsors/receiving-sponsorships-through-github-sponsors/tax-information-for-github-sponsors.md
@@ -15,7 +15,7 @@ shortTitle: Tax information
 
 ## W-9/W-8 tax forms
 
-By law, {% data variables.product.prodname_dotcom %} is required by the U.S. Inland Revenue Service (IRS) to collect tax information from all U.S. and non-U.S. maintainers. These forms are held by {% data variables.product.prodname_dotcom %} and are not required to be submitted to the IRS. 
+By law, {% data variables.product.prodname_dotcom %} is required by the U.S. Internal Revenue Service (IRS) to collect tax information from all U.S. and non-U.S. maintainers. These forms are held by {% data variables.product.prodname_dotcom %} and are not required to be submitted to the IRS. 
 
 ### W-9 (U.S.)
 


### PR DESCRIPTION
### Why:

Fixes a typo in tax docs.

### What's being changed:

The IRS name is corrected: Inland -> Internal.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")