### PR TITLE
Align handling-plan-cancellations with billing-customers

### DIFF
--- a/content/developers/github-marketplace/using-the-github-marketplace-api-in-your-app/handling-plan-cancellations.md
+++ b/content/developers/github-marketplace/using-the-github-marketplace-api-in-your-app/handling-plan-cancellations.md
@@ -21,12 +21,13 @@ If a customer chooses to cancel a {% data variables.product.prodname_marketplace
 
 ## Step 2. Deactivating customer accounts
 
-When a customer cancels a free or paid plan, your app must perform these steps to complete cancellation:
+When a customer cancels a plan, you must:
 
-1. Deactivate the account of the customer who cancelled their plan.
-1. Revoke the OAuth token your app received for the customer.
-1. If your app is an OAuth App, remove all webhooks your app created for repositories.
-1. Remove all customer data within 30 days of receiving the `cancelled` event.
+* Automatically downgrade them to the free plan, if it exists.
+
+    When a customer cancels a GitHub Marketplace subscription, GitHub does not automatically uninstall the app, so the customer can expect that free features will continue to function.
+
+* Enable them to upgrade the plan through GitHub if they would like to continue the plan at a later time.
 
 {% note %}
 


### PR DESCRIPTION

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

https://docs.github.com/en/developers/github-marketplace/selling-your-app-on-github-marketplace/billing-customers#downgrades-and-cancellations has slightly different behaviour specified for cancelling than https://docs.github.com/en/developers/github-marketplace/using-the-github-marketplace-api-in-your-app/handling-plan-cancellations#step-2-deactivating-customer-accounts

This commit aligns the two so they say the same thing. It's possible this should be the other way around.

I opened a ticket at https://support.github.com/ticket/personal/0/1792415 about this too to clarify this.

Closes [issue link]

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Matching the cancellation behaviour between two docs.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
