### PR TITLE
Fixes things which break the link checker actions for AE and GHES

### DIFF
--- a/content/get-started/using-github/keyboard-shortcuts.md
+++ b/content/get-started/using-github/keyboard-shortcuts.md
@@ -42,8 +42,10 @@ Below is a list of some of the available keyboard shortcuts.
 ## Source code editing
 
 | Keyboard shortcut | Description
-|-----------|------------
+|-----------|------------|
+{% ifversion fpt %}
 |<kbd>.</kbd>| Opens a repository or pull request in the web-based editor. For more information, see [Web-based editor](/codespaces/developing-in-codespaces/web-based-editor).
+{% endif %}
 | <kbd>control b</kbd> or <kbd>command b</kbd> | Inserts Markdown formatting for bolding text
 | <kbd>control i</kbd> or <kbd>command i</kbd> | Inserts Markdown formatting for italicizing text
 | <kbd>control k</kbd> or <kbd>command k</kbd> | Inserts Markdown formatting for creating a link

--- a/content/get-started/using-github/keyboard-shortcuts.md
+++ b/content/get-started/using-github/keyboard-shortcuts.md
@@ -43,9 +43,6 @@ Below is a list of some of the available keyboard shortcuts.
 
 | Keyboard shortcut | Description
 |-----------|------------|
-{% ifversion fpt %}
-|<kbd>.</kbd>| Opens a repository or pull request in the web-based editor. For more information, see [Web-based editor](/codespaces/developing-in-codespaces/web-based-editor).
-{% endif %}
 | <kbd>control b</kbd> or <kbd>command b</kbd> | Inserts Markdown formatting for bolding text
 | <kbd>control i</kbd> or <kbd>command i</kbd> | Inserts Markdown formatting for italicizing text
 | <kbd>control k</kbd> or <kbd>command k</kbd> | Inserts Markdown formatting for creating a link
@@ -59,7 +56,8 @@ Below is a list of some of the available keyboard shortcuts.
 |<kbd>control z</kbd> or <kbd>command z</kbd> | Undo
 |<kbd>control y</kbd> or <kbd>command y</kbd> | Redo
 |<kbd>cmd + shift + p</kbd> | Toggles between the **Edit file** and **Preview changes** tabs
-|<kbd>control s</kbd> or <kbd>command s</kbd> | Write a commit message
+|<kbd>control s</kbd> or <kbd>command s</kbd> | Write a commit message {% ifversion fpt %}
+|<kbd>.</kbd>| Opens a repository or pull request in the web-based editor. For more information, see [Web-based editor](/codespaces/developing-in-codespaces/web-based-editor).{% endif %}
 
 For more keyboard shortcuts, see the [CodeMirror documentation](https://codemirror.net/doc/manual.html#commands).
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Yesterday, #9215 got merged in and it broke the Link Checker Actions for GitHub AE & Enterprise Server because it doesn't have a conditional to check the version of the article. Maybe even @ramyaparimi & @timeyoutakeit didn't notice that.

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

This adds a ifversion conditional to check for fpt (Free, Pro & Team Hosted on GitHub versions) which have Codespaces while others don't.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [X] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).


<!-- Not a Hubber
### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video") -->

<!-- Description of the writer impact here -->
