### PR TITLE
chore: fix render syntax

### DIFF
--- a/data/reusables/community/issue-forms-sample.md
+++ b/data/reusables/community/issue-forms-sample.md
@@ -52,7 +52,7 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: shell
+      render: console
   - type: checkboxes
     id: terms
     attributes:


### PR DESCRIPTION
It looks like `shell` is no longer a valid value from the `render` property. When I use it in a YAML template, I get a "value is not accepted" error in VSCode. I scrolled through the list of possible values, and the closest one seems to be `console`.

![vscode error dialog showing the value is not accepted error](https://user-images.githubusercontent.com/10350960/193460005-c50a174f-8eae-4f61-8a5f-09081a2e59f3.png)

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

