### PR TITLE
Remove duplicate sections for PR in Forks

### DIFF
--- a/content/actions/learn-github-actions/events-that-trigger-workflows.md
+++ b/content/actions/learn-github-actions/events-that-trigger-workflows.md
@@ -630,8 +630,6 @@ on:
     types: [edited, dismissed]
 ```
 
-{% data reusables.developer-site.pull_request_forked_repos_link %}
-
 ### `pull_request_review_comment`
 
 Runs your workflow anytime a comment on a pull request's unified diff is modified, which triggers the `pull_request_review_comment` event. {% data reusables.developer-site.multiple_activity_types %} For information about the REST API, see [Review comments](/rest/reference/pulls#comments).
@@ -649,8 +647,6 @@ on:
   pull_request_review_comment:
     types: [created, deleted]
 ```
-
-{% data reusables.developer-site.pull_request_forked_repos_link %}
 
 {% ifversion fpt or ghes > 2.22 or ghae or ghec %}
 


### PR DESCRIPTION
The section 'Pull request events for forked repositories' was displayed three times by mistake - this commit removes the two duplicate sections.

### Why:

Removes duplicate sections to correct the documentation.
Resolves #11212 

### What's being changed:

Second and Third occurrence of the redundant text have been removed.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the latest deployment event in your pull request's timeline, then click **View deployment**).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
