### PR TITLE
update ubuntu-latest reference

### DIFF
--- a/data/reusables/actions/supported-github-runners.md
+++ b/data/reusables/actions/supported-github-runners.md
@@ -33,7 +33,7 @@ Windows Server 2019
 Ubuntu 22.04
 </td>
 <td>
-<code>ubuntu-22.04</code>
+<code>ubuntu-latest</code> or <code>ubuntu-22.04</code>
 </td>
 <td>
 </td>
@@ -43,7 +43,7 @@ Ubuntu 22.04
 Ubuntu 20.04
 </td>
 <td>
-<code>ubuntu-latest</code> or <code>ubuntu-20.04</code>
+<code>ubuntu-20.04</code>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
ubuntu 22 is now ubuntu-latest

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes #22132

<!-- If there's an existing issue for your change, please link to it in the brackets above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->
Changing what `ubuntu-latest` points to in the docs

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
