### PR TITLE
replace '--set-upstream origin' with --set-upstream-to

### DIFF
--- a/content/get-started/using-git/about-git.md
+++ b/content/get-started/using-git/about-git.md
@@ -97,7 +97,7 @@ git add file1.md file2.md
 git commit -m "my snapshot"
 
 # push changes to github
-git push --set-upstream origin my-branch
+git push --set-upstream-to my-branch
 ```
 
 ### Example: Start a new repository and publish it to {% data variables.product.product_name %}

--- a/content/get-started/using-git/about-git.md
+++ b/content/get-started/using-git/about-git.md
@@ -124,7 +124,7 @@ git commit -m "add README to initial commit"
 git remote add origin https://github.com/YOUR-USERNAME/YOUR-REPOSITORY-NAME.git
 
 # push changes to github
-git push --set-upstream origin main
+git push --set-upstream-to main
 ```
 
 ### Example: contribute to an existing branch on {% data variables.product.product_name %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

https://stackoverflow.com/a/18032014

<!-- If there's an existing issue for your change, please replace ISSUE above with a link to the issue.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Git documentation states the call has been deprecated (for confusing syntax) in favor of --set-upstream-to which is self-descriptive and thus more suitable for examples in GitHub's documentation.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
