### PR TITLE
Add new runner variable `runner.arch`

### DIFF
--- a/content/actions/learn-github-actions/contexts.md
+++ b/content/actions/learn-github-actions/contexts.md
@@ -133,6 +133,7 @@ The `runner` context contains information about the runner that is executing the
 |---------------|------|-------------|
 | `runner.name` | `string` | {% data reusables.actions.runner-name-description %} |
 | `runner.os` | `string` | {% data reusables.actions.runner-os-description %} |
+| `runner.arch` | `string` | {% data reusables.actions.runner-arch-description %} |
 | `runner.temp` | `string` | {% data reusables.actions.runner-temp-directory-description %} |
 | `runner.tool_cache` | `string` | {% ifversion ghae %}For instructions on how to make sure your {% data variables.actions.hosted_runner %} has the required software installed, see "[Creating custom images](/actions/using-github-hosted-runners/creating-custom-images)." {% else %} {% data reusables.actions.runner-tool-cache-description %} {% endif %}|
 

--- a/content/actions/learn-github-actions/environment-variables.md
+++ b/content/actions/learn-github-actions/environment-variables.md
@@ -75,6 +75,7 @@ We strongly recommend that actions use environment variables to access the files
 | `GITHUB_GRAPHQL_URL` | Returns the GraphQL API URL. For example: `{% data variables.product.graphql_url_code %}`.
 | `RUNNER_NAME` | {% data reusables.actions.runner-name-description %}
 | `RUNNER_OS` | {% data reusables.actions.runner-os-description %}
+| `RUNNER_ARCH` | {% data reusables.actions.runner-arch-description %}
 | `RUNNER_TEMP` | {% data reusables.actions.runner-temp-directory-description %}
 {% ifversion not ghae %}| `RUNNER_TOOL_CACHE` | {% data reusables.actions.runner-tool-cache-description %}{% endif %}
 

--- a/data/reusables/actions/runner-arch-description.md
+++ b/data/reusables/actions/runner-arch-description.md
@@ -1,1 +1,1 @@
-The architecture of the runner. Possible values are `X86`, `X64`, `ARM`, and `ARM64`.
+The architecture of the runner executing the job. Possible values are `X86`, `X64`, `ARM`, and `ARM64`.

--- a/data/reusables/actions/runner-arch-description.md
+++ b/data/reusables/actions/runner-arch-description.md
@@ -1,0 +1,1 @@
+The architecture of the runner. Possible values are `X86`, `X64`, `ARM`, and `ARM64`.


### PR DESCRIPTION
### Why:

Adding `runner.arch` variable after https://github.com/actions/runner/issues/1185 is merged.

### What's being changed:

Context:

https://gha-docs-10389--add-runner-arc.herokuapp.com/en/actions/learn-github-actions/contexts#runner-context

Environment variable:

https://gha-docs-10389--add-runner-arc.herokuapp.com/en/actions/learn-github-actions/environment-variables#:~:text=Windows%2C%20or%20macOS.-,RUNNER_ARCH,-The%20architecture%20of

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).
