### PR TITLE
Update reusing-workflows.md

### DIFF
--- a/content/actions/using-workflows/reusing-workflows.md
+++ b/content/actions/using-workflows/reusing-workflows.md
@@ -142,7 +142,7 @@ You can define inputs and secrets, which can be passed from the caller workflow 
        steps:
        - uses: actions/labeler@v4
          with:
-           repo-token: ${{ secrets.envPAT }}
+           envPAT: ${{ secrets.envPAT }}
            configuration-path: ${{ inputs.config-path }}
    ```
    {% endraw %}


### PR DESCRIPTION
### Why:
The caller is passing in  `repo-token` but the called workflow expects `envPAT`.  This is either incorrect or something is happening to get the right values passed and it should be further explained in the doc.

Closes https://github.com/github/docs/issues/23207

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
