### PR TITLE
Add TOTP Apps Google Authenticator.

### DIFF
--- a/content/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication.md
+++ b/content/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication.md
@@ -41,6 +41,7 @@ A time-based one-time password (TOTP) application automatically generates an aut
 - [Authy](https://authy.com/guides/github/)
 - [LastPass Authenticator](https://lastpass.com/auth/)
 - [Microsoft Authenticator](https://www.microsoft.com/en-us/account/authenticator/)
+- [Google Authenticator](https://support.google.com/accounts/answer/1066447/)
 
 {% tip %}
 


### PR DESCRIPTION
Google Authenticator was also able to perform 2FA.



### Why:
Google Authenticator seems to be a major TOTP application, so I modified it.

### What's being changed:
Add TOTP Apps Google Authenticator Link.

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
