### PR TITLE
Documentation on how to use the release trigger is wrong and confusing.

### DIFF
--- a/content/actions/using-workflows/events-that-trigger-workflows.md
+++ b/content/actions/using-workflows/events-that-trigger-workflows.md
@@ -1067,16 +1067,17 @@ on:
 
 {% endnote %}
 
-{% note %}
-
-**Note:** The `prereleased` type will not trigger for pre-releases published from draft releases, but the `published` type will trigger. If you want a workflow to run when stable *and* pre-releases publish, subscribe to `published` instead of `released` and `prereleased`.
-
-{% endnote %}
-
 Runs your workflow when release activity in your repository occurs. For information about the release APIs, see "[Release](/graphql/reference/objects#release)" in the GraphQL API documentation or "[Releases](/rest/reference/releases)" in the REST API documentation.
 
-For example, you can run a workflow when a release has been `published`.
+For example, you can run a workflow whenever a release or a prerelease is published, including if you change a prerelease to a release.
 
+```yaml
+on:
+  release:
+    types: [released, prereleased]
+```
+
+If want to only run a workflow the first time a prerelease or a release is published you do as follows:
 ```yaml
 on:
   release:


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The documentation does not correctly describe how to make a release that triggers when you publish a release or change the toggle to prerelease and update the release. To do this, you need to use both the `released` and `prereleased` option. This contradicts what was written in the deleted note.

The toggle mentioned above is this one:

<img width="441" alt="Screenshot 2022-08-19 at 11 40 45" src="https://user-images.githubusercontent.com/26203420/185592292-f814094c-39a2-4680-b84e-52649c8d7d41.png">


<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

- Deleted note that says you should use `published` to trigger when a prerelease or a release is happening. This is wrong. With `published` it only triggers the first time a release is published.
- Added info on how to trigger workflows with release in typical scenarios, e.g., when you want to trigger each time a prerelease or release is published or edited from prerelease to release or vice-versa.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

