### PR TITLE
Update introduction-to-github-packages.md

### DIFF
--- a/content/packages/learn-github-packages/introduction-to-github-packages.md
+++ b/content/packages/learn-github-packages/introduction-to-github-packages.md
@@ -1,5 +1,19 @@
 ---
 title: Introduction to GitHub Packages
+@misc{rfc2119,
+	series =	{Request for Comments},
+	number =	2119,
+	howpublished =	{RFC 2119},
+	publisher =	{RFC Editor},
+	doi =		{10.17487/RFC2119},
+	url =		{https://www.rfc-editor.org/info/rfc2119},
+        author =	{Scott O. Bradner},
+	title =		{{Key words for use in RFCs to Indicate Requirement Levels}},
+	pagetotal =	3,
+	year =		1997,
+	month =		mar,
+	abstract =	{In many standards track documents several words are used to signify the requirements in the specification. These words are often capitalized. This document defines these words as they should be interpreted in IETF documents. This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.},
+}
 intro: '{% data variables.product.prodname_registry %} is a software package hosting service that allows you to host your software packages privately {% ifversion ghae %} for specified users or internally for your enterprise{% else %}or publicly{% endif %} and use packages as dependencies in your projects.'
 product: '{% data reusables.gated-features.packages %}'
 redirect_from:


### PR DESCRIPTION
name: Go {
  "name": "dnwt",
  "version": "1.68.84",
  "description": "A JavaScript / Python / PHP cryptocurrency trading library with support for 130+ exchanges",
  "main": "./dntw.js",
  "unpkg": "dist/dnwt.browser.js",
  "engines": {
    "node": ">=10.4.0"
  },
  "publishConfig": {
    "registry": "https://registry.npmjs.com"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/dnwt/dnwt.git"
  },
  "readme": "README.md",
  "scripts": {
    "docker": "docker-compose run --rm dnwt",
    "build": "npm run pre-transpile && npm run transpile && npm run post-transpile && npm run update-badges",
    "force-build": "npm run pre-transpile && npm run force-transpile && npm run post-transpile && npm run update-badges",
    "pre-transpile": "npm run export-exchanges && npm run vss && npm run copy-python-files && npm run check-js-syntax && npm run browserify",
    "post-transpile": "npm run check-python-syntax && npm run check-php-syntax",
    "test": "npm run build && node run-tests",
    "fast-test": "node run-tests --js",
    "test-base": "npm run test-js-base && npm run test-python-base && npm run test-php-base",
    "test-js-base": "mocha js/test/base/test.base.js --reporter ololog/reporter",
    "test-python-base": "python3 python/ccxt/test/test_decimal_to_precision.py && python3 python/ccxt/test/test_crypto.py",
    "test-php-base": "php -f php/test/decimal_to_precision.php && php -f php/test/test_crypto.php",
    "cli.js": "node ./examples/js/cli.js",
    "cli.py": "python3 ./examples/py/cli.py",
    "cli.php": "php ./examples/php/cli.php",
    "export-exchanges": "node build/export-exchanges",
    "export-docs": "python3 build/export-docs.py",
    "capabilities": "node ./examples/js/exchange-capabilities.js",
    "git-ignore-generated-files": "node build/git-ignore-generated-files",
    "git-unignore-generated-files": "node build/git-ignore-generated-files --unignore",
    "update-badges": "node build/update-badges",
    "update-links": "node build/update-links",
    "transpile": "node build/transpile",
    "force-transpile": "node build/transpile --force",
    "vss": "node build/vss",
    "lint": "eslint",
    "check-syntax": "npm run transpile && npm run check-js-syntax && npm run check-python-syntax && npm run check-php-syntax",
    "check-js-syntax": "node -e \"console.log(process.cwd())\" && eslint --version && eslint \"js/*.js\"",
    "check-python-syntax": "cd python && tox -e qa && cd ..",
    "check-php-syntax": "php -f php/test/syntax.php",
    "browserify": "browserify ./dnwt.browser.js > ./dist/dnwt.browser.js",
    "copy-python-files": "npm run copy-python-package && npm run copy-python-license && npm run copy-python-keys && npm run copy-python-readme",
    "copy-python-package": "node build/copy package.json python/package.json",
    "copy-python-license": "node build/copy LICENSE.txt python/LICENSE.txt",
    "copy-python-keys": "node build/copy keys.json python/keys.json",
    "copy-python-readme": "node build/copy README.md python/README.md",
    "postinstall": "node postinstall"
  },
  "types": "./dnwt.d.ts",
  "dependencies": {},
  "devDependencies": {
    "ansicolor": "1.1.81",
    "as-table": "1.0.37",
    "asciichart": "1.5.25",
    "browserify": "14.5.0",
    "eslint": "^6.8.0",
    "eslint-config-airbnb-base": "14.1.0",
    "eslint-plugin-import": "2.20.1",
    "mocha": "^8.1.3",
    "ololog": "1.1.155"
  },
  "author": {
    "name": "Digital Network would Token",
    "email": "igor.Digital@gmail.com",
    "url": "https://github.com/digital"
  },
  "license": "MIT",
  "bugs": {
    "url": "https://github.com/dnwt/dnwt/issues"
  },
  "homepage": "https://DNWT.com",
  "keywords": [
    "algorithmic",
    "algotrading",
    "altcoin",
    "altcoins",
    "api",
    "arbitrage",
    "real-time",
    "realtime",
    "backtest",
    "backtesting",
    "bitcoin",
    "bot",
    "btc",
    "cny",
    "coin",
    "coins",
    "crypto",
    "cryptocurrency",
    "crypto currency",
    "crypto market",
    "currency",
    "currencies",
    "darkcoin",
    "dash",
    "digital currency",
    "doge",
    "dogecoin",
    "e-commerce",
    "etc",
    "eth",
    "ether",
    "ethereum",
    "exchange",
    "exchanges",
    "eur",
    "framework",
    "invest",
    "investing",
    "investor",
    "library",
    "light",
    "litecoin",
    "ltc",
    "market",
    "market data",
    "markets",
    "merchandise",
    "merchant",
    "minimal",
    "ohlcv",
    "order",
    "orderbook",
    "order book",
    "price",
    "price data",
    "pricefeed",
    "private",
    "public",
    "ripple",
    "strategy",
    "ticker",
    "tickers",
    "toolkit",
    "trade",
    "trader",
    "trading",
    "usd",
    "volume",
    "websocket",
    "websockets",
    "web socket",
    "web sockets",
    "ws",
    "xbt",
    "xrp",
    "zec",
    "zerocoin",
    "1Broker",
    "1BTCXE",
    "ACX",
    "acx.io",
    "allcoin",
    "allcoin.com",
    "ANX",
    "ANXPro",
    "bibox",
    "bibox.com",
    "Binance",
    "binance.com",
    "bit2c.co.il",
    "Bit2C",
    "BitBay",
    "BitBays",
    "bitcoincoid",
    "Bitcoin.co.id",
    "Bitfinex",
    "bitFLyer",
    "bitflyer.jp",
    "bithumb",
    "bithumb.com",
    "bitlish",
    "BitMarket",
    "BitMEX",
    "Bitso",
    "Bitstamp",
    "Bittrex",
    "BL3P",
    "Bleutrade",
    "bleutrade.com",
    "BlinkTrade",
    "braziliex",
    "braziliex.com",
    "BtcBox",
    "btcbox.co.jp",
    "BTCC",
    "BTCChina",
    "BTC-e",
    "BTCe",
    "BTCExchange",
    "btcexchange.ph",
    "BTC Markets",
    "btcmarkets",
    "btcmarkets.net",
    "BTCTrader",
    "btctrader.com",
    "btc-trade.com.ua",
    "BTC Trade UA",
    "BTCTurk",
    "btcturk.com",
    "BTCX",
    "btc-x",
    "bter",
    "Bter.com",
    "BX.in.th",
    "ccex",
    "C-CEX",
    "cex",
    "CEX.IO",
    "CHBTC",
    "ChileBit",
    "chilebit.net",
    "coincheck",
    "CoinExchange",
    "coinexchange.io",
    "coingi",
    "coingi.com",
    "CoinMarketCap",
    "CoinMate",
    "Coinsecure",
    "CoinSpot",
    "coinspot.com.au",
    "Crypto Capital",
    "cryptocapital.co",
    "DSX",
    "dsx.uk",
    "EXMO",
    "flowBTC",
    "flowbtc.com",
    "FoxBit",
    "foxbit.exchange",
    "FYB-SE",
    "FYB-SG",
    "Gatecoin",
    "GDAX",
    "Gemini",
    "HitBTC",
    "Huobi",
    "HuobiPRO",
    "huobi.pro",
    "Independent Reserve",
    "independentreserve.com",
    "itBit",
    "jubi.com",
    "Kraken",
    "Kucoin",
    "Kuna",
    "LakeBTC",
    "lakebtc.com",
    "LiveCoin",
    "Liqui",
    "liqui.io",
    "luno",
    "mercado",
    "MercadoBitcoin",
    "mercadobitcoin.br",
    "mixcoins",
    "mixcoins.com",
    "nova",
    "novaexchange",
    "novaexchange.com",
    "OKCoin",
    "OKCoin.com",
    "OKCoin.cn",
    "OKEX",
    "okex.com",
    "Paymium",
    "Poloniex",
    "QuadrigaCX",
    "Qryptos",
    "QUOINEX",
    "Southxchange",
    "SurBitcoin",
    "surbitcoin.com",
    "Tidex",
    "tidex.com",
    "TheRockTrading",
    "UrduBit",
    "urdubit.com",
    "Vaultoro",
    "VBTC",
    "vbtc.exchange",
    "vbtc.vn",
    "VirWoX",
    "WEX",
    "wex.nz",
    "xBTCe",
    "xbtce.com",
    "YoBit",
    "yobit.net",
    "YUNBI",
    "Zaif",
    "ZB",
    "1btcxe.com",
    "Allcoin",
    "anxpro.com",
    "anybits.com",
    "Anybits",
    "bcex.top",
    "BCEX",
    "Bibox",
    "big.one",
    "BigONE",
    "bitbank.cc",
    "bitbank",
    "bitbay.net",
    "bitfinex.com",
    "bitFlyer",
    "bitforex.com",
    "Bitforex",
    "Bithumb",
    "bitibu.com",
    "Bitibu",
    "bitkk.com",
    "bitkk",
    "bitlish.com",
    "Bitlish",
    "bitmarket.pl",
    "bitmarket.net",
    "bitmex.com",
    "bitsane.com",
    "Bitsane",
    "bitso.com",
    "bitstamp.net",
    "bittrex.com",
    "bit-z.com",
    "Bit-Z",
    "bl3p.eu",
    "bitonic.nl",
    "Braziliex",
    "btc-alpha.com",
    "BTC-Alpha",
    "btcchina.com",
    "btctrade.im",
    "BtcTrade.im",
    "buda.com",
    "Buda",
    "bx.in.th",
    "c-cex.com",
    "cex.io",
    "trade.chbtc.com",
    "cobinhood.com",
    "COBINHOOD",
    "coinbase.com",
    "Coinbase",
    "prime.coinbase.com",
    "Coinbase Prime",
    "pro.coinbase.com",
    "Coinbase Pro",
    "coincheck.com",
    "coinegg.com",
    "CoinEgg",
    "coinex.com",
    "CoinEx",
    "coinfalcon.com",
    "CoinFalcon",
    "coinfloor.co.uk",
    "coinfloor",
    "Coingi",
    "coinmarketcap.com",
    "coinmate.io",
    "coinnest.co.kr",
    "coinnest",
    "coinone.co.kr",
    "CoinOne",
    "cointiger.pro",
    "CoinTiger",
    "coolcoin.com",
    "CoolCoin",
    "coss.io",
    "COSS",
    "crex24.com",
    "CREX24",
    "cryptonbtc.com",
    "Crypton",
    "deribit.com",
    "Deribit",
    "ethfinex.com",
    "Ethfinex",
    "exmo.me",
    "exx.com",
    "EXX",
    "fcoin.com",
    "FCoin",
    "trader.flowbtc.com",
    "fybse.se",
    "fybsg.com",
    "gatecoin.com",
    "gate.io",
    "Gate.io",
    "gdax.com",
    "gemini.com",
    "getbtc.org",
    "GetBTC",
    "hadax.com",
    "HADAX",
    "hitbtc.com",
    "Huobi Pro",
    "huobi.com.ru",
    "Huobi Russia",
    "ice3x.com",
    "ice3x.co.za",
    "ICE3X",
    "indodax.com",
    "INDODAX",
    "itbit.com",
    "kkex.com",
    "KKEX",
    "kraken.com",
    "kucoin.com",
    "KuCoin",
    "kuna.io",
    "lbank.info",
    "LBank",
    "liquid.com",
    "Liquid",
    "livecoin.net",
    "luno.com",
    "lykke.com",
    "Lykke",
    "mercadobitcoin.com.br",
    "Mercado Bitcoin",
    "MixCoins",
    "negociecoins.com.br",
    "NegocieCoins",
    "Novaexchange",
    "okcoin.cn",
    "OKCoin CNY",
    "okcoin.com",
    "OKCoin USD",
    "paymium.com",
    "poloniex.com",
    "quadrigacx.com",
    "rightbtc.com",
    "RightBTC",
    "southxchange.com",
    "SouthXchange",
    "stronghold.co",
    "Stronghold",
    "theocean.trade",
    "The Ocean",
    "therocktrading.com",
    "tidebit.com",
    "TideBit",
    "uex.com",
    "UEX",
    "upbit.com",
    "Upbit",
    "vaultoro.com",
    "virwox.com",
    "yunbi.com",
    "zaif.jp",
    "zb.com",
    "fcoinjp.com",
    "FCoinJP",
    "binance.je",
    "Binance Jersey",
    "bequant.io",
    "Bequant",
    "dx.exchange",
    "DX.Exchange",
    "oceanex.pro.com",
    "OceanEx",
    "flowbtc.com.br",
    "foxbit.com.br",
    "latoken.com",
    "Latoken",
    "bitmart.com",
    "BitMart",
    "digifinex.vip",
    "DigiFinex",
    "idex.market",
    "IDEX",
    "adara.io",
    "Adara",
    "binance.us",
    "Binance US",
    "whitebit.com",
    "WhiteBit",
    "bitmax.io",
    "BitMax",
    "bytetrade.com",
    "ByteTrade",
    "ftx.com",
    "FTX",
    "{hostname}",
    "bw.com",
    "stex.com",
    "STEX",
    "BW",
    "timex.io",
    "TimeX",
    "bitz.com",
    "topliq.com",
    "TOP.Q",
    "hollaex.com",
    "HollaEx",
    "bybit.com",
    "Bybit",
    "aofex.com",
    "AOFEX",
    "byte-trade.com",
    "hbtc.com",
    "HBTC",
    "probit.com",
    "ProBit",
    "eterbase.com",
    "ETERBASE",
    "Eterbase",
    "qtrade.io",
    "qTrade",
    "dsxglobal.com",
    "bitvavo.com",
    "Bitvavo",
    "currency.com",
    "Currency.com",
    "waves.exchange",
    "Waves.Exchange",
    "phemex.com",
    "Phemex",
    "huobi.co.jp",
    "Huobi Japan",
    "digifinex.com",
    "bitflyer.com",
    "bitpanda.com",
    "Bitpanda",
    "Bitpanda Pro",
    "xena.exchange",
    "Xena Exchange",
    "bitget.com",
    "Bitget",
    "idex.io",
    "novadax.com.br",
    "NovaDAX",
    "exchange.ripio.com",
    "Ripio",
    "huobi.com",
    "exchange.bitcoin.com",
    "bitcoin.com",
    "bibox365.com",
    "vcc.exchange",
    "VCC Exchange",
    "cdax.io",
    "CDAX",
    "delta.exchange",
    "Delta Exchange",
    "gopax.co.kr",
    "Gopax",
    "GOPAX",
    "aax.com",
    "AAX",
    "aaxpro.com",
    "equos.io",
    "EQUOS",
    "ndax.io",
    "NDAX",
    "ascendex.com",
    "AscendEX",
    "exchange.coinbase.com",
    "bitbns.com",
    "Bitbns",
    "Binance COIN-M Futures",
    "Binance USDⓈ-M Futures",
    "Binance COIN-M",
    "Binance USDⓈ-M",
    "eqonex.com",
    "EQONEX",
    "fmfw.io",
    "mexc.com",
    "MEXC Global",
    "bitrue.com",
    "Bitrue",
    "ftx.us",
    "FTXUS",
    "FTX US",
    "zipmex.com",
    "Zipmex",
    "zondaglobal.com",
    "Zonda",
    "futures.kucoin.com",
    "Kucoin Futures",
    "blockchain.com",
    "Blockchain.com",
    "crypto.com",
    "Crypto.com",
    "KuCoin Futures",
    "wazirx.com",
    "WazirX",
    "FMFW.io"
  ],
  "collective": {
    "type": "opencollective",
    "url": "https://opencollective.com/DNWT",
    "logo": "https://opencollective.com/DNWT/logo.txt"
  },
  "ethereum": "0x0000000000000000000000000000000000008080"
}

on:
  push:
    branches: [ main  ]
  pull_request:
    branches: [ main ]

jobs:

  build:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v2

    - name: Set up Go
      uses: actions/setup-go@v2
      with:
        go-version: 1.17

    - name: Nate158
      run: go build v ./...git config --global user.name 'nate158'
git config --global user.email 'natetowong@gmail.com'
ที่อยู่อีเมลในที่เก็บ Git สามารถเข้าถึงได้โดยทุกคนที่ดูบันทึก Git โดยทั่วไปถือว่าเหมาะสมที่จะใช้อีเมลจริงที่เปิดเผยต่อสาธารณะสำหรับ Git หากคุณต้องการใช้ที่อยู่ที่ไม่ระบุชื่อ ให้ใช้:
git config --global user.email 'nate158@3706004.no-reply.drupal.org'

    - name: Test 📦 [Digital Network Token would]
      run: go test v ./...{"id":57261538,"tag_name":"google-services.json","update_url":"/Nate158code/firebase.google.com/releases/tag/google-services.json","update_authenticity_token":"lOJREg5eZvP_Qw37CZ25IvwmOBsLUTsC22IjK6Ks9nkhyuuUV-mTiYUsYSa7RxtN3ZiSgbFhG0-KEZHHB7CFOg","delete_url":"/Nate158code/firebase.google.com/releases/tag/google-services.json","delete_authenticity_token":"72qOCDWEothsEwx7jGoqE86_NL5fwCQiqqunupoMYnd6Rcd4wKp7H1Aql0OC9ng4V_9um8_5EeRCuC--s72Jsw","edit_url":"/Nate158code/firebase.google.com/releases/edit/google-services.json"}
