### PR TITLE
Add RepositoryType to .csproj examples

### DIFF
--- a/content/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry.md
@@ -137,6 +137,7 @@ When publishing, you need to use the same value for `OWNER` in your *csproj* fil
       <Company>GitHub</Company>
       <PackageDescription>This package adds an Octocat!</PackageDescription>
       <RepositoryUrl>https://{% ifversion fpt or ghec %}github.com{% else %}HOSTNAME{% endif %}/OWNER/REPOSITORY</RepositoryUrl>
+      <RepositoryType>git</RepositoryType>
     </PropertyGroup>
 
   </Project>
@@ -171,6 +172,7 @@ For example, the *OctodogApp* and *OctocatApp* projects will publish to the same
     <Company>GitHub</Company>
     <PackageDescription>This package adds an Octodog!</PackageDescription>
     <RepositoryUrl>https://{% ifversion fpt or ghec %}github.com{% else %}HOSTNAME{% endif %}/octo-org/octo-cats-and-dogs</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
 </Project>
@@ -188,6 +190,7 @@ For example, the *OctodogApp* and *OctocatApp* projects will publish to the same
     <Company>GitHub</Company>
     <PackageDescription>This package adds an Octocat!</PackageDescription>
     <RepositoryUrl>https://{% ifversion fpt or ghec %}github.com{% else %}HOSTNAME{% endif %}/octo-org/octo-cats-and-dogs</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [types-of-contributions.md](/main/contributing/types-of-contributions.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

I was banging my head against the wall for a long time getting this kind of response when pushing (using a nuget.config file)

```
$ dotnet nuget push "releases/<packages>.nupkg" --source "github" --api-key <PAT_TOKEN>
Pushing <package> to 'https://nuget.pkg.github.com/<owner>'...
  PUT https://nuget.pkg.github.com/<owner>/
warn : No destination repository detected. Ensure the source project has a 'RepositoryUrl' property defined. If you're using a nuspec file, ensure that it has a repository element with the required 'type' and 'url' attributes.
  BadRequest https://nuget.pkg.github.com/<owner>/ 102ms
error: Response status code does not indicate success: 400 (Bad Request).
```

Adding the `<RepositoryType>git</RepositoryType>` solved the problem.


<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

I've added missing nodes to the .csproj examples

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
