### PR TITLE
Update splitting-a-subfolder-out-into-a-new-repository.md

### DIFF
--- a/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
+++ b/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
@@ -73,7 +73,7 @@ If you create a new clone of the repository, you won't lose any of your Git hist
 
 9. Set up a new remote URL for your new repository using the existing remote name and the remote repository URL you copied in step 7.
    ```shell
-   git remote set-url origin https://{% data variables.command_line.codeblock %}/<em>USERNAME/NEW-REPOSITORY-NAME</em>.git
+   git remote add origin https://{% data variables.command_line.codeblock %}/<em>USERNAME/NEW-REPOSITORY-NAME</em>.git
    ```
 
 10. Verify that the remote URL has changed with your new repository name.


### PR DESCRIPTION
`git remote set-url`  reports no remotes set up for current working folder. Exchanging ` git remote add ` add resolves and allows commit to the new split out repo.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:
The published instructions were incomplete and not usable. 

Closes [issue link]

<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

### Check off the following:

- [X] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [X] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
