### PR TITLE
Add Renovate to communities using discussions

### DIFF
--- a/data/product-examples/discussions/community-examples.yml
+++ b/data/product-examples/discussions/community-examples.yml
@@ -35,3 +35,6 @@
 
 - repo: react-hook-form/react-hook-form
   description: 📋 React Hooks for forms validation (Web + React Native)
+
+- repo: renovatebot/renovate
+  description: Automated dependency updates. Multi-platform and multi-language.


### PR DESCRIPTION
### Why:

Highlight Renovate as a example of a big project that uses discussions to help users/contributors.

Conflict of interest warning: I contribute on a regular basis to Renovate bot, so I'm biased towards including it in this list... 😉 
Just so you know who's making this PR... 😄 

### What's being changed:

- Add entry for Renovate to the list of communities using discussions

The change affects this published page: https://docs.github.com/en/discussions
Scroll down to the "Communities using discussions" section and click "Show more" to see the new entry for Renovate on the preview.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
