### PR TITLE
macos-latest is now macos-12

### DIFF
--- a/data/reusables/actions/supported-github-runners.md
+++ b/data/reusables/actions/supported-github-runners.md
@@ -62,18 +62,18 @@ Migrate to <code>ubuntu-20.04</code> or <code>ubuntu-22.04</code>. For more info
 macOS Monterey 12
 </td>
 <td>
-<code>macos-12</code>
+<code>macos-latest</code> or <code>macos-12</code>
   </td>
+<td>
+The <code>macos-latest</code> label currently uses the macOS 12 runner image.
+</td>
 </tr>
 <tr>
 <td>
 macOS Big Sur 11
 </td>
 <td>
-<code>macos-latest</code> or <code>macos-11</code>
-</td>
-<td>
-The <code>macos-latest</code> label currently uses the macOS 11 runner image.
+<code>macos-11</code>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
### Why:

[maintainer edit]
Closes #21990 - a separate issue

macos-latest is still documented at being the same as macos-11 when this was switched to macos-12 last month:
https://github.blog/changelog/2022-10-03-github-actions-jobs-running-on-macos-latest-are-now-running-on-macos-12/


### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).