### PR TITLE
https://github.com/DigitalNetgomarketingUpdate and rename content/code-security/supply-chain-security/managin…

### DIFF
--- a/เนื้อหา/รหัสความปลอดภัย/ห่วงโซ่อุปทาน-ความปลอดภัย/การจัดการช่องโหว่ในโครงการพึ่งพาของคุณ/configuring-dependabot-security-updates.md
+++ b/เนื้อหา/รหัสความปลอดภัย/ห่วงโซ่อุปทาน-ความปลอดภัย/การจัดการช่องโหว่ในโครงการพึ่งพาของคุณ/configuring-dependabot-security-updates.md
@@ -1,4 +1,41 @@
 ---
+I have a java code example to make a digest computed using the HMAC-SHA1 algorithm (RFC 2104.), then encoded using Base64 encoding (RFC 2045).
+
+here is the java code
+
+public static String buildDigest(String key, String idString) throws SignatureException {
+
+
+ try {
+    String algorithm = "HmacSHA1";
+    Charset charset = Charset.forName("utf-8");
+    SecretKeySpec signingKey = new SecretKeySpec(key.getBytes(), algorithm);
+    Mac mac = Mac.getInstance(algorithm);
+    mac.init(signingKey);
+    return new String(Base64.encodeBase64(mac.doFinal(idString.getBytes(charset))), charset);
+  } catch (Exception e) {
+    throw new SignatureException("Failed to generate HMAC : " + e.getMessage());
+  }
+}
+I found answers here in Stack Overflow so here is the C# code
+
+   private string EncodeHMAC(string input, byte[] key)
+    {
+        HMACSHA1 myhmacsha1 = new HMACSHA1(key);
+        byte[] byteArray = Encoding.UTF8.GetBytes(input);
+       // MemoryStream stream = new MemoryStream(byteArray);
+        var hashValue = myhmacsha1.ComputeHash(byteArray);
+        return hashValue.Aggregate("", (s, e) => s + String.Format("{0:x2}", e), s => s);
+    }
+
+    private string EncodeTo64(string toEncode)
+    {
+        byte[] toEncodeAsBytes = System.Text.UTF8Encoding.UTF8.GetBytes(toEncode);
+
+        string returnValue = System.Convert.ToBase64String(toEncodeAsBytes);
+
+        return returnValue;
+    }
 title: Configuring Dependabot security updates
 intro: 'You can use {% data variables.product.prodname_dependabot_security_updates %} or manual pull requests to easily update vulnerable dependencies.'
 shortTitle: Configure security updates


### PR DESCRIPTION
…g-vulnerabilities-in-your-projects-dependencies/configuring-dependabot-security-updates.md to เนื้อหา/รหัสความปลอดภัย/ห่วงโซ่อุปทาน-ความปลอดภัย/การจัดการช่องโหว่ในโครงการพึ่งพาของคุณ/configuring-dependabot-security-updates.md


---
title: Configuring Dependabot security updates
intro: 'You can use {% data variables.product.prodname_dependabot_security_updates %} or manual pull requests to easily update vulnerable dependencies.'
shortTitle: Configure security updates
redirect_from:
  - /articles/configuring-automated-security-fixes
  - /github/managing-security-vulnerabilities/configuring-automated-security-fixes
  - /github/managing-security-vulnerabilities/configuring-automated-security-updates
  - /github/managing-security-vulnerabilities/configuring-github-dependabot-security-updates
  - /github/managing-security-vulnerabilities/configuring-dependabot-security-updates
  - /code-security/supply-chain-security/configuring-dependabot-security-updates
versions:
  fpt: '*'
  ghec: '*'
  ghes: '>3.2'
type: how_to
topics:
  - Dependabot
  - Security updates
  - Alerts
  - Dependencies
  - Pull requests
  - Repositories
---
<!--Marketing-LINK: From home page "Learn more about Dependabot".-->

{% data reusables.dependabot.beta-security-and-version-updates %}
{% data reusables.dependabot.enterprise-enable-dependabot %}

## About configuring {% data variables.product.prodname_dependabot_security_updates %}

You can enable {% data variables.product.prodname_dependabot_security_updates %} for any repository that uses {% data variables.product.prodname_dependabot_alerts %} and the dependency graph. For more information, see "[About {% data variables.product.prodname_dependabot_security_updates %}](/github/managing-security-vulnerabilities/about-dependabot-security-updates)."

You can disable {% data variables.product.prodname_dependabot_security_updates %} for an individual repository or for all repositories owned by your user account or organization. For more information, see "[Managing {% data variables.product.prodname_dependabot_security_updates %} for your repositories](#managing-dependabot-security-updates-for-your-repositories)" below.

{% ifversion fpt or ghec %}{% data reusables.dependabot.dependabot-tos %}{% endif %}

## Supported repositories

{% data variables.product.prodname_dotcom %} automatically enables {% data variables.product.prodname_dependabot_security_updates %} for every repository that meets these prerequisites. 

{% note %}

**Note**: You can manually enable {% data variables.product.prodname_dependabot_security_updates %}, even if the repository doesn't meet some of the prerequisites below. For example, you can enable {% data variables.product.prodname_dependabot_security_updates %} on a fork, or for a package manager that isn't directly supported by following the instructions in "[Managing {% data variables.product.prodname_dependabot_security_updates %} for your repositories](#managing-dependabot-security-updates-for-your-repositories)."

{% endnote %}

| Automatic enablement prerequisite | More information |
| ----------------- | ----------------------- |
| Repository is not a fork | "[About forks](/github/collaborating-with-issues-and-pull-requests/about-forks)" |
| Repository is not archived | "[Archiving repositories](/github/creating-cloning-and-archiving-repositories/archiving-repositories)" |{% ifversion fpt or ghec %}
| Repository is public, or repository is private and you have enabled read-only analysis by {% data variables.product.prodname_dotcom %}, dependency graph, and vulnerability alerts in the repository's settings | "[Managing data use settings for your private repository](/github/understanding-how-github-uses-and-protects-your-data/managing-data-use-settings-for-your-private-repository)." |{% endif %}
| Repository contains dependency manifest file from a package ecosystem that {% data variables.product.prodname_dotcom %} supports | "[Supported package ecosystems](/github/visualizing-repository-data-with-graphs/about-the-dependency-graph#supported-package-ecosystems)" |
| {% data variables.product.prodname_dependabot_security_updates %} are not disabled for the repository | "[Managing {% data variables.product.prodname_dependabot_security_updates %} for your repository](#managing-dependabot-security-updates-for-your-repositories)" |

If security updates are not enabled for your repository and you don't know why, first try enabling them using the instructions given in the procedural sections below. If security updates are still not working, you can contact {% data variables.contact.contact_support %}.

## Managing {% data variables.product.prodname_dependabot_security_updates %} for your repositories

You can enable or disable {% data variables.product.prodname_dependabot_security_updates %} for an individual repository (see below).

You can also enable or disable {% data variables.product.prodname_dependabot_security_updates %} for all repositories owned by your user account or organization. For more information, see "[Managing security and analysis settings for your user account](/github/setting-up-and-managing-your-github-user-account/managing-security-and-analysis-settings-for-your-user-account)" or "[Managing security and analysis settings for your organization](/organizations/keeping-your-organization-secure/managing-security-and-analysis-settings-for-your-organization)." 

{% data variables.product.prodname_dependabot_security_updates %} require specific repository settings. For more information, see "[Supported repositories](#supported-repositories)."

### Enabling or disabling {% data variables.product.prodname_dependabot_security_updates %} for an individual repository

{% data reusables.repositories.navigate-to-repo %}
{% data reusables.repositories.sidebar-settings %}
{% data reusables.repositories.navigate-to-security-and-analysis %}
1. Under "Configure security and analysis features", to the right of "{% data variables.product.prodname_dependabot %} security updates", click **Enable** or **Disable**.
  {% ifversion fpt or ghec %}!["Configure security and analysis features" section with button to enable {% data variables.product.prodname_dependabot_security_updates %}](/assets/images/help/repository/enable-dependabot-security-updates-button.png){% else %}!["Configure security and analysis features" section with button to enable {% data variables.product.prodname_dependabot_security_updates %}](/assets/images/enterprise/3.3/repository/security-and-analysis-disable-or-enable-ghes.png){% endif %}


## Further reading

- "[About alerts for vulnerable dependencies](/code-security/supply-chain-security/about-alerts-for-vulnerable-dependencies)"{% ifversion fpt or ghec %}
- "[Managing data use settings for your private repository](/github/understanding-how-github-uses-and-protects-your-data/managing-data-use-settings-for-your-private-repository)"{% endif %}
- "[Supported package ecosystems](/github/visualizing-repository-data-with-graphs/about-the-dependency-graph#supported-package-ecosystems)"
I have a java code example to make a digest computed using the HMAC-SHA1 algorithm (RFC 2104.), then encoded using Base64 encoding (RFC 2045).

here is the java code

public static String buildDigest(String key, String idString) throws SignatureException {


 try {
    String algorithm = "HmacSHA1";
    Charset charset = Charset.forName("utf-8");
    SecretKeySpec signingKey = new SecretKeySpec(key.getBytes(), algorithm);
    Mac mac = Mac.getInstance(algorithm);
    mac.init(signingKey);
    return new String(Base64.encodeBase64(mac.doFinal(idString.getBytes(charset))), charset);
  } catch (Exception e) {
    throw new SignatureException("Failed to generate HMAC : " + e.getMessage());
  }
}
I found answers here in Stack Overflow so here is the C# code

   private string EncodeHMAC(string input, byte[] key)
    {
        HMACSHA1 myhmacsha1 = new HMACSHA1(key);
        byte[] byteArray = Encoding.UTF8.GetBytes(input);
       // MemoryStream stream = new MemoryStream(byteArray);
        var hashValue = myhmacsha1.ComputeHash(byteArray);
        return hashValue.Aggregate("", (s, e) => s + String.Format("{0:x2}", e), s => s);
    }

    private string EncodeTo64(string toEncode)
    {
        byte[] toEncodeAsBytes = System.Text.UTF8Encoding.UTF8.GetBytes(toEncode);

        string returnValue = System.Convert.ToBase64String(toEncodeAsBytes);

        return returnValue;
    }

#14240 
≥123.45.67.89 - 25/Mar/2003 10:15:32 -
http://www.google.com/search?q=cars -
Firefox 1.0.7; Windows NT 5.1 -
740674ce2123e969
≥_CSzXksMf0txApO9F0P7_yA token Atom 
http://search.yahoo.com/mrss
https://github.com/DigitalNetgomarketing
https://github.com/DigitalNetgomarketing.private.atom?token=?
