### PR TITLE
Clarify wording for runs-on syntax

### DIFF
--- a/content/actions/learn-github-actions/workflow-syntax-for-github-actions.md
+++ b/content/actions/learn-github-actions/workflow-syntax-for-github-actions.md
@@ -465,7 +465,7 @@ In this example, `job3` uses the `always()` conditional expression so that it al
 
 ## `jobs.<job_id>.runs-on`
 
-**Required**. The type of machine to run the job on. The machine can be either a {% data variables.product.prodname_dotcom %}-hosted runner or a self-hosted runner.
+**Required**. The type of machine to run the job on. The machine can be either a {% data variables.product.prodname_dotcom %}-hosted runner or a self-hosted runner. Depending on the type of runner you want to specify, you can provide `runs-on` as a single string or as an array of strings.
 
 {% ifversion ghae %}
 ### {% data variables.actions.hosted_runner %}s

--- a/content/actions/learn-github-actions/workflow-syntax-for-github-actions.md
+++ b/content/actions/learn-github-actions/workflow-syntax-for-github-actions.md
@@ -465,7 +465,7 @@ In this example, `job3` uses the `always()` conditional expression so that it al
 
 ## `jobs.<job_id>.runs-on`
 
-**Required**. The type of machine to run the job on. The machine can be either a {% data variables.product.prodname_dotcom %}-hosted runner or a self-hosted runner. Depending on the type of runner you want to specify, you can provide `runs-on` as a single string or as an array of strings.
+**Required**. The type of machine to run the job on. The machine can be either a {% data variables.product.prodname_dotcom %}-hosted runner or a self-hosted runner. You can provide `runs-on` as a single string or as an array of strings.
 
 {% ifversion ghae %}
 ### {% data variables.actions.hosted_runner %}s

--- a/data/reusables/github-actions/self-hosted-runner-labels-runs-on.md
+++ b/data/reusables/github-actions/self-hosted-runner-labels-runs-on.md
@@ -1,3 +1,5 @@
 To specify a self-hosted runner for your job, configure `runs-on` in your workflow file with self-hosted runner labels.
 
-All self-hosted runners have the `self-hosted` label. Using only this label will select any self-hosted runner. To select runners that meet certain criteria, such as operating system or architecture, provide an array of labels that begins with `self-hosted` (this must be listed first) and then includes additional labels as needed.
+All self-hosted runners have the `self-hosted` label. Using only this label will select any self-hosted runner. To select runners that meet certain criteria, such as operating system or architecture, we recommend providing an array of labels that begins with `self-hosted` (this must be listed first) and then includes additional labels as needed.
+
+Although the `self-hosted` label is not required, we strongly recommend specifying it when using self-hosted runners to ensure that your job does not unintentionally specify any current or future {% data variables.product.prodname_dotcom %}-hosted runners.

--- a/data/reusables/github-actions/self-hosted-runner-labels-runs-on.md
+++ b/data/reusables/github-actions/self-hosted-runner-labels-runs-on.md
@@ -1,5 +1,5 @@
 To specify a self-hosted runner for your job, configure `runs-on` in your workflow file with self-hosted runner labels.
 
-All self-hosted runners have the `self-hosted` label. Using only this label will select any self-hosted runner. To select runners that meet certain criteria, such as operating system or architecture, we recommend providing an array of labels that begins with `self-hosted` (this must be listed first) and then includes additional labels as needed.
+All self-hosted runners have the `self-hosted` label. Using only this label will select any self-hosted runner. To select runners that meet certain criteria, such as operating system or architecture, we recommend providing an array of labels that begins with `self-hosted` (this must be listed first) and then includes additional labels as needed. When you specify an array of labels, jobs will be queued on runners that have all the labels that you specify.
 
 Although the `self-hosted` label is not required, we strongly recommend specifying it when using self-hosted runners to ensure that your job does not unintentionally specify any current or future {% data variables.product.prodname_dotcom %}-hosted runners.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Closes https://github.com/github/docs/issues/11729

<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

Clarifies the `runs-on` syntax, and that `self-hosted` is not required for self-hosted runners, but is strongly recommended.

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
