### PR TITLE
Update working-with-ssh-key-passphrases.md

### DIFF
--- a/content/authentication/connecting-to-github-with-ssh/working-with-ssh-key-passphrases.md
+++ b/content/authentication/connecting-to-github-with-ssh/working-with-ssh-key-passphrases.md
@@ -40,7 +40,7 @@ If your key already has a passphrase, you will be prompted to enter it before yo
 
 ## Auto-launching `ssh-agent` on Git for Windows
 
-You can run `ssh-agent` automatically when you open bash or Git shell. Copy the following lines and paste them into your `~/.profile` or `~/.bashrc` file in Git shell:
+You can run `ssh-agent` automatically when you open bash or Git shell. Copy the following lines and paste them into the `~/.profile` or `~/.bashrc` file found in your `~/git/etc` folder:
 
 ``` bash
 env=~/.ssh/agent.env


### PR DESCRIPTION
Added clearer directions to locating `~/.profile` or `~/.bashrc` file for windows users.

### Why:

Closes [ISSUE](https://github.com/github/docs/issues/22819#issue-1507420605)

### What's being changed:
Line 43 in the `content/authentication/connecting-to-github-with-ssh/working-with-ssh-key-passphrases.md` file.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
