### PR TITLE
chore: remove git.io

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -7,5 +7,5 @@ then
     printf >&2 "\nGitHub Docs requires Git LFS but using the 'git-lfs' on your path failed.\n"
   fi
 else
-  printf >&2 "\nGitHub Docs requires Git LFS but 'git-lfs' was not found on your path.\nLearn how to install Git LFS at <https://git.io/JBCId>.\n"
+  printf >&2 "\nGitHub Docs requires Git LFS but 'git-lfs' was not found on your path.\nLearn how to install Git LFS at <https://docs.github.com/en/github/managing-large-files/versioning-large-files/installing-git-large-file-storage>.\n"
 fi

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -7,5 +7,5 @@ then
     printf >&2 "\nGitHub Docs requires Git LFS but using the 'git-lfs' on your path failed.\n"
   fi
 else
-  printf >&2 "\nGitHub Docs requires Git LFS but 'git-lfs' was not found on your path.\nLearn how to install Git LFS at <https://git.io/JBCId>.\n"
+  printf >&2 "\nGitHub Docs requires Git LFS but 'git-lfs' was not found on your path.\nLearn how to install Git LFS at <https://docs.github.com/en/github/managing-large-files/versioning-large-files/installing-git-large-file-storage>.\n"
 fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -7,5 +7,5 @@ then
     printf >&2 "\nGitHub Docs requires Git LFS but using the 'git-lfs' on your path failed.\n"
   fi
 else
-  printf >&2 "\nGitHub Docs requires Git LFS but 'git-lfs' was not found on your path.\nLearn how to install Git LFS at <https://git.io/JBCId>.\n"
+  printf >&2 "\nGitHub Docs requires Git LFS but 'git-lfs' was not found on your path.\nLearn how to install Git LFS at <https://docs.github.com/en/github/managing-large-files/versioning-large-files/installing-git-large-file-storage>.\n"
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,7 +7,7 @@ then
     printf >&2 "\nGitHub Docs requires Git LFS but using the 'git-lfs' on your path failed.\n"
   fi
 else
-  printf >&2 "\nGitHub Docs requires Git LFS but 'git-lfs' was not found on your path.\nLearn how to install Git LFS at <https://git.io/JBCId>.\n"
+  printf >&2 "\nGitHub Docs requires Git LFS but 'git-lfs' was not found on your path.\nLearn how to install Git LFS at <https://docs.github.com/en/github/managing-large-files/versioning-large-files/installing-git-large-file-storage>.\n"
 fi
 
 . "$(dirname "$0")/_/husky.sh"

--- a/script/toggle-ghae-feature-flags.js
+++ b/script/toggle-ghae-feature-flags.js
@@ -27,7 +27,7 @@ program
   .description(
     'Toggle issue-based, feature-flagged versioning for GitHub AE content like\n' +
       'ghae-next or ghae-issue-1234, then commit the results.\n\n' +
-      'Documentation: https://git.io/JCtUO\n\n' +
+      'Documentation: https://github.com/github/docs-content/blob/main/docs-content-docs/docs-content-workflows/content-creation/versioning-documentation.md#internal-versioning-conventions-for-github-ae\n\n' +
       'Examples:\n' +
       `  ${scriptName} -n\n` +
       `  ${scriptName} -f 'issue-1234, issue-5678'`


### PR DESCRIPTION
### Why:

All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

I replaced all short URLs with their original URL.

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
