### PR TITLE
Correct workflow badge 'event' example

### DIFF
--- a/content/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge.md
+++ b/content/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge.md
@@ -38,10 +38,10 @@ This Markdown example adds a status badge for a branch with the name `feature-1`
 ![example branch parameter](https://github.com/github/docs/actions/workflows/main.yml/badge.svg?branch=feature-1)
 ```
 
-## Using the `event` parameter
+## Using the `on` parameter
 
 This Markdown example adds a badge that displays the status of workflow runs triggered by the `pull_request` event.
 
 ```markdown
-![example event parameter](https://github.com/github/docs/actions/workflows/main.yml/badge.svg?event=pull_request)
+![example on parameter](https://github.com/github/docs/actions/workflows/main.yml/badge.svg?on=pull_request)
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Closes https://github.com/github/docs/issues/12329

### What's being changed:

As described in issue #123129, Using a URL such as <https://github.com/github/docs/actions/workflows/main.yml/badge.svg?event=pull_request> shows no status, as with this badge: ![test-check-links PR](https://github.com/danielfdickinson/hugo-action-check-links/actions/workflows/test-check-links.yml/badge.svg?event=pull_request).

Changing it to a URL such as <https://github.com/danielfdickinson/hugo-action-check-links/actions/workflows/test-check-links.yml/badge.svg?on=pull_request> shows the status of the event (in this case ``pull_request``) as shown with the following badge: ![test-check-links PR](https://github.com/danielfdickinson/hugo-action-check-links/actions/workflows/test-check-links.yml/badge.svg?on=pull_request).

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
