### PR TITLE
docs, enhancement: Updating docs to use `$GITHUB_OUTPUT` environment file

### DIFF
--- a/.github/workflows/check-broken-links-github-github.yml
+++ b/.github/workflows/check-broken-links-github-github.yml
@@ -92,7 +92,7 @@ jobs:
       - if: ${{ failure() && env.FREEZE != 'true' }}
         name: Get title for issue
         id: check
-        run: echo "::set-output name=title::$(head -1 broken_github_github_links.md)"
+        run: echo "title=$(head -1 broken_github_github_links.md)" >> $GITHUB_OUTPUT
       - if: ${{ failure() && env.FREEZE != 'true'}}
         name: Create issue from file
         id: github-github-broken-link-report

--- a/.github/workflows/check-broken-links-github-github.yml
+++ b/.github/workflows/check-broken-links-github-github.yml
@@ -92,7 +92,7 @@ jobs:
       - if: ${{ failure() && env.FREEZE != 'true' }}
         name: Get title for issue
         id: check
-        run: echo "title=$(head -1 broken_github_github_links.md)" >> $GITHUB_OUTPUT
+        run: echo "::set-output name=title::$(head -1 broken_github_github_links.md)"
       - if: ${{ failure() && env.FREEZE != 'true'}}
         name: Create issue from file
         id: github-github-broken-link-report

--- a/content/actions/creating-actions/creating-a-composite-action.md
+++ b/content/actions/creating-actions/creating-a-composite-action.md
@@ -31,32 +31,33 @@ Before you begin, you'll create a repository on {% ifversion ghae %}{% data vari
 
 1. Create a new public repository on {% data variables.location.product_location %}. You can choose any repository name, or use the following `hello-world-composite-action` example. You can add these files after your project has been pushed to {% data variables.product.product_name %}. For more information, see "[Create a new repository](/articles/creating-a-new-repository)."
 
-1. Clone your repository to your computer. For more information, see "[Cloning a repository](/articles/cloning-a-repository)."
+2. Clone your repository to your computer. For more information, see "[Cloning a repository](/articles/cloning-a-repository)."
 
-1. From your terminal, change directories into your new repository.
+3. From your terminal, change directories into your new repository.
 
-  ```shell
-  cd hello-world-composite-action
-  ```
+    ```shell
+    cd hello-world-composite-action
+    ```
 
-2. In the `hello-world-composite-action` repository, create a new file called `goodbye.sh`, and add the following example code:
+4. In the `hello-world-composite-action` repository, create a new file called `goodbye.sh`, and add the following example code:
 
-  ```bash
-  echo "Goodbye"
-  ```
+    ```bash
+    echo "Goodbye"
+    ```
 
-3. From your terminal, make `goodbye.sh` executable.
+5. From your terminal, make `goodbye.sh` executable.
 
-  ```shell
-  chmod +x goodbye.sh
-  ```
+    ```shell
+    chmod +x goodbye.sh
+    ```
 
-1. From your terminal, check in your `goodbye.sh` file.
-  ```shell
-  git add goodbye.sh
-  git commit -m "Add goodbye script"
-  git push
-  ```
+6. From your terminal, check in your `goodbye.sh` file.
+
+    ```shell
+    git add goodbye.sh
+    git commit -m "Add goodbye script"
+    git push
+    ```
 
 ## Creating an action metadata file
 
@@ -64,6 +65,7 @@ Before you begin, you'll create a repository on {% ifversion ghae %}{% data vari
 
     {% raw %}
     **action.yml**
+
     ```yaml
     name: 'Hello World'
     description: 'Greet someone'
@@ -82,33 +84,33 @@ Before you begin, you'll create a repository on {% ifversion ghae %}{% data vari
         - run: echo Hello ${{ inputs.who-to-greet }}.
           shell: bash
         - id: random-number-generator{% endraw %}
-{%- ifversion actions-save-state-set-output-envs %}
-          run: echo "random-number=$(echo $RANDOM)" >> $GITHUB_OUTPUT
-{%- else %}
-          run: echo "::set-output name=random-number::$(echo $RANDOM)"
-{%- endif %}{% raw %}
-          shell: bash
-        - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
-          shell: bash
-        - run: goodbye.sh
-          shell: bash
-    ```
+   {%- ifversion actions-save-state-set-output-envs %}
+             run: echo "random-number=$(echo $RANDOM)" >> $GITHUB_OUTPUT
+   {%- else %}
+             run: echo "::set-output name=random-number::$(echo $RANDOM)"
+   {%- endif %}{% raw %}
+             shell: bash
+           - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
+             shell: bash
+           - run: goodbye.sh
+             shell: bash
+       ```
     {% endraw %}
-  This file defines the `who-to-greet` input, maps the random generated number to the `random-number` output variable, and runs the `goodbye.sh` script. It also tells the runner how to execute the composite action.
+    This file defines the `who-to-greet` input, maps the random generated number to the `random-number` output variable, and runs the `goodbye.sh` script. It also tells the runner how to execute the composite action.
 
-  For more information about managing outputs, see "[`outputs` for a composite action](/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions)".
+    For more information about managing outputs, see "[`outputs` for a composite action](/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions)".
 
-  For more information about how to use `github.action_path`, see "[`github context`](/actions/reference/context-and-expression-syntax-for-github-actions#github-context)".
+    For more information about how to use `github.action_path`, see "[`github context`](/actions/reference/context-and-expression-syntax-for-github-actions#github-context)".
 
-1. From your terminal, check in your `action.yml` file.
+2. From your terminal, check in your `action.yml` file.
 
-  ```shell
-  git add action.yml
-  git commit -m "Add action"
-  git push
-  ```
+    ```shell
+    git add action.yml
+    git commit -m "Add action"
+    git push
+    ```
 
-1. From your terminal, add a tag. This example uses a tag called `v1`. For more information, see "[About actions](/actions/creating-actions/about-actions#using-release-management-for-actions)."
+3. From your terminal, add a tag. This example uses a tag called `v1`. For more information, see "[About actions](/actions/creating-actions/about-actions#using-release-management-for-actions)."
 
   ```shell
   git tag -a -m "Description of this release" v1
@@ -122,21 +124,22 @@ The following workflow code uses the completed hello world action that you made 
 Copy the workflow code into a `.github/workflows/main.yml` file in another repository, but replace `actions/hello-world-composite-action@v1` with the repository and tag you created. You can also replace the `who-to-greet` input with your name.
 
 **.github/workflows/main.yml**
-```yaml
-on: [push]
 
-jobs:
-  hello_world_job:
-    runs-on: ubuntu-latest
-    name: A job to say hello
-    steps:
-      - uses: {% data reusables.actions.action-checkout %}
-      - id: foo
-        uses: actions/hello-world-composite-action@v1
-        with:
-          who-to-greet: 'Mona the Octocat'
-      - run: echo random-number {% raw %}${{ steps.foo.outputs.random-number }}{% endraw %}
-        shell: bash
-```
+  ```yaml
+  on: [push]
+
+  jobs:
+    hello_world_job:
+      runs-on: ubuntu-latest
+      name: A job to say hello
+      steps:
+        - uses: {% data reusables.actions.action-checkout %}
+        - id: foo
+          uses: actions/hello-world-composite-action@v1
+          with:
+            who-to-greet: 'Mona the Octocat'
+        - run: echo random-number {% raw %}${{ steps.foo.outputs.random-number }}{% endraw %}
+          shell: bash
+  ```
 
 From your repository, click the **Actions** tab, and select the latest workflow run. The output should include: "Hello Mona the Octocat", the result of the "Goodbye" script, and a random number.

--- a/content/actions/creating-actions/creating-a-docker-container-action.md
+++ b/content/actions/creating-actions/creating-a-docker-container-action.md
@@ -76,24 +76,26 @@ Create a new `action.yml` file in the `hello-world-docker-action` directory you 
 
 {% raw %}
 **action.yml**
+
 ```yaml{:copy}
 # action.yml
 name: 'Hello World'
 description: 'Greet someone and record the time'
 inputs:
-  who-to-greet:  # id of input
-    description: 'Who to greet'
-    required: true
-    default: 'World'
+ who-to-greet:  # id of input
+   description: 'Who to greet'
+   required: true
+   default: 'World'
 outputs:
-  time: # id of output
-    description: 'The time we greeted you'
+ time: # id of output
+   description: 'The time we greeted you'
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
-  args:
-    - ${{ inputs.who-to-greet }}
+ using: 'docker'
+ image: 'Dockerfile'
+ args:
+   - ${{ inputs.who-to-greet }}
 ```
+
 {% endraw %}
 
 This metadata defines one `who-to-greet`  input and one `time` output parameter. To pass inputs to the Docker container, you should declare the input using `inputs` and pass the input in the `args` keyword. Everything you include in `args` is passed to the container, but for better discoverability for users of your action, we recommended using inputs.
@@ -104,16 +106,16 @@ This metadata defines one `who-to-greet`  input and one `time` output parameter.
 
 You can choose any base Docker image and, therefore, any language for your action. The following shell script example uses the `who-to-greet` input variable to print "Hello [who-to-greet]" in the log file.
 
-Next, the script gets the current time and sets it as an output variable that actions running later in a job can use. In order for {% data variables.product.prodname_dotcom %} to recognize output variables, you must {% ifversion actions-save-state-set-output-envs %}write them to the `$GITHUB_OUTPUT` environment file: `echo "<output name>=<value>" >> $GITHUB_OUTPUT`{% else %}use a workflow command in a specific syntax: `echo "::set-output name=<output name>::<value>"`{% endif %}. For more information, see "[Workflow commands for {% data variables.product.prodname_actions %}](/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter)."
+Next, the script gets the current time and sets it as an output variable that actions running later in a job can use. In order for {% data variables.product.prodname_dotcom %} to recognize output variables, you must {% ifversion actions-save-state-set-output-envs %}write them to the `$GITHUB_OUTPUT` environment file: `echo "{name}={value}" >> $GITHUB_OUTPUT`{% else %}use a workflow command in a specific syntax: `echo "::set-output name={output name}::{value}"`{% endif %}. For more information, see "[Workflow commands for {% data variables.product.prodname_actions %}](/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter)."
 
 1. Create a new `entrypoint.sh` file in the `hello-world-docker-action` directory.
 
-1. Add the following code to your `entrypoint.sh` file.
+2. Add the following code to your `entrypoint.sh` file.
 
-  **entrypoint.sh**
-  ```shell{:copy}
+**entrypoint.sh**
+
+```shell{:copy}
   #!/bin/sh -l
-
   echo "Hello $1"
   time=$(date)
 {%- ifversion actions-save-state-set-output-envs %}
@@ -121,17 +123,17 @@ Next, the script gets the current time and sets it as an output variable that ac
 {%- else %}
   echo "::set-output name=time::$time"
 {%- endif %}
-  ```
-  If `entrypoint.sh` executes without any errors, the action's status is set to `success`. You can also explicitly set exit codes in your action's code to provide an action's status. For more information, see "[Setting exit codes for actions](/actions/creating-actions/setting-exit-codes-for-actions)."
+```
 
+  If `entrypoint.sh` executes without any errors, the action's status is set to `success`. You can also explicitly set exit codes in your action's code to provide an action's status. For more information, see "[Setting exit codes for actions](/actions/creating-actions/setting-exit-codes-for-actions)."
 
 1. Make your `entrypoint.sh` file executable. Git provides a way to explicitly change the permission mode of a file so that it doesn’t get reset every time there is a clone/fork.
 
-  ```shell{:copy}
-  $ git update-index --chmod=+x entrypoint.sh
-  ```
+   ```shell{:copy}
+   $ git update-index --chmod=+x entrypoint.sh
+   ```
 
-1. Optionally, to check the permission mode of the file in the git index, run the following command.
+2. Optionally, to check the permission mode of the file in the git index, run the following command.
 
   ```shell{:copy}
   $ git ls-files --stage entrypoint.sh
@@ -153,29 +155,30 @@ In your `hello-world-docker-action` directory, create a `README.md` file that sp
 - An example of how to use your action in a workflow.
 
 **README.md**
-```markdown{:copy}
-# Hello world docker action
 
-This action prints "Hello World" or "Hello" + the name of a person to greet to the log.
+  ```markdown{:copy}
+  # Hello world docker action
 
-## Inputs
+  This action prints "Hello World" or "Hello" + the name of a person to greet to the log.
 
-## `who-to-greet`
+  ## Inputs
 
-**Required** The name of the person to greet. Default `"World"`.
+  ## `who-to-greet`
 
-## Outputs
+  **Required** The name of the person to greet. Default `"World"`.
 
-## `time`
+  ## Outputs
 
-The time we greeted you.
+  ## `time`
 
-## Example usage
+  The time we greeted you.
 
-uses: actions/hello-world-docker-action@{% ifversion actions-save-state-set-output-envs %}v2{% else %}v1{% endif %}
-with:
-  who-to-greet: 'Mona the Octocat'
-```
+  ## Example usage
+
+  uses: actions/hello-world-docker-action@{% ifversion actions-save-state-set-output-envs %}v2{% else %}v1{% endif %}
+  with:
+    who-to-greet: 'Mona the Octocat'
+  ```
 
 ## Commit, tag, and push your action to {% data variables.product.product_name %}
 
@@ -201,50 +204,52 @@ Now you're ready to test your action out in a workflow. When an action is in a p
 The following workflow code uses the completed _hello world_ action in the public [`actions/hello-world-docker-action`](https://github.com/actions/hello-world-docker-action) repository. Copy the following workflow example code into a `.github/workflows/main.yml` file, but replace the `actions/hello-world-docker-action` with your repository and action name. You can also replace the `who-to-greet` input with your name. {% ifversion fpt or ghec %}Public actions can be used even if they're not published to {% data variables.product.prodname_marketplace %}. For more information, see "[Publishing an action](/actions/creating-actions/publishing-actions-in-github-marketplace#publishing-an-action)." {% endif %}
 
 **.github/workflows/main.yml**
-```yaml{:copy}
-on: [push]
 
-jobs:
-  hello_world_job:
-    runs-on: ubuntu-latest
-    name: A job to say hello
-    steps:
-      - name: Hello world action step
-        id: hello
-        uses: actions/hello-world-docker-action{% ifversion actions-save-state-set-output-envs %}v2{% else %}v1{% endif %}
-        with:
-          who-to-greet: 'Mona the Octocat'
-      # Use the output from the `hello` step
-      - name: Get the output time
-        run: echo "The time was {% raw %}${{ steps.hello.outputs.time }}"{% endraw %}
-```
+  ```yaml{:copy}
+  on: [push]
+
+  jobs:
+    hello_world_job:
+      runs-on: ubuntu-latest
+      name: A job to say hello
+      steps:
+        - name: Hello world action step
+          id: hello
+          uses: actions/hello-world-docker-action{% ifversion actions-save-state-set-output-envs %}v2{% else %}v1{% endif %}
+          with:
+            who-to-greet: 'Mona the Octocat'
+        # Use the output from the `hello` step
+        - name: Get the output time
+          run: echo "The time was {% raw %}${{ steps.hello.outputs.time }}"{% endraw %}
+  ```
 
 ### Example using a private action
 
 Copy the following example workflow code into a `.github/workflows/main.yml` file in your action's repository. You can also replace the `who-to-greet` input with your name. {% ifversion fpt or ghec %}This private action can't be published to {% data variables.product.prodname_marketplace %}, and can only be used in this repository.{% endif %}
 
 **.github/workflows/main.yml**
-```yaml{:copy}
-on: [push]
 
-jobs:
-  hello_world_job:
-    runs-on: ubuntu-latest
-    name: A job to say hello
-    steps:
-      # To use this repository's private action,
-      # you must check out the repository
-      - name: Checkout
-        uses: {% data reusables.actions.action-checkout %}
-      - name: Hello world action step
-        uses: ./ # Uses an action in the root directory
-        id: hello
-        with:
-          who-to-greet: 'Mona the Octocat'
-      # Use the output from the `hello` step
-      - name: Get the output time
-        run: echo "The time was {% raw %}${{ steps.hello.outputs.time }}"{% endraw %}
-```
+  ```yaml{:copy}
+  on: [push]
+
+  jobs:
+    hello_world_job:
+      runs-on: ubuntu-latest
+      name: A job to say hello
+      steps:
+        # To use this repository's private action,
+        # you must check out the repository
+        - name: Checkout
+          uses: {% data reusables.actions.action-checkout %}
+        - name: Hello world action step
+          uses: ./ # Uses an action in the root directory
+          id: hello
+          with:
+            who-to-greet: 'Mona the Octocat'
+        # Use the output from the `hello` step
+        - name: Get the output time
+          run: echo "The time was {% raw %}${{ steps.hello.outputs.time }}"{% endraw %}
+  ```
 
 From your repository, click the **Actions** tab, and select the latest workflow run. Under **Jobs** or in the visualization graph, click **A job to say hello**. You should see "Hello Mona the Octocat" or the name you used for the `who-to-greet` input and the timestamp printed in the log.
 

--- a/content/actions/using-workflows/workflow-commands-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-commands-for-github-actions.md
@@ -102,14 +102,14 @@ core.setOutput('SELECTED_COLOR', 'green');
 
 ### Example: Setting a value
 
-You can use the `set-output` command in your workflow to set the same value:
+You can use the `GITHUB_OUTPUT` environment file in your workflow to set the same value:
 
 {% bash %}
 
 {% raw %}
 ```yaml{:copy}
       - name: Set selected color
-        run: echo '::set-output name=SELECTED_COLOR::green'
+        run: echo "SELECTED_COLOR=green" >> $GITHUB_OUTPUT
         id: random-color-generator
       - name: Get color
         run: echo "The selected color is ${{ steps.random-color-generator.outputs.SELECTED_COLOR }}"
@@ -123,7 +123,7 @@ You can use the `set-output` command in your workflow to set the same value:
 {% raw %}
 ```yaml{:copy}
       - name: Set selected color
-        run: Write-Output "::set-output name=SELECTED_COLOR::green"
+        run: Write-Output "SELECTED_COLOR=green" >> $GITHUB_OUTPUT
         id: random-color-generator
       - name: Get color
         run: Write-Output "The selected color is ${{ steps.random-color-generator.outputs.SELECTED_COLOR }}"
@@ -164,7 +164,7 @@ The following table shows which toolkit functions are available within a workflo
 Sets an action's output parameter.
 
 ```{:copy}
-::set-output name={name}::{value}
+echo "{name}={value}" >> $GITHUB_OUTPUT
 ```
 
 Optionally, you can also declare output parameters in an action's metadata file. For more information, see "[Metadata syntax for {% data variables.product.prodname_actions %}](/articles/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions)."
@@ -176,7 +176,7 @@ You can escape multiline strings for setting an output parameter by creating an 
 {% bash %}
 
 ```bash{:copy}
-echo "::set-output name=action_fruit::strawberry"
+echo "action_fruit=strawberry" >> $GITHUB_OUTPUT
 ```
 
 {% endbash %}
@@ -184,7 +184,7 @@ echo "::set-output name=action_fruit::strawberry"
 {% powershell %}
 
 ```pwsh{:copy}
-Write-Output "::set-output name=action_fruit::strawberry"
+Write-Output "action_fruit=strawberry" >> $GITHUB_OUTPUT
 ```
 
 {% endpowershell %}
@@ -484,7 +484,7 @@ jobs:
 {% ifversion actions-save-state-set-output-envs %}{% else %}
 ## Echoing command outputs
 
-Enables or disables echoing of workflow commands. For example, if you use the `set-output` command in a workflow, it sets an output parameter but the workflow run's log does not show the command itself. If you enable command echoing, then the log shows the command, such as `::set-output name={name}::{value}`.
+Enables or disables echoing of workflow commands. For example, if you use the `$GITHUB_STATE` environment file, it sets an output parameter but the workflow run's log does not show the command itself. If you enable command echoing, then the log shows the command, such as `"{name}={value}" >> $GITHUB_OUTPUT`.
 
 ```{:copy}
 ::echo::on
@@ -508,11 +508,11 @@ jobs:
     steps:
       - name: toggle workflow command echoing
         run: |
-          echo '::set-output name=action_echo::disabled'
-          echo '::echo::on'
-          echo '::set-output name=action_echo::enabled'
-          echo '::echo::off'
-          echo '::set-output name=action_echo::disabled'
+          echo action_echo="disabled" >> $GITHUB_OUTPUT
+          echo "::echo::on"
+          echo action_echo="enabled" >> $GITHUB_OUTPUT
+          echo "::echo::off"
+          echo action_echo="disabled" >> $GITHUB_OUTPUT
 ```
 
 {% endbash %}
@@ -526,11 +526,11 @@ jobs:
     steps:
       - name: toggle workflow command echoing
         run: |
-          write-output "::set-output name=action_echo::disabled"
+          write-output action_echo="disabled" >> $GITHUB_OUTPUT
           write-output "::echo::on"
-          write-output "::set-output name=action_echo::enabled"
+          write-output action_echo="enabled" >> $GITHUB_OUTPUT
           write-output "::echo::off"
-          write-output "::set-output name=action_echo::disabled"
+          write-output action_echo="disabled" >> $GITHUB_OUTPUT
 ```
 
 {% endpowershell %}
@@ -538,11 +538,10 @@ jobs:
 The example above prints the following lines to the log:
 
 ```{:copy}
-::set-output name=action_echo::enabled
 ::echo::off
 ```
 
-Only the second `set-output` and `echo` workflow commands are included in the log because command echoing was only enabled when they were run. Even though it is not always echoed, the output parameter is set in all cases.
+Only the second `$GITHUB_OUTPUT` and `echo` workflow commands are included in the log because command echoing was only enabled when they were run. Even though it is not always echoed, the output parameter is set in all cases.
  
 {% endif %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes #21548 and general formatting of the docs 
Closes #21549 

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The [below](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action#writing-the-action-code) should be updated to align with the `$GITHUB_OUTPUT` examples in the [changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples)

>Next, the script gets the current time and sets it as an output variable that actions running later in a job can use. In order for {% data variables.product.prodname_dotcom %} to recognize output variables, you must {% ifversion actions-save-state-set-output-envs %}write them to the ```$GITHUB_OUTPUT``` environment file:```echo "<output name>=<value>" >> $GITHUB_OUTPUT`{% else %}use a workflow command in a specific syntax: ```echo "::set-output name=<output name>::<value>"```{% endif %}. For more information, see "[Workflow commands for {% data variables.product.prodname_actions %}](/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter)."

### Workflow commands for GitHub Actions

The [below](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) should be updated to align with the `$GITHUB_OUTPUT` examples in the [changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples)

> You can use the `set-output` command in your workflow to set the same value:

> run: echo '::set-output name=SELECTED_COLOR::green'

> run: Write-Output "::set-output name=SELECTED_COLOR::green"

> ::set-output name={name}::{value}

> Write-Output "::set-output name=action_fruit::strawberry"

> Enables or disables echoing of workflow commands. For example, if you use the `set-output` command in a workflow, it sets an output parameter but the workflow run's log does not show the command itself. If you enable command echoing, then the log shows the command, such as `::set-output name={name}::{value}`.

> echo '::set-output name=action_echo::disabled'
> echo '::echo::on'
> echo '::set-output name=action_echo::enabled'
> echo '::echo::off'
> echo '::set-output name=action_echo::disabled'

> write-output "::set-output name=action_echo::disabled"
> write-output "::echo::on"
> write-output "::set-output name=action_echo::enabled"
> write-output "::echo::off"
> write-output "::set-output name=action_echo::disabled"

> ::set-output name=action_echo::enabled

> Only the second `set-output` and `echo` workflow commands are included in the log because command echoing was only enabled when they were run. Even though it is not always echoed, the output parameter is set in all cases.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
