### PR TITLE
Fix `git config` command syntax in "Telling Git about your signing key"

### DIFF
--- a/data/reusables/gpg/paste-ssh-public-key.md
+++ b/data/reusables/gpg/paste-ssh-public-key.md
@@ -1,3 +1,3 @@
 1. To set your SSH signing key in Git, paste the text below, substituting **/PATH/TO/KEY.PUB** with the path to the public key you'd like to use.
   ```bash
-  $ git config --global user.signingkey=/PATH/TO/.SSH/KEY.PUB
+  $ git config --global user.signingkey /PATH/TO/.SSH/KEY.PUB


### PR DESCRIPTION


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes https://github.com/github/docs/issues/21999

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

`git config` expects a space between the key and value rather than an equals sign.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
