### PR TITLE
Prevent settings.xml generation in gradle publishing instructions

### DIFF
--- a/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
+++ b/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
@@ -114,7 +114,7 @@ jobs:
 
 ## Publishing packages to {% data variables.product.prodname_registry %}
 
-Each time you create a new release, you can trigger a workflow to publish your package. / in the example below runs when the `release` event triggers with type `created`. The workflow publishes the package to {% data variables.product.prodname_registry %} if CI tests pass. For more information on the `release` event, see "[Events that trigger workflows](/actions/reference/events-that-trigger-workflows#release)."
+Each time you create a new release, you can trigger a workflow to publish your package. The workflow in the example below runs when the `release` event triggers with type `created`. The workflow publishes the package to {% data variables.product.prodname_registry %} if CI tests pass. For more information on the `release` event, see "[Events that trigger workflows](/actions/reference/events-that-trigger-workflows#release)."
 
 You can define a new Maven repository in the publishing block of your _build.gradle_ that points to {% data variables.product.prodname_registry %}.  In that repository configuration, you can also take advantage of environment variables set in your CI workflow run.  You can use the `GITHUB_ACTOR` environment variable as a username, and you can set the `GITHUB_TOKEN` environment variable with your `GITHUB_TOKEN` secret.
 

--- a/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
+++ b/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
@@ -110,7 +110,7 @@ jobs:
 
    For more information about using secrets in your workflow, see "[Creating and using encrypted secrets](/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)."
    
-Note that the `overwrite-settings` option is set to false to prevent the `setup-java` action from automatically generating an unnecessary `~/.m2/settings.xml` file that require specific environment variables.
+Setting `overwrite-settings` to false prevents the `actions/setup-java` action from automatically generating or overwriting an existing `settings.xml` file.
 
 ## Publishing packages to {% data variables.product.prodname_registry %}
 

--- a/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
+++ b/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
@@ -108,9 +108,9 @@ jobs:
 {% data reusables.github-actions.gradle-workflow-steps %}
 1. Runs the [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action) action with the `publish` argument to publish to the `OSSRH` Maven repository. The `MAVEN_USERNAME` environment variable will be set with the contents of your `OSSRH_USERNAME` secret, and the `MAVEN_PASSWORD` environment variable will be set with the contents of your `OSSRH_TOKEN` secret.
 
-   Note that the `overwrite-settings` option is set to false to prevent the `setup-java` action from automatically generating an unnecessary `~/.m2/settings.xml` file that require specific environment variables.
-
    For more information about using secrets in your workflow, see "[Creating and using encrypted secrets](/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)."
+   
+Note that the `overwrite-settings` option is set to false to prevent the `setup-java` action from automatically generating an unnecessary `~/.m2/settings.xml` file that require specific environment variables.
 
 ## Publishing packages to {% data variables.product.prodname_registry %}
 

--- a/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
+++ b/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
@@ -93,6 +93,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+          overwrite-settings: false
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
@@ -107,11 +108,13 @@ jobs:
 {% data reusables.github-actions.gradle-workflow-steps %}
 1. Runs the [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action) action with the `publish` argument to publish to the `OSSRH` Maven repository. The `MAVEN_USERNAME` environment variable will be set with the contents of your `OSSRH_USERNAME` secret, and the `MAVEN_PASSWORD` environment variable will be set with the contents of your `OSSRH_TOKEN` secret.
 
+   Note that the `overwrite-settings` option is set to false to prevent the `setup-java` action from automatically generating an unnecessary `~/.m2/settings.xml` file that require specific environment variables.
+
    For more information about using secrets in your workflow, see "[Creating and using encrypted secrets](/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)."
 
 ## Publishing packages to {% data variables.product.prodname_registry %}
 
-Each time you create a new release, you can trigger a workflow to publish your package. The workflow in the example below runs when the `release` event triggers with type `created`. The workflow publishes the package to {% data variables.product.prodname_registry %} if CI tests pass. For more information on the `release` event, see "[Events that trigger workflows](/actions/reference/events-that-trigger-workflows#release)."
+Each time you create a new release, you can trigger a workflow to publish your package. / in the example below runs when the `release` event triggers with type `created`. The workflow publishes the package to {% data variables.product.prodname_registry %} if CI tests pass. For more information on the `release` event, see "[Events that trigger workflows](/actions/reference/events-that-trigger-workflows#release)."
 
 You can define a new Maven repository in the publishing block of your _build.gradle_ that points to {% data variables.product.prodname_registry %}.  In that repository configuration, you can also take advantage of environment variables set in your CI workflow run.  You can use the `GITHUB_ACTOR` environment variable as a username, and you can set the `GITHUB_TOKEN` environment variable with your `GITHUB_TOKEN` secret.
 
@@ -164,6 +167,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+          overwrite-settings: false
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
@@ -243,6 +247,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+          overwrite-settings: false
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package


### PR DESCRIPTION
Per https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven (and https://github.com/actions/setup-java/issues/51), `setup-java` automatically creates a settings.xml file like so:

``` xml
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
  <servers>
    <server>
      <id>github</id>
      <username>${env.GITHUB_ACTOR}</username>
      <password>${env.GITHUB_TOKEN}</password>
    </server>
  </servers>
</settings>
```

This forces the developer to pass along `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables every time a gradle command is used or else the xml parsing will fail, claiming that it was `Unable to decrypt local Maven settings credentials`. If you plan on doing, say, `./gradlew build` in one step and `./gradlew publish` in another, this can understandably cause issues.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

Closes https://github.com/github/docs/issues/14662

### What's being changed:

I added an explicit `overwrite-settings: false` flag to all of the `setup-java` actions.

I also added this doc snippet:

> Note that the `overwrite-settings` option is set to false to prevent the `setup-java` action from automatically generating an unnecessary `~/.m2/settings.xml` file that require specific environment variables.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

Note - I can't check off the first item because I couldn't find staging. I checked https://github.com/github/docs/actions?query=automatically+generated+content

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
