### PR TITLE
Dustone25

### DIFF
--- a/content/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry.md
@@ -153,3 +153,136 @@ You can use gems from {% data variables.product.prodname_registry %} much like y
 ## Further reading
 
 - "{% ifversion fpt or ghes > 3.0 %}[Deleting and restoring a package](/packages/learn-github-packages/deleting-and-restoring-a-package){% elsif ghes < 3.1 or ghae %}[Deleting a package](/packages/learn-github-packages/deleting-a-package){% endif %}"
+GitHub Docs
+GitHub Packages/Working with a GitHub Packages registry/RubyGems registry
+Working with the RubyGems registry
+You can configure RubyGems to publish a package to GitHub Packages and to use packages stored on GitHub Packages as dependencies in a Ruby project with Bundler.
+
+GitHub Packages is available with GitHub Free, GitHub Pro, GitHub Free for organizations, GitHub Team, GitHub Enterprise Cloud, GitHub Enterprise Server, and GitHub AE.
+
+
+GitHub Packages is not available for private repositories owned by accounts using legacy per-repository plans. Also, accounts using legacy per-repository plans cannot access the Container registry since these accounts are billed by repository. For more information, see "GitHub's products."
+
+In this article
+Prerequisites
+Authenticating to GitHub Packages
+Publishing a package
+Publishing multiple packages to the same repository
+Installing a package
+Further reading
+Prerequisites
+You must have rubygems 2.4.1 or higher. To find your rubygems version:
+
+$ gem --version
+You must have bundler 1.6.4 or higher. To find your Bundler version:
+
+$ bundle --version
+Bundler version 1.13.7
+Install keycutter to manage multiple credentials. To install keycutter:
+
+$ gem install keycutter
+Authenticating to GitHub Packages
+You need an access token to publish, install, and delete packages.
+
+You can use a personal access token (PAT) to authenticate to GitHub Packages or the GitHub API. When you create a personal access token, you can assign the token different scopes depending on your needs. For more information about packages-related scopes for a PAT, see "About permissions for GitHub Packages."
+
+To authenticate to a GitHub Packages registry within a GitHub Actions workflow, you can use:
+
+GITHUB_TOKEN to publish packages associated with the workflow repository.
+a PAT to install packages associated with other private repositories (which GITHUB_TOKEN can't access).
+For more information about GITHUB_TOKEN used in GitHub Actions workflows, see "Authentication in a workflow."
+
+Authenticating with a personal access token
+You must use a personal access token with the appropriate scopes to publish and install packages in GitHub Packages. For more information, see "About GitHub Packages."
+
+You can authenticate to GitHub Packages with RubyGems by editing the ~/.gem/credentials file for publishing gems, editing the ~/.gemrc file for installing a single gem, or using Bundler for tracking and installing one or more gems.
+
+To publish new gems, you need to authenticate to GitHub Packages with RubyGems by editing your ~/.gem/credentials file to include your personal access token. Create a new ~/.gem/credentials file if this file doesn't exist.
+
+For example, you would create or edit a ~/.gem/credentials to include the following, replacing TOKEN with your personal access token.
+
+---
+:github: Bearer TOKEN
+To install gems, you need to authenticate to GitHub Packages by editing the ~/.gemrc file for your project to include https://USERNAME:TOKEN@rubygems.pkg.github.com/OWNER/. You must replace:
+
+USERNAME with your GitHub username.
+TOKEN with your personal access token.
+OWNER with the name of the user or organization account that owns the repository containing your project.
+If you don't have a ~/.gemrc file, create a new ~/.gemrc file using this example.
+
+---
+:backtrace: false
+:bulk_threshold: 1000
+:sources:
+- https://rubygems.org/
+- https://USERNAME:TOKEN@rubygems.pkg.github.com/OWNER/
+:update_sources: true
+:verbose: true  
+To authenticate with Bundler, configure Bundler to use your personal access token, replacing USERNAME with your GitHub username, TOKEN with your personal access token, and OWNER with the name of the user or organization account that owns the repository containing your project.
+
+$ bundle config https://rubygems.pkg.github.com/OWNER USERNAME:TOKEN
+Publishing a package
+By default, GitHub publishes the package to an existing repository with the same name as the package. For example, when you publish octo-gem to the octo-org organization, GitHub Packages publishes the gem to the octo-org/octo-gem repository. For more information on creating your gem, see "Make your own gem" in the RubyGems documentation.
+
+After you publish a package, you can view the package on GitHub. For more information, see "Viewing packages."
+
+Authenticate to GitHub Packages. For more information, see "Authenticating to GitHub Packages."
+
+Build the package from the gemspec to create the .gem package.
+
+gem build OCTO-GEM.gemspec
+Publish a package to GitHub Packages, replacing OWNER with the name of the user or organization account that owns the repository containing your project and OCTO-GEM with the name of your gem package.
+
+$ gem push --key github \
+--host https://rubygems.pkg.github.com/OWNER \
+OCTO-GEM-0.0.1.gem
+Publishing multiple packages to the same repository
+To publish multiple gems to the same repository, you can include the URL to the GitHub repository in the github_repo field in gem.metadata. If you include this field, GitHub matches the repository based on this value, instead of using the gem name.
+
+gem.metadata = { "github_repo" => "ssh://github.com/OWNER/REPOSITORY" }
+Installing a package
+You can use gems from GitHub Packages much like you use gems from rubygems.org. You need to authenticate to GitHub Packages by adding your GitHub user or organization as a source in the ~/.gemrc file or by using Bundler and editing your Gemfile.
+
+Authenticate to GitHub Packages. For more information, see "Authenticating to GitHub Packages."
+
+For Bundler, add your GitHub user or organization as a source in your Gemfile to fetch gems from this new source. For example, you can add a new source block to your Gemfile that uses GitHub Packages only for the packages you specify, replacing GEM NAME with the package you want to install from GitHub Packages and OWNER with the user or organization that owns the repository containing the gem you want to install.
+
+source "https://rubygems.org"
+
+gem "rails"
+
+source "https://rubygems.pkg.github.com/OWNER" do
+  gem "GEM NAME"
+end
+For Bundler versions earlier than 1.7.0, you need to add a new global source. For more information on using Bundler, see the bundler.io documentation.
+
+source "https://rubygems.pkg.github.com/OWNER"
+source "https://rubygems.org"
+
+gem "rails"
+gem "GEM NAME"
+Install the package:
+
+$ gem install octo-gem --version "0.1.1"
+Further reading
+"Deleting and restoring a package"
+Did this doc help you?Privacy policy
+
+Help us make these docs great!
+All GitHub docs are open source. See something that's wrong or unclear? Submit a pull request.
+
+Or, learn how to contribute.
+
+Still need help?
+© 2021 GitHub, Inc.
+Terms
+Privacy
+Security
+Status
+Help
+Contact GitHub
+Pricing
+Developer API
+Training
+About
+


### PR DESCRIPTION
GitHub Docs
GitHub Packages/Working with a GitHub Packages registry/RubyGems registry
Working with the RubyGems registry
You can configure RubyGems to publish a package to GitHub Packages and to use packages stored on GitHub Packages as dependencies in a Ruby project with Bundler.

GitHub Packages is available with GitHub Free, GitHub Pro, GitHub Free for organizations, GitHub Team, GitHub Enterprise Cloud, GitHub Enterprise Server, and GitHub AE.


GitHub Packages is not available for private repositories owned by accounts using legacy per-repository plans. Also, accounts using legacy per-repository plans cannot access the Container registry since these accounts are billed by repository. For more information, see "GitHub's products."

In this article
Prerequisites
Authenticating to GitHub Packages
Publishing a package
Publishing multiple packages to the same repository
Installing a package
Further reading
Prerequisites
You must have rubygems 2.4.1 or higher. To find your rubygems version:

$ gem --version
You must have bundler 1.6.4 or higher. To find your Bundler version:

$ bundle --version
Bundler version 1.13.7
Install keycutter to manage multiple credentials. To install keycutter:

$ gem install keycutter
Authenticating to GitHub Packages
You need an access token to publish, install, and delete packages.

You can use a personal access token (PAT) to authenticate to GitHub Packages or the GitHub API. When you create a personal access token, you can assign the token different scopes depending on your needs. For more information about packages-related scopes for a PAT, see "About permissions for GitHub Packages."

To authenticate to a GitHub Packages registry within a GitHub Actions workflow, you can use:

GITHUB_TOKEN to publish packages associated with the workflow repository.
a PAT to install packages associated with other private repositories (which GITHUB_TOKEN can't access).
For more information about GITHUB_TOKEN used in GitHub Actions workflows, see "Authentication in a workflow."

Authenticating with a personal access token
You must use a personal access token with the appropriate scopes to publish and install packages in GitHub Packages. For more information, see "About GitHub Packages."

You can authenticate to GitHub Packages with RubyGems by editing the ~/.gem/credentials file for publishing gems, editing the ~/.gemrc file for installing a single gem, or using Bundler for tracking and installing one or more gems.

To publish new gems, you need to authenticate to GitHub Packages with RubyGems by editing your ~/.gem/credentials file to include your personal access token. Create a new ~/.gem/credentials file if this file doesn't exist.

For example, you would create or edit a ~/.gem/credentials to include the following, replacing TOKEN with your personal access token.

---
:github: Bearer TOKEN
To install gems, you need to authenticate to GitHub Packages by editing the ~/.gemrc file for your project to include https://USERNAME:TOKEN@rubygems.pkg.github.com/OWNER/. You must replace:

USERNAME with your GitHub username.
TOKEN with your personal access token.
OWNER with the name of the user or organization account that owns the repository containing your project.
If you don't have a ~/.gemrc file, create a new ~/.gemrc file using this example.

---
:backtrace: false
:bulk_threshold: 1000
:sources:
- https://rubygems.org/
- https://USERNAME:TOKEN@rubygems.pkg.github.com/OWNER/
:update_sources: true
:verbose: true  
To authenticate with Bundler, configure Bundler to use your personal access token, replacing USERNAME with your GitHub username, TOKEN with your personal access token, and OWNER with the name of the user or organization account that owns the repository containing your project.

$ bundle config https://rubygems.pkg.github.com/OWNER USERNAME:TOKEN
Publishing a package
By default, GitHub publishes the package to an existing repository with the same name as the package. For example, when you publish octo-gem to the octo-org organization, GitHub Packages publishes the gem to the octo-org/octo-gem repository. For more information on creating your gem, see "Make your own gem" in the RubyGems documentation.

After you publish a package, you can view the package on GitHub. For more information, see "Viewing packages."

Authenticate to GitHub Packages. For more information, see "Authenticating to GitHub Packages."

Build the package from the gemspec to create the .gem package.

gem build OCTO-GEM.gemspec
Publish a package to GitHub Packages, replacing OWNER with the name of the user or organization account that owns the repository containing your project and OCTO-GEM with the name of your gem package.

$ gem push --key github \
--host https://rubygems.pkg.github.com/OWNER \
OCTO-GEM-0.0.1.gem
Publishing multiple packages to the same repository
To publish multiple gems to the same repository, you can include the URL to the GitHub repository in the github_repo field in gem.metadata. If you include this field, GitHub matches the repository based on this value, instead of using the gem name.

gem.metadata = { "github_repo" => "ssh://github.com/OWNER/REPOSITORY" }
Installing a package
You can use gems from GitHub Packages much like you use gems from rubygems.org. You need to authenticate to GitHub Packages by adding your GitHub user or organization as a source in the ~/.gemrc file or by using Bundler and editing your Gemfile.

Authenticate to GitHub Packages. For more information, see "Authenticating to GitHub Packages."

For Bundler, add your GitHub user or organization as a source in your Gemfile to fetch gems from this new source. For example, you can add a new source block to your Gemfile that uses GitHub Packages only for the packages you specify, replacing GEM NAME with the package you want to install from GitHub Packages and OWNER with the user or organization that owns the repository containing the gem you want to install.

source "https://rubygems.org"

gem "rails"

source "https://rubygems.pkg.github.com/OWNER" do
  gem "GEM NAME"
end
For Bundler versions earlier than 1.7.0, you need to add a new global source. For more information on using Bundler, see the bundler.io documentation.

source "https://rubygems.pkg.github.com/OWNER"
source "https://rubygems.org"

gem "rails"
gem "GEM NAME"
Install the package:

$ gem install octo-gem --version "0.1.1"
Further reading
"Deleting and restoring a package"
Did this doc help you?Privacy policy

Help us make these docs great!
All GitHub docs are open source. See something that's wrong or unclear? Submit a pull request.

Or, learn how to contribute.

Still need help?
© 2021 GitHub, Inc.
Terms
Privacy
Security
Status
Help
Contact GitHub
Pricing
Developer API
Training
About

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Closes [issue link]

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
