### PR TITLE
Update working-with-the-npm-registry.md

### DIFF
--- a/content/packages/working-with-a-github-packages-registry/working-with-the-npm-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-npm-registry.md
@@ -68,7 +68,7 @@ If your instance has subdomain isolation disabled:
 
 To authenticate by logging in to npm, use the `npm login` command, replacing *USERNAME* with your {% data variables.product.prodname_dotcom %} username, *TOKEN* with your {% data variables.product.pat_v1 %}, and *PUBLIC-EMAIL-ADDRESS* with your email address.
 
-If {% data variables.product.prodname_registry %} is not your default package registry for using npm and you want to use the `npm audit` command, we recommend you use the `--scope` flag with the owner of the package when you authenticate to {% data variables.product.prodname_registry %}.
+If {% data variables.product.prodname_registry %} is not your default package registry for using npm and you want to use the `npm audit` command, we recommend you use the `--scope` flag with the owner of the package when you authenticate to {% data variables.product.prodname_registry %}. You will be prompted with username, password entering, and please note to use your personal access token as the password upon prompt.
 
 {% ifversion ghes %}
 If your instance has subdomain isolation enabled:
@@ -86,10 +86,7 @@ $ npm login --scope=@OWNER --registry=https://{% ifversion fpt or ghec %}npm.pkg
 If your instance has subdomain isolation disabled:
 
 ```shell
-$ npm login --scope=@OWNER --registry=https://HOSTNAME/_registry/npm/
-> Username: USERNAME
-> Password: TOKEN
-> Email: PUBLIC-EMAIL-ADDRESS
+$ npm login --scope=@OWNER --registry=https://HOSTNAME/_registry/npm/ --auth-type=legacy
 ```
 {% endif %}
 


### PR DESCRIPTION
Document and sample command update based on my testing/experiment. With npm v9, using the command without "--auth-type=legacy" will result in "Web login not supported" error.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes [ISSUE](https://github.com/github/docs/issues/22199)

<!-- If there's an existing issue for your change, please replace ISSUE above with a link to the issue.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added instruction "You will be prompted with username, password entering, and please note to use your personal access token as the password upon prompt."

Updated command from
'''
$ npm login --scope=@OWNER --registry=https://HOSTNAME/_registry/npm/
> Username: USERNAME
> Password: TOKEN
> Email: PUBLIC-EMAIL-ADDRESS
'''
to
'''
npm login --scope=@OWNER --registry=https://HOSTNAME/_registry/npm/ --auth-type=legacy
'''
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
