### PR TITLE
Changed {:copy} function to remove any preceding $ before copying to clipboard

### DIFF
--- a/lib/render-content/plugins/code-header.js
+++ b/lib/render-content/plugins/code-header.js
@@ -96,6 +96,8 @@ export default function addCodeHeader(node) {
   const btnIconHtml = octicons.copy.toSVG()
   const btnIconAst = parse(String(btnIconHtml), { sourceCodeLocationInfo: true })
   const btnIcon = fromParse5(btnIconAst, { file: btnIconHtml })
+  // if the command starts with a $, remove it from the value that is copied to the clipboard
+  const value = node.value[0] === '$' ? node.value.replace(/[$]/, '') : node.value
 
   // Need to create the header using Markdown AST utilities, to fit
   // into the Unified processor ecosystem.
@@ -118,7 +120,7 @@ export default function addCodeHeader(node) {
         'button',
         {
           class: ['js-btn-copy', 'btn', 'btn-sm', 'tooltipped', 'tooltipped-nw'],
-          'data-clipboard-text': node.value,
+          'data-clipboard-text': value,
           'aria-label': 'Copy code to clipboard',
         },
         btnIcon


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes #21645 

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

I have changed the function that copies the string to the clipboard when `{:copy}` is used in an .md file. 
The change will remove, if it is present, the preceding $ 

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
