### PR TITLE
Provide example of boolean input usage

### DIFF
--- a/content/actions/learn-github-actions/contexts.md
+++ b/content/actions/learn-github-actions/contexts.md
@@ -762,10 +762,14 @@ on:
       deploy_target:
         required: true
         type: string
+      perform_deploy:
+        required: true
+        type: boolean
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ inputs.perform_deploy == 'true' }}
     steps:
       - name: Deploy build to target
         run: deploy --build ${{ inputs.build_id }} --target ${{ inputs.deploy_target }}

--- a/data/reusables/github-actions/workflow-dispatch-inputs.md
+++ b/data/reusables/github-actions/workflow-dispatch-inputs.md
@@ -15,14 +15,14 @@ on:
         - info
         - warning
         - debug {% endif %}
+      print_tags:
+        description: 'True to print to STDOUT'
+        required: true {% ifversion fpt or ghec or ghes > 3.3 or ghae-issue-5511 %}
+        type: boolean {% endif %}
       tags:
         description: 'Test scenario tags'
         required: true {% ifversion fpt or ghec or ghes > 3.3 or ghae-issue-5511 %}
         type: string
-      print_tags:
-        description: 'True to print to STDOUT'
-        required: true {% ifversion fpt or ghec or ghes > 3.3 or ghae-issue-5511 %}
-        type: boolean
       environment:
         description: 'Environment to run tests against'
         type: environment

--- a/data/reusables/github-actions/workflow-dispatch-inputs.md
+++ b/data/reusables/github-actions/workflow-dispatch-inputs.md
@@ -17,7 +17,11 @@ on:
         - debug {% endif %}
       tags:
         description: 'Test scenario tags'
-        required: false {% ifversion fpt or ghec or ghes > 3.3 or ghae-issue-5511 %}
+        required: true {% ifversion fpt or ghec or ghes > 3.3 or ghae-issue-5511 %}
+        type: string
+      print_tags:
+        description: 'True to print to STDOUT'
+        required: true {% ifversion fpt or ghec or ghes > 3.3 or ghae-issue-5511 %}
         type: boolean
       environment:
         description: 'Environment to run tests against'
@@ -30,5 +34,6 @@ jobs:
 
     steps:
       - name: Print the input tag to STDOUT
-        run: echo {% raw %} The tag is ${{ github.event.inputs.tag }} {% endraw %}
+        if: {% raw %} ${{ github.event.inputs.tags == 'true' }} {% endraw %}
+        run: echo {% raw %} The tag is ${{ github.event.inputs.tags }} {% endraw %}
 ```


### PR DESCRIPTION
### Why:
Many people are confused by the usage of boolean.  https://github.com/actions/runner/issues/1483

invalid
if: ${{ inputs.perform_deploy }}
if: inputs.perform_deploy

Must be treated as string
if: ${{ inputs.perform_deploy == 'true' }}

### What's being changed:

Update examples of the usage of workflow inputs of type boolean

### Check off the following:

- [ ] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
