### PR TITLE
Add raw tags around YAML example

### DIFF
--- a/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform.md
+++ b/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform.md
@@ -70,6 +70,8 @@ This example has a job called `Get_OIDC_ID_token` that uses actions to request a
 
 This action exchanges a {% data variables.product.prodname_dotcom %} OIDC token for a Google Cloud access token, using [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation).
 
+{% raw %}
+
 ```yaml{:copy}
 name: List services in GCP
 on:
@@ -97,3 +99,5 @@ jobs:
         gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
         gcloud config list
 ```
+
+{% endraw %}

--- a/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform.md
+++ b/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform.md
@@ -71,7 +71,6 @@ This example has a job called `Get_OIDC_ID_token` that uses actions to request a
 This action exchanges a {% data variables.product.prodname_dotcom %} OIDC token for a Google Cloud access token, using [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation).
 
 {% raw %}
-
 ```yaml{:copy}
 name: List services in GCP
 on:
@@ -99,5 +98,4 @@ jobs:
         gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
         gcloud config list
 ```
-
 {% endraw %}


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs/issues/12026

### What's being changed:

Add `{% raw %}` tags around an example to protect the `{{...}}` elements in the YAML example.

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
