### PR TITLE
Update about-billing-for-codespaces.md

### DIFF
--- a/content/billing/managing-billing-for-github-codespaces/about-billing-for-codespaces.md
+++ b/content/billing/managing-billing-for-github-codespaces/about-billing-for-codespaces.md
@@ -1,63 +1,140 @@
----
-title: About billing for Codespaces
-shortTitle: About billing
-intro: 'View pricing and see how to manage {% data variables.product.prodname_codespaces %} billing for your organization.'
-permissions: 'To manage billing for Codespaces for an organization, you must be an organization owner or a billing manager.'
-versions:
-  fpt: '*'
-  ghec: '*'
-type: overview
-product: '{% data reusables.gated-features.codespaces %}'
-topics:
-  - Codespaces
-  - Billing
----
+Log In
+Register
+Have you taken the WordPress 2021 Survey yet?
+Skip to content
+WordPress.org
+Search WordPress.org for:
+Search WordPress.org
+Submit
+Toggle Menu
+Showcase
+Learn
+Themes
+Plugins
+Mobile
+Support
+Documentation
+Forums
+Get Involved
+Five for the Future
+About
+Blog
+Hosting
+Get WordPress
+Make WordPress
+WordPress Community Summit 2017
+Whether you’re a budding developer, a designer, or just like helping out, we’re always looking for people to help make WordPress even better.
+If you want to get involved in WordPress, this is the place to be. We’ve got blogs for each contributor group, general news, and upcoming events.
+Meetings Team Updates Five for the Future
+There are many different ways for you to get involved with WordPress:
+Core
+The core team makes WordPress. Whether you’re a seasoned PHP, HTML, JavaScript or CSS developer or are just learning to code, we’d love to have you on board. You can write code, fix bugs, debate decisions, and help with development.
+Next meeting: JavaScript Weekly Office Hours (+7 more)
+วันอังคาร 22:00 GMT+7 (2 days from now) at #core-js on Slack
 
-## {% data variables.product.prodname_codespaces %} pricing
+Design
+The design group is focused on the designing and developing the user interface. It’s a home for designers and UXers alike. There are regular discussions about mockups, design, and user testing.
+Next meeting: Design Team Weekly Chat
+วันพฤหัสบดี 01:00 GMT+7 (2 weeks from now) at #design on Slack
 
-{% data variables.product.prodname_codespaces %} usage is billed for all accounts on the Team and Enterprise plans, and does not include any entitlements. Individual accounts are not currently billed for {% data variables.product.prodname_codespaces %} usage. 
+Mobile
+The mobile team builds the iOS and Android apps. Lend them your Java, Objective-C, or Swift skills. The team also needs designers, UX experts, and testers to give users a smooth experience on every device.
+Accessibility
+The a11y group provides accessibility expertise across the project. They make sure that WordPress core and all of WordPress’ resources are accessible.
+Next meeting: Accessibility Weekly Bug Scrub (+1 more)
+วันศุกร์ 23:00 GMT+7 (5 days from now) at #accessibility on Slack
 
-{% data variables.product.prodname_codespaces %} usage is billed according to the units of measure in the following table:
+Polyglots
+WordPress is used all over the world and in many different languages. If you’re a polyglot, help out by translating WordPress into your own language. You can also assist with creating the tools that make translations easier.
+Next meeting: Polyglots Team Chat (Europe) (+3 more)
+วันพุธ 20:00 GMT+7 (3 days from now) at #polyglots on Slack
 
-| Product             | SKU      | Unit of measure | Price |
-| ------------------- | -------- | --------------- | ----- |
-| Codespaces Compute  |  2 core  | 1 hour          | $0.18 |
-|                     |  4 core  | 1 hour          | $0.36 |
-|                     |  8 core  | 1 hour          | $0.72 |
-|                     |  16 core | 1 hour          | $1.44 |
-|                     |  32 core | 1 hour          | $2.88 |
-| Codespaces Storage  |  Storage | 1 GB-month      | $0.07 |
+Support
+Answering a question in the support forums or IRC is one of the easiest ways to start contributing. Everyone knows the answer to something! This blog is the place for discussion of issues around support.
+Next meeting: Support Team Weekly Chat (+1 more)
+วันศุกร์ 00:00 GMT+7 (4 days from now) at #forums on Slack
 
-## About billing for {% data variables.product.prodname_codespaces %}
+Documentation
+Good documentation lets people help themselves when they get stuck. The docs team is responsible for creating documentation and is always on the look-out for writers. The blog has discussion around the team’s current projects.
+Next meeting: Docs Team Weekly Chat
+วันอังคาร 21:00 GMT+7 (2 days from now) at #docs on Slack
 
-{% data reusables.codespaces.codespaces-billing %}
+Themes
+The Theme Review Team reviews and approves every Theme submitted to the WordPress Theme repository. Reviewing Themes sharpens your own Theme development skills. You can help out and join the discussion on the blog.
+Next meeting: Themes Team Biweekly Chat (+2 more)
+วันอังคาร 22:00 GMT+7 (1 week from now) at #themereview on Slack
 
-Your {% data variables.product.prodname_codespaces %} usage shares your account's existing billing date, payment method, and receipt. {% data reusables.dotcom_billing.view-all-subscriptions %}
+Plugins
+If you are a Plugin developer, subscribe to the Plugin review team blog to keep up with the latest updates, find resources, and learn about any issues around Plugin development.
+Community
+If you’re interested in organizing a meetup or a WordCamp, the community blog is a great place to get started. There are groups working to support events, to create outreach and training programs, and generally support the community.
+Next meeting: Community Team meeting (Asia-Pacific / EMEA) (+1 more)
+วันพฤหัสบดี 19:00 GMT+7 (3 weeks from now) at #community-team on Slack
 
-{% ifversion ghec %}
-If you purchased {% data variables.product.prodname_enterprise %} through a Microsoft Enterprise Agreement, you can connect your Azure Subscription ID to your enterprise account to enable and pay for {% data variables.product.prodname_codespaces %} usage. For more information, see "[Connecting an Azure subscription to your enterprise](/billing/managing-billing-for-your-github-account/connecting-an-azure-subscription-to-your-enterprise)."
-{% endif %}
+Meta
+The Meta team makes WordPress.org, provides support, and builds tools for use by all the contributor groups. If you want to help make WordPress.org better, sign up for updates from the Meta blog.
+Next meeting: Meta Team Biweekly Chat
+วันพฤหัสบดี 04:00 GMT+7 (1 week from now) at #meta on Slack
 
-{% data reusables.dotcom_billing.pricing_cal %}
+Training
+The WordPress training team helps people learn to use, extend, and contribute to WordPress through synchronous and asynchronous learning as well as downloadable lesson plans for instructors to use in live environments, via learn.wordpress.org. If you enjoy teaching people how to use and build stuff for WordPress, immediately stop what you’re doing and join our team!
+Next meeting: Training team weekly meeting
+วันพุธ 00:00 GMT+7 (2 days from now) at #training on Slack
 
-## Setting a spending limit
+Test
+The Test team patrols flow across the entire WordPress ecosystem on every device we have at hand. We test, document, and report on the WordPress user experience. Through continuous dogfooding and visual records, we understand not only what is wrong, but also what is right. We immerse ourselves in the context of what we are making and champion user experience.
+Next meeting: Test Team Meeting (+2 more)
+วันอังคาร 20:00 GMT+7 (2 days from now) at #core-test on Slack
 
-{% data reusables.codespaces.codespaces-spending-limit-requirement %} 
+TV
+The TV team reviews and approves every video submitted to WordPress.tv. They also help WordCamps with video post-production and are responsible for the captioning and subtitling of published videos. Reviewing videos is a great way to learn about WordPress and help the community: experience is not required to get involved.
+Next meeting: WordPress.tv Team Weekly Chat
+วันพฤหัสบดี 22:00 GMT+7 (4 days from now) at #wptv on Slack
 
-For information on managing and changing your account's spending limit, see "[Managing your spending limit for {% data variables.product.prodname_codespaces %}](/billing/managing-billing-for-github-codespaces/managing-spending-limits-for-codespaces)."
+Marketing
+Our vision for the Marketing Team is to be the go-to resource for strategy and content for other WordPress teams.
+Next meeting: Marketing Team Weekly Chat
+วันพุธ 21:00 GMT+7 (3 days from now) at #marketing on Slack
 
-{% data reusables.codespaces.exporting-changes %}
+CLI
+WP-CLI is the official command line tool for interacting with and managing your WordPress sites.
+Next meeting: WP-CLI Weekly Chat
+วันพฤหัสบดี 22:00 GMT+7 (4 days from now) at #cli on Slack
 
-## How billing is handled for forked repositories
+Hosting
+We work to improve WordPress’ end-user experience across hosting environments through industry collaboration and user education. Come join us!
+Next meeting: Hosting Team Weekly Chat (+1 more)
+วันพุธ 16:00 GMT+7 (3 days from now) at #hosting-community on Slack
 
-{% data variables.product.prodname_codespaces %} can only be used in organizations where a billable owner has been defined. To incur charges to the organization, the user must be a member or collaborator, otherwise they cannot create a codespace. 
+Tide
+Tide is a series of automated tests run against every plugin and theme in the directory and then displays PHP compatibility and test errors/warnings in the directory.
+Next meeting: Tide Weekly Chat
+วันพุธ 01:00 GMT+7 (2 days from now) at #tide on Slack
 
-For example, a user in a private organization can fork a repository within that organization, and can subsequently use a codespace billed to the organization; this is because the organization is the owner of the parent repository, which can remove the user's access, the forked repository, and the codespace.
-  
-## How billing is handled when a repository is transferred
+Openverse
+Openverse is a search engine for openly-licensed media. The Openverse team implements new features and new media types; maintains the public API and front-end search engine; and develops WordPress integrations to share Openverse with the entire WordPress community.
+Next meeting: Openverse Development Weekly Chat
+วันอังคาร 22:00 GMT+7 (2 days from now) at #openverse on Slack
 
-Usage is billed and reported on every hour. As such, you pay for any usage when a repository is within your organization. When a repository is transferred out of your organization, any codespaces in that repository are removed as part of the transfer process.
-
-## What happens when users are removed
-
-If a user is removed from an organization or repository, their codespaces are automatically deleted. 
+About
+Blog
+Hosting
+Donate
+Support
+Developers
+Get Involved
+Learn
+Showcase
+Plugins
+Themes
+WordCamp
+WordPress.TV
+BuddyPress
+bbPress
+WordPress.com
+Matt
+Privacy
+Public Code
+@WordPress
+WordPress
+CODE IS POETRY.


### PR DESCRIPTION
> Log In
Register
Have you taken the WordPress 2021 Survey yet?
Skip to content
WordPress.org
Search WordPress.org for:
Search WordPress.org
Submit
Toggle Menu
Showcase
Learn
Themes
Plugins
Mobile
Support
Documentation
Forums
Get Involved
Five for the Future
About
Blog
Hosting
Get WordPress
Make WordPress
WordPress Community Summit 2017
Whether you’re a budding developer, a designer, or just like helping out, we’re always looking for people to help make WordPress even better.
If you want to get involved in WordPress, this is the place to be. We’ve got blogs for each contributor group, general news, and upcoming events.
Meetings Team Updates Five for the Future
There are many different ways for you to get involved with WordPress:
Core
The core team makes WordPress. Whether you’re a seasoned PHP, HTML, JavaScript or CSS developer or are just learning to code, we’d love to have you on board. You can write code, fix bugs, debate decisions, and help with development.
Next meeting: JavaScript Weekly Office Hours (+7 more)
วันอังคาร 22:00 GMT+7 (2 days from now) at #core-js on Slack

Design
The design group is focused on the designing and developing the user interface. It’s a home for designers and UXers alike. There are regular discussions about mockups, design, and user testing.
Next meeting: Design Team Weekly Chat
วันพฤหัสบดี 01:00 GMT+7 (2 weeks from now) at #design on Slack

Mobile
The mobile team builds the iOS and Android apps. Lend them your Java, Objective-C, or Swift skills. The team also needs designers, UX experts, and testers to give users a smooth experience on every device.
Accessibility
The a11y group provides accessibility expertise across the project. They make sure that WordPress core and all of WordPress’ resources are accessible.
Next meeting: Accessibility Weekly Bug Scrub (+1 more)
วันศุกร์ 23:00 GMT+7 (5 days from now) at #accessibility on Slack

Polyglots
WordPress is used all over the world and in many different languages. If you’re a polyglot, help out by translating WordPress into your own language. You can also assist with creating the tools that make translations easier.
Next meeting: Polyglots Team Chat (Europe) (+3 more)
วันพุธ 20:00 GMT+7 (3 days from now) at #polyglots on Slack

Support
Answering a question in the support forums or IRC is one of the easiest ways to start contributing. Everyone knows the answer to something! This blog is the place for discussion of issues around support.
Next meeting: Support Team Weekly Chat (+1 more)
วันศุกร์ 00:00 GMT+7 (4 days from now) at #forums on Slack

Documentation
Good documentation lets people help themselves when they get stuck. The docs team is responsible for creating documentation and is always on the look-out for writers. The blog has discussion around the team’s current projects.
Next meeting: Docs Team Weekly Chat
วันอังคาร 21:00 GMT+7 (2 days from now) at #docs on Slack

Themes
The Theme Review Team reviews and approves every Theme submitted to the WordPress Theme repository. Reviewing Themes sharpens your own Theme development skills. You can help out and join the discussion on the blog.
Next meeting: Themes Team Biweekly Chat (+2 more)
วันอังคาร 22:00 GMT+7 (1 week from now) at #themereview on Slack

Plugins
If you are a Plugin developer, subscribe to the Plugin review team blog to keep up with the latest updates, find resources, and learn about any issues around Plugin development.
Community
If you’re interested in organizing a meetup or a WordCamp, the community blog is a great place to get started. There are groups working to support events, to create outreach and training programs, and generally support the community.
Next meeting: Community Team meeting (Asia-Pacific / EMEA) (+1 more)
วันพฤหัสบดี 19:00 GMT+7 (3 weeks from now) at #community-team on Slack

Meta
The Meta team makes WordPress.org, provides support, and builds tools for use by all the contributor groups. If you want to help make WordPress.org better, sign up for updates from the Meta blog.
Next meeting: Meta Team Biweekly Chat
วันพฤหัสบดี 04:00 GMT+7 (1 week from now) at #meta on Slack

Training
The WordPress training team helps people learn to use, extend, and contribute to WordPress through synchronous and asynchronous learning as well as downloadable lesson plans for instructors to use in live environments, via learn.wordpress.org. If you enjoy teaching people how to use and build stuff for WordPress, immediately stop what you’re doing and join our team!
Next meeting: Training team weekly meeting
วันพุธ 00:00 GMT+7 (2 days from now) at #training on Slack

Test
The Test team patrols flow across the entire WordPress ecosystem on every device we have at hand. We test, document, and report on the WordPress user experience. Through continuous dogfooding and visual records, we understand not only what is wrong, but also what is right. We immerse ourselves in the context of what we are making and champion user experience.
Next meeting: Test Team Meeting (+2 more)
วันอังคาร 20:00 GMT+7 (2 days from now) at #core-test on Slack

TV
The TV team reviews and approves every video submitted to WordPress.tv. They also help WordCamps with video post-production and are responsible for the captioning and subtitling of published videos. Reviewing videos is a great way to learn about WordPress and help the community: experience is not required to get involved.
Next meeting: WordPress.tv Team Weekly Chat
วันพฤหัสบดี 22:00 GMT+7 (4 days from now) at #wptv on Slack

Marketing
Our vision for the Marketing Team is to be the go-to resource for strategy and content for other WordPress teams.
Next meeting: Marketing Team Weekly Chat
วันพุธ 21:00 GMT+7 (3 days from now) at #marketing on Slack

CLI
WP-CLI is the official command line tool for interacting with and managing your WordPress sites.
Next meeting: WP-CLI Weekly Chat
วันพฤหัสบดี 22:00 GMT+7 (4 days from now) at #cli on Slack

Hosting
We work to improve WordPress’ end-user experience across hosting environments through industry collaboration and user education. Come join us!
Next meeting: Hosting Team Weekly Chat (+1 more)
วันพุธ 16:00 GMT+7 (3 days from now) at #hosting-community on Slack

Tide
Tide is a series of automated tests run against every plugin and theme in the directory and then displays PHP compatibility and test errors/warnings in the directory.
Next meeting: Tide Weekly Chat
วันพุธ 01:00 GMT+7 (2 days from now) at #tide on Slack

Openverse
Openverse is a search engine for openly-licensed media. The Openverse team implements new features and new media types; maintains the public API and front-end search engine; and develops WordPress integrations to share Openverse with the entire WordPress community.
Next meeting: Openverse Development Weekly Chat
วันอังคาร 22:00 GMT+7 (2 days from now) at #openverse on Slack

About
Blog
Hosting
Donate
Support
Developers
Get Involved
Learn
Showcase
Plugins
Themes
WordCamp
WordPress.TV
BuddyPress
bbPress
WordPress.com
Matt
Privacy
Public Code
@WordPress
WordPress
CODE IS POETRY.Log In
Register
Have you taken the WordPress 2021 Survey yet?
Skip to content
WordPress.org
Search WordPress.org for:
Search WordPress.org
Submit
Toggle Menu
Showcase
Learn
Themes
Plugins
Mobile
Support
Documentation
Forums
Get Involved
Five for the Future
About
Blog
Hosting
Get WordPress
Make WordPress
WordPress Community Summit 2017
Whether you’re a budding developer, a designer, or just like helping out, we’re always looking for people to help make WordPress even better.
If you want to get involved in WordPress, this is the place to be. We’ve got blogs for each contributor group, general news, and upcoming events.
Meetings Team Updates Five for the Future
There are many different ways for you to get involved with WordPress:
Core
The core team makes WordPress. Whether you’re a seasoned PHP, HTML, JavaScript or CSS developer or are just learning to code, we’d love to have you on board. You can write code, fix bugs, debate decisions, and help with development.
Next meeting: JavaScript Weekly Office Hours (+7 more)
วันอังคาร 22:00 GMT+7 (2 days from now) at #core-js on Slack

Design
The design group is focused on the designing and developing the user interface. It’s a home for designers and UXers alike. There are regular discussions about mockups, design, and user testing.
Next meeting: Design Team Weekly Chat
วันพฤหัสบดี 01:00 GMT+7 (2 weeks from now) at #design on Slack

Mobile
The mobile team builds the iOS and Android apps. Lend them your Java, Objective-C, or Swift skills. The team also needs designers, UX experts, and testers to give users a smooth experience on every device.
Accessibility
The a11y group provides accessibility expertise across the project. They make sure that WordPress core and all of WordPress’ resources are accessible.
Next meeting: Accessibility Weekly Bug Scrub (+1 more)
วันศุกร์ 23:00 GMT+7 (5 days from now) at #accessibility on Slack

Polyglots
WordPress is used all over the world and in many different languages. If you’re a polyglot, help out by translating WordPress into your own language. You can also assist with creating the tools that make translations easier.
Next meeting: Polyglots Team Chat (Europe) (+3 more)
วันพุธ 20:00 GMT+7 (3 days from now) at #polyglots on Slack

Support
Answering a question in the support forums or IRC is one of the easiest ways to start contributing. Everyone knows the answer to something! This blog is the place for discussion of issues around support.
Next meeting: Support Team Weekly Chat (+1 more)
วันศุกร์ 00:00 GMT+7 (4 days from now) at #forums on Slack

Documentation
Good documentation lets people help themselves when they get stuck. The docs team is responsible for creating documentation and is always on the look-out for writers. The blog has discussion around the team’s current projects.
Next meeting: Docs Team Weekly Chat
วันอังคาร 21:00 GMT+7 (2 days from now) at #docs on Slack

Themes
The Theme Review Team reviews and approves every Theme submitted to the WordPress Theme repository. Reviewing Themes sharpens your own Theme development skills. You can help out and join the discussion on the blog.
Next meeting: Themes Team Biweekly Chat (+2 more)
วันอังคาร 22:00 GMT+7 (1 week from now) at #themereview on Slack

Plugins
If you are a Plugin developer, subscribe to the Plugin review team blog to keep up with the latest updates, find resources, and learn about any issues around Plugin development.
Community
If you’re interested in organizing a meetup or a WordCamp, the community blog is a great place to get started. There are groups working to support events, to create outreach and training programs, and generally support the community.
Next meeting: Community Team meeting (Asia-Pacific / EMEA) (+1 more)
วันพฤหัสบดี 19:00 GMT+7 (3 weeks from now) at #community-team on Slack

Meta
The Meta team makes WordPress.org, provides support, and builds tools for use by all the contributor groups. If you want to help make WordPress.org better, sign up for updates from the Meta blog.
Next meeting: Meta Team Biweekly Chat
วันพฤหัสบดี 04:00 GMT+7 (1 week from now) at #meta on Slack

Training
The WordPress training team helps people learn to use, extend, and contribute to WordPress through synchronous and asynchronous learning as well as downloadable lesson plans for instructors to use in live environments, via learn.wordpress.org. If you enjoy teaching people how to use and build stuff for WordPress, immediately stop what you’re doing and join our team!
Next meeting: Training team weekly meeting
วันพุธ 00:00 GMT+7 (2 days from now) at #training on Slack

Test
The Test team patrols flow across the entire WordPress ecosystem on every device we have at hand. We test, document, and report on the WordPress user experience. Through continuous dogfooding and visual records, we understand not only what is wrong, but also what is right. We immerse ourselves in the context of what we are making and champion user experience.
Next meeting: Test Team Meeting (+2 more)
วันอังคาร 20:00 GMT+7 (2 days from now) at #core-test on Slack

TV
The TV team reviews and approves every video submitted to WordPress.tv. They also help WordCamps with video post-production and are responsible for the captioning and subtitling of published videos. Reviewing videos is a great way to learn about WordPress and help the community: experience is not required to get involved.
Next meeting: WordPress.tv Team Weekly Chat
วันพฤหัสบดี 22:00 GMT+7 (4 days from now) at #wptv on Slack

Marketing
Our vision for the Marketing Team is to be the go-to resource for strategy and content for other WordPress teams.
Next meeting: Marketing Team Weekly Chat
วันพุธ 21:00 GMT+7 (3 days from now) at #marketing on Slack

CLI
WP-CLI is the official command line tool for interacting with and managing your WordPress sites.
Next meeting: WP-CLI Weekly Chat
วันพฤหัสบดี 22:00 GMT+7 (4 days from now) at #cli on Slack

Hosting
We work to improve WordPress’ end-user experience across hosting environments through industry collaboration and user education. Come join us!
Next meeting: Hosting Team Weekly Chat (+1 more)
วันพุธ 16:00 GMT+7 (3 days from now) at #hosting-community on Slack

Tide
Tide is a series of automated tests run against every plugin and theme in the directory and then displays PHP compatibility and test errors/warnings in the directory.
Next meeting: Tide Weekly Chat
วันพุธ 01:00 GMT+7 (2 days from now) at #tide on Slack

Openverse
Openverse is a search engine for openly-licensed media. The Openverse team implements new features and new media types; maintains the public API and front-end search engine; and develops WordPress integrations to share Openverse with the entire WordPress community.
Next meeting: Openverse Development Weekly Chat
วันอังคาร 22:00 GMT+7 (2 days from now) at #openverse on Slack

About
Blog
Hosting
Donate
Support
Developers
Get Involved
Learn
Showcase
Plugins
Themes
WordCamp
WordPress.TV
BuddyPress
bbPress
WordPress.com
Matt
Privacy
Public Code
@WordPress
WordPress
CODE IS POETRY.``