### PR TITLE
Update about-self-hosted-runners.md

### DIFF
--- a/content/actions/hosting-your-own-runners/about-self-hosted-runners.md
+++ b/content/actions/hosting-your-own-runners/about-self-hosted-runners.md
@@ -28,8 +28,6 @@ You can add self-hosted runners at various levels in the management hierarchy:
 - Organization-level runners can process jobs for multiple repositories in an organization.
 - Enterprise-level runners can be assigned to multiple organizations in an enterprise account.
 
-Your runner machine connects to {% data variables.product.product_name %} using the {% data variables.product.prodname_actions %} self-hosted runner application. {% data reusables.actions.runner-app-open-source %} When a new version is released, the runner application automatically updates itself when a job is assigned to the runner, or within a week of release if the runner hasn't been assigned any jobs.
-
 {% data reusables.actions.self-hosted-runner-auto-removal %}
 
 For more information about installing and using self-hosted runners, see "[Adding self-hosted runners](/github/automating-your-workflow-with-github-actions/adding-self-hosted-runners)" and "[Using self-hosted runners in a workflow](/github/automating-your-workflow-with-github-actions/using-self-hosted-runners-in-a-workflow)."


### PR DESCRIPTION
### Why:

There is a duplicated paragraph of text in the documentation which leads to confusion and is 100% the same in both places - it should only occur once.

### What's being changed:

The duplicated paragraph of text is being removed at its second occurrence. I chose to keep the more templated copy intact. If you'd like the ordering to differ, I can remove the first one and keep the second instead. The page where this occurs: https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners. Attached is a screenshot where both paragraph are the same (a sentence is highlighted from each).

<img width="788" alt="Screen Shot 2022-03-24 at 11 12 17 AM" src="https://user-images.githubusercontent.com/39606064/159973039-a3cbc40a-492a-42b5-9e53-706a62e429af.png">

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
