### PR TITLE
Example of Python Iteration over pages

### DIFF
--- a/content/rest/guides/traversing-with-pagination.md
+++ b/content/rest/guides/traversing-with-pagination.md
@@ -84,6 +84,23 @@ and more importantly, `rel="prev"` lets you know the page number of the previous
 page. Using this information, you could construct some UI that lets users jump
 between the first, previous, next, or last list of results in an API call.
 
+### Example of Python Iteration over pages
+
+While getting data from GitHub and the amount of pages is unknown, the `reqeusts` can
+be `while` until the `next` will end, and we'll reach the last page and only `prev` and `first` will
+show in the headers.
+
+```python
+import requests
+
+url = "https://api.github.com/XXXX?simple=yes&per_page=100&page=1"
+res=requests.get(url,headers={"Authorization": git_token})
+repos=res.json()
+while 'next' in res.links.keys():
+  res=requests.get(res.links['next']['url'],headers={"Authorization": git_token})
+  repos.extend(res.json())
+```
+
 ### Changing the number of items received
 
 By passing the `per_page` parameter, you can specify how many items you want


### PR DESCRIPTION
This was very helpful if I would just see the example here instead of writing/inventing something, and finding in StackOverflow a better solution and re-write my solution :)
I hope this will be merged and help others who struggle with GitHub API automation.


### Why:

just helpful information for the documentation that might help other developers use the API.

### What's being changed:

Added  an example in the paging API documentation to help developers work with their code

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
