### PR TITLE
Add milo/github-api library on the third-party library list

### DIFF
--- a/content/rest/overview/libraries.md
+++ b/content/rest/overview/libraries.md
@@ -104,6 +104,8 @@ topics:
 |**PHP GitHub API**|[KnpLabs/php-github-api](https://github.com/KnpLabs/php-github-api)|
 |**GitHub Joomla! Package**|[joomla-framework/github-api](https://github.com/joomla-framework/github-api)|
 |**GitHub bridge for Laravel**|[GrahamCampbell/Laravel-GitHub](https://github.com/GrahamCampbell/Laravel-GitHub)|
+|**GitHub API Easy Access**|[milo/github-api](https://github.com/milo/github-api)|
+
 
 ### PowerShell
 


### PR DESCRIPTION
### Why:

The milo/github-api library used to be on the list some time ago.


### What's being changed:

The third-party PHP libraries list

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")
