### PR TITLE
adding note about team sync

### DIFF
--- a/content/organizations/organizing-members-into-teams/synchronizing-a-team-with-an-identity-provider-group.md
+++ b/content/organizations/organizing-members-into-teams/synchronizing-a-team-with-an-identity-provider-group.md
@@ -77,6 +77,8 @@ Once user provisioning for {% data variables.product.product_name %} is configur
 
 When you connect an IdP group to a {% data variables.product.product_name %} team, all users in the group are automatically added to the team. {% ifversion ghae %}Any users who were not already members of the parent organization members are also added to the organization.{% endif %}
 
+IdP groups cannot be assigned to a GitHub team that has child teams associated.
+
 {% data reusables.profile.access_org %}
 {% data reusables.user-settings.access_org %}
 {% data reusables.organizations.specific_team %}


### PR DESCRIPTION
👋🏽 

### Why:

While working through [these instructions](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-saml-single-sign-on-for-your-organization/managing-team-synchronization-for-your-organization) and setting up our Okta instance with GitHub, we found that the IdP group assignment option does not appear for teams that have a child team assigned. here is a screenshot of the option that is not available for parent teams:

<img width="394" alt="image" src="https://user-images.githubusercontent.com/21270492/183973720-09ca013a-4273-485c-a0da-d202ee5eab29.png">


### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adding a quick note to make users aware of this requirement.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

