### PR TITLE
Fix Tool Picker typo (Dekstop -> Desktop)

### DIFF
--- a/lib/all-tools.js
+++ b/lib/all-tools.js
@@ -4,7 +4,7 @@ export const allTools = {
   cli: 'GitHub CLI',
   codespaces: 'Codespaces',
   curl: 'cURL',
-  desktop: 'Dekstop',
+  desktop: 'Desktop',
   importer_cli: 'GitHub Enterprise Importer CLI',
   graphql: 'GraphQL API',
   powershell: 'PowerShell',


### PR DESCRIPTION
This fixes a minor typo that I discovered here: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository

### Why:

Fixes a typo ("Dekstop") in https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository.

### What's being changed:

<img width="1440" alt="Screen Shot 2022-06-07 at 11 25 29 AM" src="https://user-images.githubusercontent.com/49724173/172419734-43abd40e-a9bc-4332-83f8-ab1f601395c3.png">

See: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository

This PR updates the "Dekstop" string to "Desktop".

### Check off the following:

- [ ] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
