### PR TITLE
Fix media types in rest/gists/comments.md

### DIFF
--- a/content/rest/gists/comments.md
+++ b/content/rest/gists/comments.md
@@ -17,11 +17,4 @@ miniTocMaxHeadingLevel: 3
 
 The Gist comments API lets you view and modify comments on a gist. For more information about gists, see "[Editing and sharing content with gists](/get-started/writing-on-github/editing-and-sharing-content-with-gists)."
 
-### Custom media types for Gist comments
-
-These are the supported media types for gist comments.
-
-    application/vnd.github.VERSION.raw
-    application/vnd.github.VERSION.base64
-
-For more information about media types, see "[Custom media types](/rest/overview/media-types)."
+{% data reusables.pull_requests.issues-media-types %}


### PR DESCRIPTION
The media types seem to be wrong on the page https://docs.github.com/en/rest/gists/comments

To test the current ones, which seem to have no effect:

```
$ curl --silent -H "Accept: application/vnd.github.3.base64+json" https://api.github.com/gists/9257657/comments/1221189 | grep body 
  "body": "Thanks, Octocat!\n"
```

To test the new ones, which have an effect:

```
$ curl --silent -H "Accept: application/vnd.github.3.full+json" https://api.github.com/gists/9257657/comments/1221189 | grep body 
  "body_html": "<p dir=\"auto\">Thanks, Octocat!</p>",
  "body_text": "Thanks, Octocat!",
  "body": "Thanks, Octocat!\n"
```

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
