### PR TITLE
Add context about how contribute page is created

### DIFF
--- a/content/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors.md
+++ b/content/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors.md
@@ -15,7 +15,7 @@ topics:
 shortTitle: Contributor guidelines
 ---
 ## About contributing guidelines
-To help your project contributors do good work, you can add a file with contribution guidelines to your project repository's root, `docs`, or `.github` folder. When someone opens a pull request or creates an issue, they will see a link to that file. The link to the contributing guidelines also appears on your repository's `contribute` page. For an example of a `contribute` page, see [github/docs/contribute](https://github.com/github/docs/contribute). 
+To help your project contributors do good work, you can add a file with contribution guidelines to your project repository's root, `docs`, or `.github` folder. When someone opens a pull request or creates an issue, they will see a link to that file. The link to the contributing guidelines also appears on your repository's `contribute` page, which lists issues labeled `good first issue`. For an example of a `contribute` page, see [github/docs/contribute](https://github.com/github/docs/contribute). 
 
 ![contributing-guidelines](/assets/images/help/pull_requests/contributing-guidelines.png)
 


### PR DESCRIPTION
I didn't know about the `contribute` page and was wondering how to create it. Took me a bunch of searching to finally find the info at https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels. 

I think this context helps keep people on this page and focus on the point that the contributing guidelines show up on the contribute page.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes [18952](https://github.com/github/docs/issues/18952)

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

The PR adds a clause about what creates the contribute page to this sentence: 

> The link to the contributing guidelines also appears on your repository's contribute page. For an example of a contribute page, see [github/docs/contribute](https://github.com/github/docs/contribute).

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

