### PR TITLE
fix: do not include `$` in command

### DIFF
--- a/data/reusables/gpg/list-keys-with-note.md
+++ b/data/reusables/gpg/list-keys-with-note.md
@@ -1,7 +1,7 @@
 1. Use the `gpg --list-secret-keys --keyid-format=long` command to list the long form of the GPG keys for which you have both a public and private key. A private key is required for signing commits or tags.
 
    ```shell{:copy}
-   $ gpg --list-secret-keys --keyid-format=long
+   gpg --list-secret-keys --keyid-format=long
    ```
    
    {% note %}


### PR DESCRIPTION
Currently, the command includes the `$` terminal prompt. When you click the copy to clipboard button, this is also copied to the clipboard. The command will fail if you paste and hit return in the terminal. I have also seen this on a few other pages. I will have a look and open an issue to highlight those.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->

