### PR TITLE
Adding note that teams need repository access

### DIFF
--- a/content/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review.md
+++ b/content/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review.md
@@ -19,7 +19,7 @@ Owners or collaborators can assign a pull request review to any person that has 
 
 {% note %}
 
-**Note:** Pull request authors can't request reviews unless they are either a repository owner or collaborator with write access to the repository.
+**Note:** Pull request authors can't request reviews unless they are either a repository owner or collaborator with write access to the repository.  This applies to teams as well. [Managing team access to an organization repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/managing-team-access-to-an-organization-repository)
 
 {% endnote %}
 


### PR DESCRIPTION

### Why:
It's not so obvious why a team does not show up in the possible list of reviewers.  Updating this note to also address teams, along with a link to how to fix it would have helped me

Closes N/A

### What's being changed:

NOTE regarding PR reviewers was extended to include teams as well as individual authors

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
