### PR TITLE
Fix typo: "mermeid" → "mermaid"

### DIFF
--- a/translations/pt-BR/content/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams.md
+++ b/translations/pt-BR/content/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams.md
@@ -17,7 +17,7 @@ Você pode criar diagramas em Markdown usando três sintaxes diferentes: mermaid
 
 ## Criando diagramas do mermaid
 
-O Mermeid é uma ferramenta inspirada em Markdown que transforma texto em diagramas. Por exemplo, o Mermeid pode interpretar gráficos de fluxo, diagramas de sequência, gráficos de pizza e muito mais. Para obter mais informações, confira a [documentação do Mermaid](https://mermaid-js.github.io/mermaid/#/).
+O Mermaid é uma ferramenta inspirada em Markdown que transforma texto em diagramas. Por exemplo, o Mermeid pode interpretar gráficos de fluxo, diagramas de sequência, gráficos de pizza e muito mais. Para obter mais informações, confira a [documentação do Mermaid](https://mermaid-js.github.io/mermaid/#/).
 
 Para criar um diagrama do Mermaid, adicione a sintaxe do Mermaid dentro de um bloco de código isolado com o identificador de linguagem `mermaid`. Para obter mais informações sobre como criar blocos de código, confira "[Como criar e realçar blocos de código](/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks)".
 


### PR DESCRIPTION
### Why:

It's just a typo fix.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

One word only: `mermeid` to **`mermaid`**

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
