### PR TITLE
Update for `gradle-build-action@v2.1.2` release

### DIFF
--- a/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
@@ -69,7 +69,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
+        uses: gradle/gradle-build-action@bc3340afc5e3cc44f2321809ac090d731c13c514
         with:
           arguments: build
 ```
@@ -106,7 +106,7 @@ steps:
   - name: Validate Gradle wrapper
     uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
   - name: Run the Gradle package task
-    uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
+    uses: gradle/gradle-build-action@bc3340afc5e3cc44f2321809ac090d731c13c514
     with:
       arguments: -b ci.gradle package
 ```
@@ -135,7 +135,7 @@ steps:
   - name: Validate Gradle wrapper
     uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
   - name: Build with Gradle
-    uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
+    uses: gradle/gradle-build-action@bc3340afc5e3cc44f2321809ac090d731c13c514
     with:
       arguments: build
   - uses: actions/upload-artifact@v2

--- a/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
+++ b/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
@@ -96,7 +96,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
-        uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
+        uses: gradle/gradle-build-action@bc3340afc5e3cc44f2321809ac090d731c13c514
         with:
           arguments: publish
         env:
@@ -167,7 +167,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
-        uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
+        uses: gradle/gradle-build-action@bc3340afc5e3cc44f2321809ac090d731c13c514
         with:
           arguments: publish
         env:
@@ -246,7 +246,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
-        uses: gradle/gradle-build-action@4137be6a8bf7d7133955359dbd952c0ca73b1021
+        uses: gradle/gradle-build-action@bc3340afc5e3cc44f2321809ac090d731c13c514
         with:
           arguments: publish
         env: {% raw %}


### PR DESCRIPTION
Closes https://github.com/github/docs/issues/14859

Updates docs referencing `gradle-build-action` to the latest v2.1.2 release.
