### PR TITLE
Fix Typo for japanese translation

### DIFF
--- a/translations/ja-JP/data/reusables/actions/learn-more-about-yaml.md
+++ b/translations/ja-JP/data/reusables/actions/learn-more-about-yaml.md
@@ -1,1 +1,1 @@
-YAMLについて詳しくなく、学んでいきたい場合は、「[Learn YAML in five minutes (Y分で学ぶYAML)](https://learnxinyminutes.com/docs/yaml/)」をお読みください。
+YAMLについて詳しくなく、学んでいきたい場合は、「[Learn YAML in five minutes (5分で学ぶYAML)](https://learnxinyminutes.com/docs/yaml/)」をお読みください。


### PR DESCRIPTION
### Why:
The Japanese translation is wrong, so I fixed
`Y分` -> `5分` (five minutes)

#### Closes [issue link]
No issue number

<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:


### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
