### PR TITLE
Remove banners regarding the beta state of Code Scanning on GitHub AE.

### DIFF
--- a/content/admin/advanced-security/configuring-code-scanning-for-your-appliance.md
+++ b/content/admin/advanced-security/configuring-code-scanning-for-your-appliance.md
@@ -17,8 +17,6 @@ topics:
   - Security
 ---
 
-{% data reusables.code-scanning.beta %}
-
 ## About {% data variables.product.prodname_code_scanning %}
 
 {% data reusables.code-scanning.about-code-scanning %}

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-with-codeql.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-with-codeql.md
@@ -17,7 +17,6 @@ topics:
   - CodeQL
 ---
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning %}
 
 ## About {% data variables.product.prodname_code_scanning %} with {% data variables.product.prodname_codeql %}

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning.md
@@ -19,7 +19,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning %}
 
 ## About {% data variables.product.prodname_code_scanning %}

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning.md
@@ -26,7 +26,6 @@ shortTitle: Configure code scanning
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning-actions %}
 
 ## About {% data variables.product.prodname_code_scanning %} configuration

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages.md
@@ -28,7 +28,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning-actions %}
 
 ## About the {% data variables.product.prodname_codeql_workflow %} and compiled languages

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository.md
@@ -25,7 +25,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-
 ## About alerts from {% data variables.product.prodname_code_scanning %}
 
 You can set up {% data variables.product.prodname_code_scanning %} to check the code in a repository using the default {% data variables.product.prodname_codeql %} analysis, a third-party analysis, or multiple types of analysis. When the analysis is complete, the resulting alerts are displayed alongside each other in the security view of the repository. Results from third-party tools or from custom queries may not include all of the properties that you see for alerts detected by {% data variables.product.company_short %}'s default {% data variables.product.prodname_codeql %} analysis. For more information, see "[Setting up {% data variables.product.prodname_code_scanning %} for a repository](/code-security/secure-coding/setting-up-code-scanning-for-a-repository)."

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository.md
@@ -25,7 +25,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 
 ## About alerts from {% data variables.product.prodname_code_scanning %}
 

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/running-codeql-code-scanning-in-a-container.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/running-codeql-code-scanning-in-a-container.md
@@ -24,7 +24,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.deprecation-codeql-runner %}
 
 ## About {% data variables.product.prodname_code_scanning %} with a containerized build

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/setting-up-code-scanning-for-a-repository.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/setting-up-code-scanning-for-a-repository.md
@@ -24,7 +24,6 @@ topics:
   - Repositories
 ---
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning-actions %}
 
 ## Options for setting up {% data variables.product.prodname_code_scanning %}

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/triaging-code-scanning-alerts-in-pull-requests.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/triaging-code-scanning-alerts-in-pull-requests.md
@@ -23,7 +23,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 
 ## About {% data variables.product.prodname_code_scanning %} results on pull requests
 

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/triaging-code-scanning-alerts-in-pull-requests.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/triaging-code-scanning-alerts-in-pull-requests.md
@@ -23,7 +23,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-
 ## About {% data variables.product.prodname_code_scanning %} results on pull requests
 
 In repositories where {% data variables.product.prodname_code_scanning %} is configured as a pull request check, {% data variables.product.prodname_code_scanning %} checks the code in the pull request. By default, this is limited to pull requests that target the default branch, but you can change this configuration within {% data variables.product.prodname_actions %} or in a third-party CI/CD system. If merging the changes would introduce new {% data variables.product.prodname_code_scanning %} alerts to the target branch, these are reported as check results in the pull request. The alerts are also shown as annotations in the **Files changed** tab of the pull request. If you have write permission for the repository, you can see any existing {% data variables.product.prodname_code_scanning %} alerts on the **Security** tab. For information about repository alerts, see "[Managing {% data variables.product.prodname_code_scanning %} alerts for your repository](/code-security/secure-coding/managing-code-scanning-alerts-for-your-repository)."

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/troubleshooting-the-codeql-workflow.md
@@ -28,7 +28,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.not-available %}
 
 ## Producing detailed logs for debugging

--- a/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/viewing-code-scanning-logs.md
+++ b/content/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/viewing-code-scanning-logs.md
@@ -16,7 +16,6 @@ topics:
 shortTitle: View code scanning logs
 ---
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning-actions %}
 
 ## About your {% data variables.product.prodname_code_scanning %} setup 

--- a/content/code-security/code-scanning/integrating-with-code-scanning/about-integration-with-code-scanning.md
+++ b/content/code-security/code-scanning/integrating-with-code-scanning/about-integration-with-code-scanning.md
@@ -21,7 +21,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning %}
 
 As an alternative to running {% data variables.product.prodname_code_scanning %} within {% data variables.product.prodname_dotcom %}, you can perform analysis elsewhere and then upload the results. Alerts for {% data variables.product.prodname_code_scanning %} that you run externally are displayed in the same way as those for  {% data variables.product.prodname_code_scanning %} that you run within {% data variables.product.prodname_dotcom %}. For more information, see "[Managing {% data variables.product.prodname_code_scanning %} alerts for your repository](/code-security/secure-coding/managing-code-scanning-alerts-for-your-repository)."

--- a/content/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning.md
+++ b/content/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning.md
@@ -23,7 +23,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.deprecation-codeql-runner %}
 
 ## About SARIF support

--- a/content/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github.md
+++ b/content/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github.md
@@ -26,7 +26,6 @@ topics:
 ---
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning %}
 {% data reusables.code-scanning.deprecation-codeql-runner %}
 

--- a/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/about-codeql-code-scanning-in-your-ci-system.md
+++ b/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/about-codeql-code-scanning-in-your-ci-system.md
@@ -23,7 +23,6 @@ redirect_from:
 ---
 <!--UI-LINK: When GitHub Enterprise Server 3.1+ doesn't have GitHub Actions set up, the Security > Code scanning alerts view links to this article.-->
 
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning %}
 
 ## About {% data variables.product.prodname_codeql %} {% data variables.product.prodname_code_scanning %} in your CI system

--- a/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/configuring-codeql-runner-in-your-ci-system.md
+++ b/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/configuring-codeql-runner-in-your-ci-system.md
@@ -31,7 +31,6 @@ topics:
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
 {% data reusables.code-scanning.deprecation-codeql-runner %}
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning %}
 
 ## About configuring {% data variables.product.prodname_codeql %} {% data variables.product.prodname_code_scanning %} in your CI system

--- a/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/running-codeql-runner-in-your-ci-system.md
+++ b/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/running-codeql-runner-in-your-ci-system.md
@@ -29,7 +29,6 @@ topics:
 <!--UI-LINK: When GitHub Enterprise Server <=3.0 doesn't have GitHub Actions set up, the Security > Code scanning alerts view links to this article.-->
 
 {% data reusables.code-scanning.deprecation-codeql-runner %}
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.enterprise-enable-code-scanning %}
 
 ## About the {% data variables.product.prodname_codeql_runner %}

--- a/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/troubleshooting-codeql-runner-in-your-ci-system.md
+++ b/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/troubleshooting-codeql-runner-in-your-ci-system.md
@@ -26,7 +26,6 @@ topics:
 <!--For this article in earlier GHES versions, see /content/github/finding-security-vulnerabilities-and-errors-in-your-code-->
 
 {% data reusables.code-scanning.deprecation-codeql-runner %}
-{% data reusables.code-scanning.beta %}
 {% data reusables.code-scanning.not-available %}
 
 ## The `init` command takes too long

--- a/content/rest/reference/code-scanning.md
+++ b/content/rest/reference/code-scanning.md
@@ -17,7 +17,6 @@ topics:
 miniTocMaxHeadingLevel: 3
 ---
 
-{% data reusables.code-scanning.beta %}
 
 The {% data variables.product.prodname_code_scanning %} API lets you retrieve and update {% data variables.product.prodname_code_scanning %} alerts from a repository. You can use the endpoints to create automated reports for the {% data variables.product.prodname_code_scanning %} alerts in an organization or upload analysis results generated using offline {% data variables.product.prodname_code_scanning %} tools. For more information, see "[Finding security vulnerabilities and errors in your code](/github/finding-security-vulnerabilities-and-errors-in-your-code)."
 

--- a/content/rest/reference/code-scanning.md
+++ b/content/rest/reference/code-scanning.md
@@ -17,7 +17,6 @@ topics:
 miniTocMaxHeadingLevel: 3
 ---
 
-
 The {% data variables.product.prodname_code_scanning %} API lets you retrieve and update {% data variables.product.prodname_code_scanning %} alerts from a repository. You can use the endpoints to create automated reports for the {% data variables.product.prodname_code_scanning %} alerts in an organization or upload analysis results generated using offline {% data variables.product.prodname_code_scanning %} tools. For more information, see "[Finding security vulnerabilities and errors in your code](/github/finding-security-vulnerabilities-and-errors-in-your-code)."
 
 {% ifversion fpt or ghes > 3.0 or ghae or ghec %}

--- a/data/reusables/code-scanning/beta.md
+++ b/data/reusables/code-scanning/beta.md
@@ -1,9 +1,0 @@
-{% ifversion ghae %}
-
-{% note %}
-
-**Note:** {% data variables.product.prodname_code_scanning_capc %} is currently in beta and subject to change.
-
-{% endnote %}
-
-{% endif %}

--- a/data/reusables/gated-features/code-scanning.md
+++ b/data/reusables/gated-features/code-scanning.md
@@ -1,6 +1,4 @@
 {% ifversion fpt or ghec %}{% data variables.product.prodname_code_scanning_capc %} is available for all public repositories, and for private repositories owned by organizations where {% data variables.product.prodname_GH_advanced_security %} is enabled.
 {%- elsif ghes > 3.0 %}{% data variables.product.prodname_code_scanning_capc %} is available for organization-owned repositories where {% data variables.product.prodname_GH_advanced_security %} is enabled.
-{%- elsif ghae %}
-{% data variables.product.prodname_code_scanning_capc %} is available as part of {% data variables.product.prodname_GH_advanced_security %}, which is free during the beta release.
-{%- else %}
-{% data variables.product.prodname_code_scanning_capc %} is available if you have a license for {% data variables.product.prodname_GH_advanced_security %}.{% endif %} {% data reusables.advanced-security.more-info-ghas %}
+{%- elsif ghes = 3.0 %}
+{% data variables.product.prodname_code_scanning_capc %} is available if you have a license for {% data variables.product.prodname_GH_advanced_security %}.{% endif %}{% ifversion not ghae %} {% data reusables.advanced-security.more-info-ghas %}{% endif %}


### PR DESCRIPTION
### Why:
Code Scanning will be generally available on GitHub AE. Because of this, we wish to remove the banners indicating it is still in a beta state.

Closes an internal issue that I've reverse-linked to this one.

### What's being changed:
Two banners have been removed from the Code Scanning documentation for GitHub AE.

Firstly and most simply this banner has been completely removed.

![image](https://user-images.githubusercontent.com/5584439/151568963-dcf9f07c-03dd-408a-b2b5-2d7780a26d8e.png)

Secondly this banner has also been removed on GitHub AE pages, however this is a more complex change due to the fact that the banner still needs to exist on non-AE pages. (See the reverse-linked issue for the rationale for removing this banner rather than updating its text.

![image](https://user-images.githubusercontent.com/5584439/151569191-8a146e57-b1e9-4152-828d-9520e1dde5b7.png)

Please note that I believe we will want to wait to merge this until we're ready. There is no confirmed date yet.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
