### PR TITLE
Update searching-for-repositories.md

### DIFF
--- a/content/search-github/searching-on-github/searching-for-repositories.md
+++ b/content/search-github/searching-on-github/searching-for-repositories.md
@@ -27,7 +27,7 @@ With the `in` qualifier you can restrict your search to the repository name, rep
 
 | Qualifier  | Example
 | ------------- | -------------
-| `in:name` | [**jquery in:name**](https://github.com/search?q=jquery+in%3Aname&type=Repositories) matches repositories with "jquery" in the repository name.
+| `in:name` | [**jquery in:name**](https://github.com/search?q=jquery+in%3Aname&type=Repositories) matches repositories that start with "jquery" in the repository name.
 | `in:description`  | [**jquery in:name,description**](https://github.com/search?q=jquery+in%3Aname%2Cdescription&type=Repositories) matches repositories with "jquery" in the repository name or description.
 | `in:topics`  | [**jquery in:topics**](https://github.com/search?q=jquery+in%3Atopics&type=Repositories) matches repositories labeled with "jquery" as a topic.
 | `in:readme` | [**jquery in:readme**](https://github.com/search?q=jquery+in%3Areadme&type=Repositories) matches repositories mentioning "jquery" in the repository's README file.


### PR DESCRIPTION
The search `jquery in:name` will only find repositories that **start** with the search term jquery, rather than repos that contain this search term **in** their name. 

https://github.com/search?q=jquery+in%3Aname   (122,150 repository results)

For example if one changes the search to `query in:name`, i.e. drop the j, then if the original description in this file was correct it should find more repos. However as one can see by running this query

https://github.com/search?q=query+in%3Aname 

you get less results, 81,119. This is because the examination is not actually searching if the word "query" is **in** the name but rather does the repo **start** with the word "query".

Just to prove the point lets search for repos that have "_uery_" in their names, `uery in:name`. If the code really was searching for this search term IN the name it should at least find as many results as in  `jquery in:name`.

https://github.com/search?q=uery+in%3Aname

We only get 8.



<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes [issue link]

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
