### PR TITLE
Suggest semantic versioned tags only to suitable action publishers

### DIFF
--- a/content/actions/creating-actions/releasing-and-maintaining-actions.md
+++ b/content/actions/creating-actions/releasing-and-maintaining-actions.md
@@ -70,7 +70,10 @@ Here is an example process that you can follow to automatically run tests, creat
 
    * When a release is published or edited, your release workflow will automatically take care of compilation and adjusting tags.
 
-   * We recommend creating releases using semantically versioned tags – for example, `v1.1.3` – and keeping major (`v1`) and minor (`v1.1`) tags current to the latest appropriate commit. For more information, see "[About custom actions](/actions/creating-actions/about-custom-actions#using-release-management-for-actions)" and "[About semantic versioning](https://docs.npmjs.com/about-semantic-versioning).
+   * We recommend creating releases using semantically versioned tag – for example, `v1.1.3`. For more information, see "[About semantic versioning](https://docs.npmjs.com/about-semantic-versioning)".
+
+   * If your action is intended to be used internally in your organization, it is also helpful to keep major (`v1`) and minor (`v1.1`) tags current to the latest appropriate commit. For more information, see "[About custom actions](/actions/creating-actions/about-custom-actions#using-release-management-for-actions)".
+
 
 ### Results
 


### PR DESCRIPTION
Hello, thanks for making the doc open and easy to discuss!
Here I want to discuss the idea to improve the consistency, hoping that it helps to improve users' experience and security.

### Why:

The [security guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends users avoid using tags when using third-party actions.
See "Pin actions to a full length commit SHA" and "Pin actions to a tag only if you trust
the creator" on the page for detail.

But the ["Releasing and maintaining actions" doc](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) suggests all action-authors provide semantic versioned tags, that will motivate action users to use tags instead of full length commit SHA.

Between these official docs, we have an inconsistent description at this moment.

<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

This proposal changed semantic versioned tags suggested _only for internal-use actions_.

It is OK for internal-use actions, like private actions used for audits because the author is not a "third-party" for users and it should be trusted by them.

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).


Thanks for checking this PR! :wave:

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
