### PR TITLE
Remove the "not maintained" warning

### DIFF
--- a/content/rest/overview/libraries.md
+++ b/content/rest/overview/libraries.md
@@ -24,12 +24,6 @@ topics:
   </div>
 </div>
 
-{% warning %}
-
-Warning: As of late October 2021, the offical Octokit libraries are not currently maintained. For more information, see [this discussion in the octokit.js repository](https://github.com/octokit/octokit.js/discussions/620).
-
-{% endwarning %}
-
 # Third-party libraries
 
 ### Clojure


### PR DESCRIPTION
### Why:

On [https://github.com/octokit/octokit.js/discussions/620#discussioncomment-2144643](Feb 9 it was mentioned that a dedicated SDK team is being built), and since then there have been some commits (see e.g. https://github.com/octokit/octokit.js/commits/main)

### What's being changed:

Removes this warning:

<img width="742" alt="image" src="https://user-images.githubusercontent.com/66961/169998503-6ae8296f-4da1-4e78-8b06-f23b7cf62aba.png">

from https://docs.github.com/en/rest/overview/libraries

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
