### PR TITLE
Clarify when Codespaces only appears in left sidebar

### DIFF
--- a/content/codespaces/managing-codespaces-for-your-organization/enabling-codespaces-for-your-organization.md
+++ b/content/codespaces/managing-codespaces-for-your-organization/enabling-codespaces-for-your-organization.md
@@ -34,6 +34,8 @@ By default, a codespace can only access the repository from which it was created
 {% data reusables.profile.access_org %}
 {% data reusables.profile.org_settings %}
 {% data reusables.organizations.click-codespaces %}
+
+- If Codespaces does not exist in the left sidebar, ensure that that you're on a [GitHub plan](https://github.com/pricing) that supports Codespaces
 1. Under "User permissions", select one of the following options:
 
    * **Allow for all users** to allow all your organization members to use {% data variables.product.prodname_codespaces %}.


### PR DESCRIPTION
Codespaces doesn't appear in the left sidebar unless the organization is on a Team Plan (or Enterprise). This changes makes that explicit. Right now, the user wouldn't know why Codespaces doesn't show up in the left sidebar.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Closes [issue link]

<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

### Check off the following:

- [ ] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/CONTRIBUTING.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
