### PR TITLE
Removed $ sign in the commands

### DIFF
--- a/content/rest/guides/getting-started-with-the-rest-api.md
+++ b/content/rest/guides/getting-started-with-the-rest-api.md
@@ -137,10 +137,10 @@ $ curl -i -u <em>your_username</em> {% data variables.product.api_url_pre %}/use
 
 When prompted, you can enter your OAuth token, but we recommend you set up a variable for it:
 
-You can use `-u "your_username:$token"` and set up a variable for `token` to avoid leaving your token in shell history, which should be avoided.
+You can use `-u "your_username:token"` and set up a variable for `token` to avoid leaving your token in shell history, which should be avoided.
 
 ```shell
-$ curl -i -u <em>your_username:$token</em> {% data variables.product.api_url_pre %}/users/octocat
+$ curl -i -u <em>your_username:token</em> {% data variables.product.api_url_pre %}/users/octocat
 
 ```
 


### PR DESCRIPTION
### Why:

`$` sign in front of the `token` should be removed to avoid confusion. It is common that first-time users will spend time to realize `$` sign is not necessary. (at least for the Windows OS).