### PR TITLE
Mention that `GITHUB_*` and `RUNNER_*` can't be set using `GITHUB_ENV` (but that `CI` can be)

### DIFF
--- a/content/actions/learn-github-actions/environment-variables.md
+++ b/content/actions/learn-github-actions/environment-variables.md
@@ -124,6 +124,8 @@ Any new environment variables you set that point to a location on the filesystem
 
 The default environment variables that {% data variables.product.prodname_dotcom %} sets are available to every step in a workflow. 
 
+{% data reusables.actions.environment-variables-are-fixed %}
+
 We strongly recommend that actions use environment variables to access the filesystem rather than using hardcoded file paths. {% data variables.product.prodname_dotcom %} sets environment variables for actions to use in all runner environments.
 
 | Environment variable | Description |

--- a/content/actions/learn-github-actions/environment-variables.md
+++ b/content/actions/learn-github-actions/environment-variables.md
@@ -124,7 +124,7 @@ Any new environment variables you set that point to a location on the filesystem
 
 The default environment variables that {% data variables.product.prodname_dotcom %} sets are available to every step in a workflow. 
 
-{% data reusables.actions.environment-variables-are-fixed %}
+{% data reusables.actions.environment-variables-are-fixed %} For more information about setting environment variables, see "[AUTOTITLE](/actions/learn-github-actions/variables#defining-environment-variables-for-a-single-workflow)" and "[AUTOTITLE](/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable)."
 
 We strongly recommend that actions use environment variables to access the filesystem rather than using hardcoded file paths. {% data variables.product.prodname_dotcom %} sets environment variables for actions to use in all runner environments.
 

--- a/content/actions/using-workflows/workflow-commands-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-commands-for-github-actions.md
@@ -580,6 +580,8 @@ echo "{environment_variable_name}={value}" >> $GITHUB_ENV
 
 You can make an environment variable available to any subsequent steps in a workflow job by defining or updating the environment variable and writing this to the `GITHUB_ENV` environment file. The step that creates or updates the environment variable does not have access to the new value, but all subsequent steps in a job will have access. The names of environment variables are case-sensitive, and you can include punctuation. For more information, see "[Environment variables](/actions/learn-github-actions/environment-variables)."
 
+{% data reusables.actions.environment-variables-are-fixed %}
+
 ### Example
 
 {% bash %}

--- a/content/actions/using-workflows/workflow-commands-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-commands-for-github-actions.md
@@ -580,7 +580,7 @@ echo "{environment_variable_name}={value}" >> $GITHUB_ENV
 
 You can make an environment variable available to any subsequent steps in a workflow job by defining or updating the environment variable and writing this to the `GITHUB_ENV` environment file. The step that creates or updates the environment variable does not have access to the new value, but all subsequent steps in a job will have access. The names of environment variables are case-sensitive, and you can include punctuation. For more information, see "[Environment variables](/actions/learn-github-actions/environment-variables)."
 
-{% data reusables.actions.environment-variables-are-fixed %}
+{% data reusables.actions.environment-variables-are-fixed %} For more information about the default environment variables, see "[AUTOTITLE](/actions/learn-github-actions/environment-variables#default-environment-variables)."
 
 ### Example
 

--- a/data/reusables/actions/environment-variables-are-fixed.md
+++ b/data/reusables/actions/environment-variables-are-fixed.md
@@ -1,0 +1,4 @@
+
+It is not possible nor advisable to re-set any of the default environment variables (especially those named `GITHUB_*` and `RUNNER_*`) listed in [default environment variables](/actions/learn-github-actions/environment-variables#default-environment-variables) using `GITHUB_ENV`.
+
+At the time of this note, the `CI` variable could be overwritten, but that is not guaranteed.

--- a/data/reusables/actions/environment-variables-are-fixed.md
+++ b/data/reusables/actions/environment-variables-are-fixed.md
@@ -1,4 +1,2 @@
 
-It is not possible nor advisable to re-set any of the default environment variables (especially those named `GITHUB_*` and `RUNNER_*`) listed in [default environment variables](/actions/learn-github-actions/environment-variables#default-environment-variables) using `GITHUB_ENV`.
-
-At the time of this note, the `CI` variable could be overwritten, but that is not guaranteed.
+It is not possible to overwrite the value of the default environment variables named `GITHUB_*` and `RUNNER_*`. Currently it is possible to overwrite the value of the `CI` variable. However, it's not guaranteed that this will always be possible. 


### PR DESCRIPTION
### Why:

Closes #19626

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adding note about default vars immutability.

https://docs-20069-a70e64.preview.ghdocs.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
![image](https://user-images.githubusercontent.com/2119212/186051226-e401d914-65c2-48e2-af2f-e2c08c108a17.png)

https://docs-20069-a70e64.preview.ghdocs.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable

![image](https://user-images.githubusercontent.com/2119212/186051302-edcf1d9c-7a84-46d5-bcd5-612cf3445782.png)

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

