### PR TITLE
Multi-owner example clarification

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -58,7 +58,8 @@ If any line in your CODEOWNERS file contains invalid syntax, the file will not b
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
+# review when someone opens a pull request. But an approval
+# from either @global-owner1 or @global-owner2 is sufficient.
 *       @global-owner1 @global-owner2
 
 # Order is important; the last matching pattern takes the most


### PR DESCRIPTION
Later in the doc, it is written that
```
# In this example, any change inside the `/apps` directory
# will require approval from @doctocat or @octocat.
/apps/ @doctocat @octocat
```
Making this clear in the first example mentioning multiple owners as well. Otherwise people might think that both owning team's approval is required.

### Why:

To clear some ambiguity.

### What's being changed:

Documentation only, see change.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
