### PR TITLE
Remove unneeded quotation mark

### DIFF
--- a/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors.md
+++ b/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors.md
@@ -62,7 +62,7 @@ You can use {% data variables.product.prodname_desktop %} to create a commit wit
   >
   >
   Co-authored-by: <em>name</em> &lt;<em>name@example.com</em>&gt;
-  Co-authored-by: <em>another-name</em> &lt;<em>another-name@example.com</em>&gt;"
+  Co-authored-by: <em>another-name</em> &lt;<em>another-name@example.com</em>&gt;
   ```
 
 The new commit and message will appear on {% data variables.product.product_location %} the next time you push. For more information, see "[Pushing changes to a remote repository](/github/getting-started-with-github/pushing-commits-to-a-remote-repository/)."


### PR DESCRIPTION
### Why

I noticed an extra quotation mark in the example while reading the docs. Here's what the example looks like currently (before this PR)

<img width="690" alt="Screen Shot 2022-07-08 at 2 57 08 PM" src="https://user-images.githubusercontent.com/5618806/178075477-8bce25c3-ae22-43e9-adff-2319b982df7b.png">

### What's being changed

I've removed the extra quotation mark:

<img width="685" alt="Screen Shot 2022-07-08 at 3 06 48 PM" src="https://user-images.githubusercontent.com/5618806/178076224-77cd46ca-3987-44e0-995e-7f82be51bb83.png">

### Check off the following

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

