### PR TITLE
Patch 2

### DIFF
--- a/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
+++ b/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
@@ -24,20 +24,20 @@ This example YAML configuration file defines an issue form using several inputs 
 
 ## Top-level syntax
 
-All issue form configuration files must begin with `name`, `description`, and `body` key-value pairs.
+All issue form configuration files must begin with `name`, `about`, and `body` key-value pairs.
 
 ```YAML{:copy}
 name:
-description:
+about:
 body:
 ```
 
 You can set the following top-level keys for each issue form.
 
-| Key | Description | Required | Type |
+| Key | About | Required | Type |
 | :-- | :-- | :-- | :-- | :-- |
 | `name` | A name for the issue form template. Must be unique from all other templates, including Markdown templates. | Required | String |
-| `description` | A description for the issue form template, which appears in the template chooser interface. | Required | String |
+| `about` | A description for the issue form template, which appears in the template chooser interface. | Required | String |
 | `body` | Definition of the input types in the form. | Required | Array |
 | `assignees` | People who will be automatically assigned to issues created with this template. | Optional | Array or comma-delimited string |
 | `labels` | Labels that will automatically be added to issues created with this template. | Optional | Array or comma-delimited string |
@@ -102,7 +102,7 @@ Links? References? Anything that will give us more context about the issue that 
 
 ```yaml{:copy}
 name: 🐞 Bug
-description: File a bug/issue
+about: File a bug/issue
 title: "[BUG] <title>"
 labels: [Bug, Needs Triage]
 body:

--- a/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
+++ b/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
@@ -34,7 +34,7 @@ body:
 
 You can set the following top-level keys for each issue form.
 
-| Key | About | Required | Type |
+| Key | Description | Required | Type |
 | :-- | :-- | :-- | :-- | :-- |
 | `name` | A name for the issue form template. Must be unique from all other templates, including Markdown templates. | Required | String |
 | `about` | A description for the issue form template, which appears in the template chooser interface. | Required | String |


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

There was a mix of information regarding `about` in the YAML header for an issue template. When I tried to use `description` as suggested by the example in the documentation for a YAML header on my own project, I got an error saying that the `about` category was necessary. 

<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

Changed `description` to `about` in 4 places. Note that the two commits can be squashed into one upon merge.
<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

### Check off the following:

- [ ] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
