### PR TITLE
Update forming-calls-with-graphql.md

### DIFF
--- a/content/graphql/guides/forming-calls-with-graphql.md
+++ b/content/graphql/guides/forming-calls-with-graphql.md
@@ -24,12 +24,21 @@ Follow the steps in "[Creating a personal access token](/github/authenticating-t
 
 To match the behavior of the [GraphQL Explorer](/graphql/guides/using-the-explorer), request the following scopes:
 
+```
+user{% ifversion not ghae %}
+public_repo{% endif %}
+repo
+repo_deployment
+repo:status
+read:repo_hook
+read:org
+read:public_key
+read:gpg_key
+```
+
 {% else %}
 
 The following scopes are recommended:
-
-{% endif %}
-
 
 ```
 user{% ifversion not ghae %}
@@ -41,6 +50,8 @@ read:org
 read:public_key
 read:gpg_key
 ```
+
+{% endif %}
 
 The API notifies you if a resource requires a specific scope.
 

--- a/content/graphql/guides/forming-calls-with-graphql.md
+++ b/content/graphql/guides/forming-calls-with-graphql.md
@@ -27,8 +27,8 @@ To match the behavior of the [GraphQL Explorer](/graphql/guides/using-the-explor
 ```
 user{% ifversion not ghae %}
 public_repo{% endif %}
-repo
 repo_deployment
+repo  # (The coarse "repo" permission is optional)
 repo:status
 read:repo_hook
 read:org

--- a/content/graphql/guides/forming-calls-with-graphql.md
+++ b/content/graphql/guides/forming-calls-with-graphql.md
@@ -34,7 +34,6 @@ The following scopes are recommended:
 ```
 user{% ifversion not ghae %}
 public_repo{% endif %}
-repo
 repo_deployment
 repo:status
 read:repo_hook


### PR DESCRIPTION
ℹ️  It's a ~1-line~ small change (though it could have some significance).

### Why:

Opportunity for a small edit for the sake of keeping these API calls "Least Privilege."

I needed to create a new personal access token for another project using GitHub's (awesome) GraphQL API. I used the docs to remind me what scopes to give it and such. It occurred to me that the inclusion of `repo` alongside more granular permissions, without differentiation, might confuse or dissuade some people. 

This commit may make more sense if you take a look at the Personal Access Token page on GitHub (where you create a new one), and open that alongside this small diff. Or you can view this screenshot for convenience —

<details>
<summary>Screenshot of Personal Access Token page</summary>
<img src="https://user-images.githubusercontent.com/2420688/147842945-0b77ed69-ed75-42b4-a918-e2dd78d64a9f.png"/>
</details>

### What's being changed:

Remove the `repo` line from the suggested permissions on this page in the documentation. I _think_ it is consistent with the docs' intentions ..? It feels like it might have been a proofreading/formatting confusion, but I might just be confusing myself. (Happens often enough 😆 )

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).