### PR TITLE
Update SSH key capitalization

### DIFF
--- a/content/github/authenticating-to-github/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
+++ b/content/github/authenticating-to-github/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
@@ -40,7 +40,7 @@ If you don't want to reenter your passphrase every time you use your SSH key, yo
   ```
 
   {% endnote %}  
-  This creates a new ssh key, using the provided email as a label.
+  This creates a new SSH key, using the provided email as a label.
   ```shell
   > Generating public/private ed25519 key pair.
   ```


### PR DESCRIPTION
### Why: Inconsistent capitalization for "SSH key"

Closes [#9609](https://github.com/github/docs/issues/9609)


### What's being changed:

Changing the line [Generating a new SSH key](https://github.com/github/docs/blob/main/content/github/authenticating-to-github/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md):
`This creates a new ssh key, using the provided email as a label.` to `This creates a new SSH key, using the provided email as a label.`

Specifically changes `ssh key` to `SSH key` to match capitalization in the rest of the documentation.


### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
