### PR TITLE
Different defaults with and without protection

### DIFF
--- a/content/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches.md
+++ b/content/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches.md
@@ -29,6 +29,8 @@ topics:
 
 You can enforce certain workflows or requirements before a collaborator can push changes to a branch in your repository, including merging a pull request into the branch, by creating a branch protection rule.
 
+Simply setting branch protection will set certain "default" behavior. For example, normally force pushes are allowed (git push --force). However, by enabling branch protection, then forced pushes are not allowed (allow_force_pushes = false, by default) unless explicitly re-enabled ( = true).
+
 By default, each branch protection rule disables force pushes to the matching branches and prevents the matching branches from being deleted. You can optionally disable these restrictions and enable additional branch protection settings.
 
 By default, the restrictions of a branch protection rule don't apply to people with admin permissions to the repository. You can optionally choose to include administrators, too.


### PR DESCRIPTION
Out of the box, (git push --force) is allowed "by default". With branch protection, it's not allowed "by default". These distinctions are not obvious because of two "default" contexts.

I struggle to explain that here and in text, but I think it's important to note, somehow. It certainly confused me.

Perhaps better would be a table of default values.
Columns to include: "default git", "default github", "default branch protection", "default [other contexts]";
and rows including all the different settings such as "enforce_admins", "allows_force_pushes", "allows_deletions", etc.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Why? I was confused by what "default" means. We configure our hundreds of repositories via Terraform. It seemed to me there was no point in setting "default" values to their "default" state. However, it was not clear to me that "default" has a different meaning based on context (with or without branch protection).

Closes [18936] "Explain different default contexts (fx with and without branch protection)"
https://github.com/github/docs/issues/18936


### What's being changed (if available, include any code snippets, screenshots, or gifs):

I offer an short paragraph, although I expect a side note box; or a table of settings, defaults, overrides; or rewording of extant paragraphs are likely better changes. 

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

