### PR TITLE
Actions self-hosted runners - Fix incorrect installation instruction

### DIFF
--- a/content/actions/hosting-your-own-runners/configuring-the-self-hosted-runner-application-as-a-service.md
+++ b/content/actions/hosting-your-own-runners/configuring-the-self-hosted-runner-application-as-a-service.md
@@ -78,10 +78,10 @@ You can manage the runner service in the Windows **Services** application, or yo
    ```
 {% endmac %}
 
-The command takes an optional `user` argument to install the service as a different user.
+The command takes an optional second argument to install the service as a different user.
 
 ```shell
-./svc.sh install --user <em>USERNAME</em>
+./svc.sh install <em>USERNAME</em>
 ```
 
 ## Starting the service


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

The instructions for installing a self-hosted actions runner on linux as another user are incorrect, and if followed fail with an error. This change corrects those instructions.

[svc.sh](https://github.com/actions/runner/blob/408d6c579c36f0eb318acfdafdcbafc872696501/src/Misc/layoutbin/systemd.svc.sh.template#L65) simply takes the [second argument](https://github.com/actions/runner/blob/408d6c579c36f0eb318acfdafdcbafc872696501/src/Misc/layoutbin/systemd.svc.sh.template#L8); there's no `--user` flag. If provided, the script tries to find a user literally named `--user` and fails with "Group not available".

There's no associated issue.

<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

Remove `--user` flag from `./svc.sh install <USER>` instructions, which results in desired behavior.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
