### PR TITLE
Fix broken title

### DIFF
--- a/content/actions/using-workflows/workflow-commands-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-commands-for-github-actions.md
@@ -257,6 +257,7 @@ Write-Output "::error file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
 ```
 
 {% endpowershell %}
+
 ## Grouping log lines
 
 Creates an expandable group in the log. To create a group, use the `group` command and specify a `title`. Anything you print to the log between the `group` and `endgroup` commands is nested inside an expandable entry in the log.


### PR DESCRIPTION
### Why:

Fix a broken title.

I suspect a newline between `{% endpowershell %}` and the title is needed, otherwise, the title does not render properly.

<img width="771" alt="Screenshot 2022-03-22 at 13 02 28" src="https://user-images.githubusercontent.com/649677/159477750-7e2431ec-c981-4b9a-a9f3-9080bd8a8a43.png">

### What's being changed:

Adds a newline before the `## Grouping log lines` title.
