### PR TITLE
remove redundant space in curl code examples which prevents copying and using the sample as-is

### DIFF
--- a/components/lib/get-rest-code-samples.ts
+++ b/components/lib/get-rest-code-samples.ts
@@ -42,7 +42,7 @@ export function getShellExample(operation: Operation, codeSample: CodeSample) {
 
   const args = [
     operation.verb !== 'get' && `-X ${operation.verb.toUpperCase()}`,
-    `-H "Accept: ${defaultAcceptHeader}" \\ \n  -H "Authorization: token <TOKEN>"`,
+    `-H "Accept: ${defaultAcceptHeader}" \\\n  -H "Authorization: token <TOKEN>"`,
     `${operation.serverUrl}${requestPath}`,
     requestBodyParams,
   ].filter(Boolean)


### PR DESCRIPTION
### Why:
* Go to any page showing a code sample (e.g. [this page](https://docs.github.com/en/rest/collaborators/invitations#list-repository-invitations-for-the-authenticated-user))
* Click on the "cURL" tab
* Copy the sample (either by clicking on the copy button, or selecting and copying the code sample)
* Paste the code sample in a terminal and run it

#### Expected
* cURL command will run and return an error (e.g. bad credentials)

#### Actual
* cURL command does not run properly and is split to 2 separate commands:
```
$ curl \
>   -H "Accept: application/vnd.github+json" \ 
curl: (3) URL using bad/illegal format or missing URL
$   -H "Authorization: token <TOKEN>" \
>   https://api.github.com/user/repository_invitations
-H: command not found
```

### What's being changed

Removed redundant space before the newline

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

