### PR TITLE
Use Hyperlinks in the personal access token doc – Link 2

### DIFF
--- a/content/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token.md
+++ b/content/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token.md
@@ -37,7 +37,7 @@ A token with no assigned scopes can only access public information. To use your 
 {% data reusables.user_settings.access_settings %}
 {% data reusables.user_settings.developer_settings %}
 {% data reusables.user_settings.personal_access_tokens %}
-4. Click **Generate new token**.
+4. Click **[Generate new token](https://github.com/settings/tokens/new)**.
    ![Generate new token button](/assets/images/help/settings/generate_new_token.png)
 5. Give your token a descriptive name.
    ![Token description field](/assets/images/help/settings/token_description.png){% ifversion fpt or ghes > 3.2 or ghae-issue-4374 %}


### PR DESCRIPTION
Is there a reason, why the docs explain how to get there in word and image … without linking to the docs? #Hypertext

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Because it is easier to click than to follow text and image descriptions. And because of the hyper in HTML.

### What's being changed:

…

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
