### PR TITLE
Fix token name for publishing GH packages

### DIFF
--- a/content/actions/publishing-packages/publishing-nodejs-packages.md
+++ b/content/actions/publishing-packages/publishing-nodejs-packages.md
@@ -144,13 +144,13 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          NPM_AUTH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 ```
 
 The `setup-node` action creates an *.npmrc* file on the runner. When you use the `scope` input to the `setup-node` action, the *.npmrc* file includes the scope prefix. By default, the `setup-node` action sets the scope in the *.npmrc* file to the account that contains that workflow file.
 
 ```ini
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}
 @octocat:registry=https://npm.pkg.github.com
 always-auth=true
 ```


### PR DESCRIPTION
### Why:
The name of the token seems wrong as the original key results always in error saying it cannot find a token inside the workflow. This example is not reproducible.

Discussed [here](https://github.com/actions/setup-node/issues/81#issuecomment-623018474)

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Changing the `NODE_AUTH_TOKEN` to `NPM_AUTH_TOKEN` logs in the workflow successfully.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

