### PR TITLE
Add warning about ssh hardware security keys.

### DIFF
--- a/content/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key.md
+++ b/content/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key.md
@@ -104,7 +104,7 @@ If you have multiple GPG keys, you need to tell Git which one to use.
 
 ## Telling Git about your SSH key
 
-You can use an existing SSH key to sign commits and tags, or generate a new one specifically for signing. For more information, see "[Generating a new SSH key and adding it to the ssh-agent](/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)."
+You can use an existing SSH key to sign commits and tags, or generate a new one specifically for signing. For more information, see "[Generating a new SSH key and adding it to the ssh-agent](/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)." You can't use a hardware security key for signing commits.
 
 {% data reusables.gpg.ssh-git-version %}
 


### PR DESCRIPTION


### Why:

Closes [issue link]

I've tried signing commits with an hardware generated ssh ed25519 key and I get an error message. Maybe this is planned to be supported, but as of git 2.38, it doesn't seem to work. See https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key-for-a-hardware-security-key for what I'm talking about.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Just adding a sentence.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
