### PR TITLE
fix: Update first example to not use expression syntax

### DIFF
--- a/content/actions/learn-github-actions/expressions.md
+++ b/content/actions/learn-github-actions/expressions.md
@@ -34,7 +34,7 @@ You need to use specific syntax to tell {% data variables.product.prodname_dotco
 ```yaml
 steps:
   - uses: actions/hello-world-javascript-action@v1.1
-    if: {% raw %}${{ <expression> }}{% endraw %}
+    if: <expression>
 ```
 
 #### Example setting an environment variable


### PR DESCRIPTION
This changes the first example not to use expression syntax to match the copy in the previous paragraph.

> When you use expressions in an if conditional, you may omit the expression syntax (${{ }}) because GitHub automatically evaluates the if conditional as an expression.

### Why:

Closes #17867 

### What's being changed:

From:

```yml
steps:
  - uses: actions/hello-world-javascript-action@v1.1
    if: ${{ <expression> }}
```

to:

```yml
steps:
  - uses: actions/hello-world-javascript-action@v1.1
    if: <expression>

```

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
