### PR TITLE
Add option type for Manually triggered workflows

### DIFF
--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -99,7 +99,7 @@ For more information, see "[Reusing workflows](/actions/learn-github-actions/reu
 
 #### `on.workflow_call.inputs.<input_id>.type`
 
-Required if input is defined for the `on.workflow_call` keyword. The value of this parameter is a string specifying the data type of the input. This must be one of: `boolean`, `number`, or `string`.
+Required if input is defined for the `on.workflow_call` keyword. The value of this parameter is a string specifying the data type of the input. This must be one of: `boolean`, `number`, `string`, `environment` or `choice`.
 
 ### `on.workflow_call.outputs`
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes [issue link]

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
According to the [blogspot](https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/)  there are other types of manual inputs that don't exist in the documentation. (`options` and `environment`)
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

