### PR TITLE
Indicate correct Ruby version to install

### DIFF
--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
@@ -20,7 +20,7 @@ shortTitle: Create site with Jekyll
 
 ## Prerequisites
 
-Before you can use Jekyll to create a {% data variables.product.prodname_pages %} site, you must install Jekyll and Git. For more information, see [Installation](https://jekyllrb.com/docs/installation/) in the Jekyll documentation and "[Set up Git](/articles/set-up-git)."
+Before you can use Jekyll to create a {% data variables.product.prodname_pages %} site, you must install Jekyll and Git. For more information, see [Installation](https://jekyllrb.com/docs/installation/) in the Jekyll documentation and "[Set up Git](/articles/set-up-git)." Notice that the Jekyll version used in the `github-pages` gem doesn't work with Ruby 3.x, but only 2.x.
 
 {% data reusables.pages.recommend-bundler %}
 

--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
@@ -20,7 +20,7 @@ shortTitle: Create site with Jekyll
 
 ## Prerequisites
 
-Before you can use Jekyll to create a {% data variables.product.prodname_pages %} site, you must install Jekyll and Git. For more information, see [Installation](https://jekyllrb.com/docs/installation/) in the Jekyll documentation and "[Set up Git](/articles/set-up-git)." Notice that the Jekyll version used in the `github-pages` gem doesn't work with Ruby 3.x, but only 2.x.
+Before you can use Jekyll to create a {% data variables.product.prodname_pages %} site, you must install Jekyll and Git. For more information, see [Installation](https://jekyllrb.com/docs/installation/) in the Jekyll documentation and "[Set up Git](/articles/set-up-git)."
 
 {% data reusables.pages.recommend-bundler %}
 

--- a/data/reusables/pages/recommend-bundler.md
+++ b/data/reusables/pages/recommend-bundler.md
@@ -1,4 +1,4 @@
 We recommend using [Bundler](http://bundler.io/) to install and run Jekyll. Bundler manages Ruby gem dependencies, reduces Jekyll build errors, and prevents environment-related bugs. To install Bundler:
 
- 1. Install Ruby. For more information, see "[Installing Ruby](https://www.ruby-lang.org/en/documentation/installation/)" in the Ruby documentation.
+ 1. Install Ruby. For more information, see "[Installing Ruby](https://www.ruby-lang.org/en/documentation/installation/)" in the Ruby documentation. Notice that the Jekyll version used in the `github-pages` gem doesn't work with Ruby 3.x, but only 2.x.
  2. Install Bundler. For more information, see "[Bundler](https://bundler.io/)."


### PR DESCRIPTION
### Why:

Closes #17504

### What's being changed:

Clarify the Ruby version to install to get Jekyll with the `github-pages` gem to build locally. This change is in a reusable snippet, used both in [`content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md`](https://github.com/github/docs/blob/9eb64f81486dc66b0a1ebfb022366ffd68ebfcc9/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md) and [`content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md`](https://github.com/github/docs/blob/9eb64f81486dc66b0a1ebfb022366ffd68ebfcc9/content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md).

In both places, the current content is

![image](https://user-images.githubusercontent.com/8521043/166122041-3aa2fbd3-9a56-4653-a6a3-015fe5853f56.png)

and with the suggested change

![image](https://user-images.githubusercontent.com/8521043/166122051-668545a5-7bfe-4b88-beaa-68630e389fa5.png)

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
