### PR TITLE
Update docs on project boards

### DIFF
--- a/content/issues/organizing-your-work-with-project-boards/managing-project-boards/changing-project-board-visibility.md
+++ b/content/issues/organizing-your-work-with-project-boards/managing-project-boards/changing-project-board-visibility.md
@@ -23,6 +23,12 @@ shortTitle: Change visibility
 
 {% endtip %}
 
+{% tip %}
+
+**Tip:** Repository based project boards cannot change visibility and they are public by default. For private repo project boards see "[Linking a repository to a project board](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/managing-project-boards/linking-a-repository-to-a-project-board)."
+
+{% endtip %}
+
 1. Navigate to the project board you want to make {% ifversion ghae %}internal{% else %}public{% endif %} or private.
 {% data reusables.project-management.click-menu %}
 {% data reusables.project-management.access-collaboration-settings %}


### PR DESCRIPTION
The current docs on project boards are assuming that you are using user or organization project boards and not repository project boards.
Clarify that repository based boards cannot change visibility unlike user project boards and organization project boards.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Closes [9523](https://github.com/github/docs/issues/9523)

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

Notifying the reader that repository based project boards cannot change visibility and have to be linked to user/organization project boards in order to be private.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
