### PR TITLE
Fix documentation about mapping container port to a random free host port

### DIFF
--- a/content/actions/using-containerized-services/about-service-containers.md
+++ b/content/actions/using-containerized-services/about-service-containers.md
@@ -83,12 +83,12 @@ You can map service containers ports to the Docker host using the `ports` keywor
 |------------------|--------------|
 | `8080:80` |	Maps TCP port 80 in the container to port 8080 on the Docker host. |
 | `8080:80/udp` |	Maps UDP port 80 in the container to port 8080 on the Docker host. |
-| `8080/udp`	| Map a randomly chosen UDP port in the container to UDP port 8080 on the Docker host. |
-| `8080` | Map TCP port 8080 of the container to random free port on the Docker host. |
+| `8080/udp`	| Maps a randomly chosen UDP port in the container to UDP port 8080 on the Docker host. |
+| `8080` | Maps TCP port 8080 of the container to random free port on the Docker host. |
 
 When you map ports using the `ports` keyword, {% data variables.product.prodname_dotcom %} uses the `--publish` command to publish the container’s ports to the Docker host. For more information, see "[Docker container networking](https://docs.docker.com/config/containers/container-networking/)" in the Docker documentation.
 
-When you specify the Docker container port but not the host port, the host port is randomly assigned to a free port. {% data variables.product.prodname_dotcom %} sets the assigned host port in the service container context. For example, for a `redis` service container, if you configured the Docker host port 5432, you can access the corresponding host port using the `job.services.redis.ports[5432]` context. For more information, see "[Contexts](/actions/learn-github-actions/contexts#job-context)."
+When you specify the Docker container port but not the host port, the host port is randomly assigned to a free port. {% data variables.product.prodname_dotcom %} sets the assigned host port in the service container context. For example, for a `redis` service container, if you configured the Docker container port 5432, you can access the corresponding host port using the `job.services.redis.ports[5432]` context. For more information, see "[Contexts](/actions/learn-github-actions/contexts#job-context)."
 
 ### Example mapping Redis ports
 

--- a/content/actions/using-containerized-services/about-service-containers.md
+++ b/content/actions/using-containerized-services/about-service-containers.md
@@ -84,10 +84,11 @@ You can map service containers ports to the Docker host using the `ports` keywor
 | `8080:80` |	Maps TCP port 80 in the container to port 8080 on the Docker host. |
 | `8080:80/udp` |	Maps UDP port 80 in the container to port 8080 on the Docker host. |
 | `8080/udp`	| Map a randomly chosen UDP port in the container to UDP port 8080 on the Docker host. |
+| `8080` | Map TCP port 8080 of the container to random free port on the Docker host. |
 
 When you map ports using the `ports` keyword, {% data variables.product.prodname_dotcom %} uses the `--publish` command to publish the container’s ports to the Docker host. For more information, see "[Docker container networking](https://docs.docker.com/config/containers/container-networking/)" in the Docker documentation.
 
-When you specify the Docker host port but not the container port, the container port is randomly assigned to a free port. {% data variables.product.prodname_dotcom %} sets the assigned container port in the service container context. For example, for a `redis` service container, if you configured the Docker host port 5432, you can access the corresponding container port using the `job.services.redis.ports[5432]` context. For more information, see "[Contexts](/actions/learn-github-actions/contexts#job-context)."
+When you specify the Docker container port but not the host port, the host port is randomly assigned to a free port. {% data variables.product.prodname_dotcom %} sets the assigned host port in the service container context. For example, for a `redis` service container, if you configured the Docker host port 5432, you can access the corresponding host port using the `job.services.redis.ports[5432]` context. For more information, see "[Contexts](/actions/learn-github-actions/contexts#job-context)."
 
 ### Example mapping Redis ports
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

I found a mistake in the docs about port mapping in the services section of the Actions documentation. This PR corrects it.

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The documentation page is changed.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

