### PR TITLE
actions(concurrency): fix typo

### DIFF
--- a/data/reusables/actions/actions-group-concurrency.md
+++ b/data/reusables/actions/actions-group-concurrency.md
@@ -1,4 +1,6 @@
-When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be `pending`. Any previously pending job or workflow in the concurrency group will be canceled. To also cancel any currently running job or workflow in the same concurrency group, specify `cancel-in-progress: true`.
+When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be `pending`.
+
+Any previously pending job or workflow in the concurrency group can be canceled. To cancel any currently running job or workflow in the same concurrency group, specify `cancel-in-progress: true`.
 
 ### Examples: Using concurrency and the default behavior
 


### PR DESCRIPTION
### Why:

To cancel workflows in same concurrency group, `cancel-in-progress: true` option is needed.

Currently docs state, "will be cancelled" which implies it as default behavior, although it is not.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

"will be cancelled" -> "can be cancelled"

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
