### PR TITLE
Small screen resolution precision

### DIFF
--- a/content/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository.md
+++ b/content/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository.md
@@ -34,7 +34,7 @@ shortTitle: Create & delete branches
 
 **Note:** If the branch you want to delete is the repository's default branch, you must choose a new default branch before deleting the branch. For more information, see "[Changing the default branch](/github/administering-a-repository/changing-the-default-branch)."
 
-Also, as browsers and their interpretation of current standards can potentially deliver visually different results and you are having issues locating the {% octicon "git-branch" aria-label="The branch icon" %} NUMBER branches icon, try zooming out some. It should show up and become usable as designed.
+Also, as browsers and their interpretation of current standards can potentially deliver visually different results and you are having issues locating the {% octicon "git-branch" aria-label="The branch icon" %} **<em>NUMBER</em> branches** icon, try zooming out some. It should show up and become usable as designed.
 
 {% endnote %}
 

--- a/content/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository.md
+++ b/content/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository.md
@@ -34,6 +34,8 @@ shortTitle: Create & delete branches
 
 **Note:** If the branch you want to delete is the repository's default branch, you must choose a new default branch before deleting the branch. For more information, see "[Changing the default branch](/github/administering-a-repository/changing-the-default-branch)."
 
+Also, as browsers and their interpretation of current standards can potentially deliver visually different results and you are having issues locating the {% octicon "git-branch" aria-label="The branch icon" %} icon, try zooming out some. It should show up and become usable as designed.
+
 {% endnote %}
 
 If the branch you want to delete is associated with an open pull request, you must merge or close the pull request before deleting the branch. For more information, see "[Merging a pull request](/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request)" or "[Closing a pull request](/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/closing-a-pull-request)."

--- a/content/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository.md
+++ b/content/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository.md
@@ -34,7 +34,7 @@ shortTitle: Create & delete branches
 
 **Note:** If the branch you want to delete is the repository's default branch, you must choose a new default branch before deleting the branch. For more information, see "[Changing the default branch](/github/administering-a-repository/changing-the-default-branch)."
 
-Also, as browsers and their interpretation of current standards can potentially deliver visually different results and you are having issues locating the {% octicon "git-branch" aria-label="The branch icon" %} icon, try zooming out some. It should show up and become usable as designed.
+Also, as browsers and their interpretation of current standards can potentially deliver visually different results and you are having issues locating the {% octicon "git-branch" aria-label="The branch icon" %} NUMBER branches icon, try zooming out some. It should show up and become usable as designed.
 
 {% endnote %}
 


### PR DESCRIPTION
It appears that the branch '{% octicon "git-branch" aria-label="The branch icon" %}' gets removed past a certain resolution and this tutorial, altho correct, becomes somewhat of a big question mark.

I have never had the issue happen until i started using this 15 inches NEC monitor SIDEWAYS as a second monitor on my current dev stack in order to test out somewhat accurately some odd resolutions mobiles have and their effects on browsing.

I couldn't figure out why i had been able to delete branches from the web gui for all i can remember and now, very very confusingly, couldnt figure out it for the life of me. Even so i had to google it because it killed my chi.

Decided to add to the docs, please feel free to do whatever you want with that and, thanks!

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

caused an issue as described when using small resolution screens which hide the subject

Closes #13662

### What's being changed:

just a precision within a NOTE block

### Check off the following:

- [X] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [X] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
