### PR TITLE
Add reason to unverify work mail

### DIFF
--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-personal-account-settings/best-practices-for-leaving-your-company.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-personal-account-settings/best-practices-for-leaving-your-company.md
@@ -15,7 +15,7 @@ shortTitle: Leaving your company
 ---
 Before you leave your company, make sure you update the following information in your personal account:
 
-- Unverify your company email address by [deleting it in your Email settings](/articles/changing-your-primary-email-address). You can then re-add it without verifying to keep any associated commits linked to your account.
+- Unverify your company email address by [deleting it in your Email settings](/articles/changing-your-primary-email-address). You can then re-add it without verifying to keep any associated commits linked to your account. Unverified email addresses cannot receive further notifications or be used to reset your password though.
 - [Change your primary email address](/articles/changing-your-primary-email-address) from your company email to your personal email.
 {% ifversion fpt or ghec %}
 - [Verify your new primary email address](/articles/verifying-your-email-address).


### PR DESCRIPTION
### Why:

Explain the reason why it is a good thing to remove the verified work mail address and then add it again without verifying it.

Otherwise the reader asks himself „why should I do this step? This seems superfluous.“.

Closes #17991

### What's being changed:

Add the reason into this paragraph straight away.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")
