### PR TITLE
GHCR: add how to create `~/.docker/config.json` without using `docker` CLI

### DIFF
--- a/data/reusables/package_registry/authenticate-to-container-registry-steps.md
+++ b/data/reusables/package_registry/authenticate-to-container-registry-steps.md
@@ -22,3 +22,12 @@
   > Login Succeeded
   ```
   {% endraw %}
+
+  The `~/.docker/config.json` credential file can be also manually created without using the `docker` CLI:
+  {% raw %}
+  ```shell
+  $ mkdir -p ~/.docker
+  $ echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"$(echo -n $USERNAME:$CR_PAT | base64)\"}}}" >~/.docker/config.json
+  ```
+  {% endraw %}
+  This is useful for third-party container tools that recognize `~/.docker/config.json`.


### PR DESCRIPTION
This is useful for third-party container tools such as ORAS (https://oras.land/)


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Because `docker` CLI isn't always installed.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Add how to create `~/.docker/config.json` without using `docker` CLI

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

- - -

Preview: https://docs-21017-d78d34.preview.ghdocs.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry