### PR TITLE
Add warnings about env: field

### DIFF
--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -184,7 +184,7 @@ A boolean specifying whether the secret must be supplied.
 
 ## `env`
 
-A `map` of environment variables that are available to the steps of all jobs in the workflow. You can also set environment variables that are only available to the steps of a single job or to a single step. For more information, see [`jobs.<job_id>.env`](#jobsjob_idenv) and [`jobs.<job_id>.steps[*].env`](#jobsjob_idstepsenv).
+A `map` of environment variables that are available to the steps of all jobs in the workflow. You can also set environment variables that are only available to the steps of a single job or to a single step. For more information, see [`jobs.<job_id>.env`](#jobsjob_idenv) and [`jobs.<job_id>.steps[*].env`](#jobsjob_idstepsenv). Note that variables in the map cannot be defined in terms of other variables in the map.  If you need complex manipulation of variables, you may wish to use a non-default shell (see below), but non-default shells do not use the `env` map.
 
 {% data reusables.repositories.actions-env-var-note %}
 
@@ -523,7 +523,7 @@ Using the `working-directory` keyword, you can specify the working directory of 
 
 ### `jobs.<job_id>.steps[*].shell`
 
-You can override the default shell settings in the runner's operating system using the `shell` keyword. You can use built-in `shell` keywords, or you can define a custom set of shell options. The shell command that is run internally executes a temporary file that contains the commands specified in the `run` keyword.
+You can override the default shell settings in the runner's operating system using the `shell` keyword. You can use built-in `shell` keywords, or you can define a custom set of shell options. The shell command that is run internally executes a temporary file that contains the commands specified in the `run` keyword.  Note that non-default shells do not use the `env` map.
 
 | Supported platform | `shell` parameter | Description | Command run internally |
 |--------------------|-------------------|-------------|------------------------|


### PR DESCRIPTION
### Why:

Relying on the documentation “workflow-syntax-for-github-actions” for complex actions which use `env:` variables is likely to fail.

### What's being changed:
Add two warnings from painful experience:
In the section on `env:`
-   Note that variables in the map cannot be defined in terms of other variables in the map.  If you need complex manipulation of variables, you may wish to use a non-default shell (see below), but non-default shells do not use the `env` map.
In the section on non-default shells
-   Note that non-default shells do not use the `env` map.
