### PR TITLE
Update differences-between-github-apps-and-oauth-apps.md

### DIFF
--- a/content/developers/apps/getting-started-with-apps/differences-between-github-apps-and-oauth-apps.md
+++ b/content/developers/apps/getting-started-with-apps/differences-between-github-apps-and-oauth-apps.md
@@ -18,7 +18,7 @@ shortTitle: GitHub Apps & OAuth Apps
 ---
 ## Who can install GitHub Apps and authorize OAuth Apps?
 
-You can install GitHub Apps in your personal account or organizations you own. If you have admin permissions in a repository, you can install GitHub Apps on organization accounts. If a GitHub App is installed in a repository and requires organization permissions, the organization owner must approve the application.
+You can install GitHub Apps in your personal account or organizations you own. If you have admin permissions in a repository, you can install GitHub Apps on the repository. If a GitHub App is installed in a repository and requires organization permissions, the organization owner must approve the application.
 
 {% data reusables.apps.app_manager_role %}
 


### PR DESCRIPTION
### Why:
>If you have admin permissions in a repository, you can install GitHub Apps on organization accounts.

That's not always true. To install GitHub Apps on organization accounts, you need to be an organization owner or acquired permission to do so.
I think "If you have admin permissions in a repository, you can install GitHub Apps **on the repository**" is more appropriate here, not organization accounts.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
