### PR TITLE
Fix incorrect repository URL for webhook push

### DIFF
--- a/lib/webhooks/static/dotcom/push.payload.json
+++ b/lib/webhooks/static/dotcom/push.payload.json
@@ -64,7 +64,7 @@
     "html_url": "https://github.com/Codertocat/Hello-World",
     "description": null,
     "fork": false,
-    "url": "https://github.com/Codertocat/Hello-World",
+    "url": "https://api.github.com/repos/Codertocat/Hello-World",
     "forks_url": "https://api.github.com/repos/Codertocat/Hello-World/forks",
     "keys_url": "https://api.github.com/repos/Codertocat/Hello-World/keys{/key_id}",
     "collaborators_url": "https://api.github.com/repos/Codertocat/Hello-World/collaborators{/collaborator}",


### PR DESCRIPTION
### Why:
The current URL is incorrect

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The repository URL in the push webhook payload

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [X] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

