### PR TITLE
CHanging breaked link to working

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -6,7 +6,7 @@ links:
     description: Docs Engineering observability docs
     kind: docs
     service: docs-internal
-    url: https://github.com/github/docs-engineering/blob/main/docs/observability/docs.github.com.md
+    url: https://github.com/microsoft/code-with-engineering-playbook/blob/main/docs/observability/README.md
   - name: Datadog dashboard
     description: Production Datadog dashboard
     kind: dashboard


### PR DESCRIPTION
There was a link to GitHub docs that was not working. I changed it to another docs link that is similar to the given topic.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes [issue link]

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [x] This pull request impacts the contribution experience
  - [x] I have added the 'writer impact' label
  - [x] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

