### PR TITLE
Add note about the git-filter-repo package

### DIFF
--- a/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
+++ b/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
@@ -37,6 +37,17 @@ If you create a new clone of the repository, you won't lose any of your Git hist
       {% endtip %}
 
     {% endwindows %}
+    
+    
+    {% linux %}
+
+      {% tip %}
+
+      **Tip:** Linux users may need to install the `git-filter-repo` package
+
+      {% endtip %}
+
+    {% endlinux %}
   
     ```shell
     $ git filter-repo --path FOLDER-NAME1/ FOLDER-NAME2/


### PR DESCRIPTION
Linux distros which have git ( e.g. ubuntu ) don't have git-filter-repo command installed by default.

### Why:

The commands as described don't work without the tip added in this pr

### What's being changed:

Documentation

### Check off the following:

- [ x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
