### PR TITLE
Adjust language in global security advisories intro

### DIFF
--- a/content/code-security/security-advisories/global-security-advisories/about-global-security-advisories.md
+++ b/content/code-security/security-advisories/global-security-advisories/about-global-security-advisories.md
@@ -1,6 +1,6 @@
 ---
 title: About global security advisories
-intro: 'Global security database live in the {% data variables.product.prodname_advisory_database %}, which contains CVEs and {% data variables.product.company_short %}-originated security advisories affecting the open source world. You can contribute to improving global advisories.'
+intro: 'Global security advisories live in the {% data variables.product.prodname_advisory_database %}, a collection of CVEs and {% data variables.product.company_short %}-originated advisories affecting the open source world. You can contribute to improving global security advisories.'
 versions:
   fpt: '*'
   ghec: '*'


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Minor copy edit.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I believe `Global security database live in the GitHub Advisory Database` was an error. Additionally `[...] advisories live in the [database], which contains [...] advisories` felt redundant so I adjusted the language slightly.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
