### PR TITLE
Update writing-mathematical-expressions.md: Unsupported Math Blocks in <details> Blocks

### DIFF
--- a/content/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions.md
@@ -27,6 +27,7 @@ This sentence uses `$` delimiters to show math inline:  $\sqrt{3x-1}+(1+x)^2$
 ## Writing expressions as blocks
 
 To add a math expression as a block, start a new line and delimit the expression with two dollar symbols `$$`.
+Math blocks enclosed within `<details>` blocks may not render correctly (matrices not supported).
 
 ```
 **The Cauchy-Schwarz Inequality**

--- a/content/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions.md
@@ -27,7 +27,12 @@ This sentence uses `$` delimiters to show math inline:  $\sqrt{3x-1}+(1+x)^2$
 ## Writing expressions as blocks
 
 To add a math expression as a block, start a new line and delimit the expression with two dollar symbols `$$`.
-Math blocks enclosed within `<details>` blocks may not render correctly (matrices not supported).
+
+{% note %}
+
+**Note:** Math blocks enclosed within `<details>` blocks may not render correctly (matrices not supported).
+
+{% endnote %}
 
 ```
 **The Cauchy-Schwarz Inequality**


### PR DESCRIPTION
This issue is about displaying math blocks inside of the `details` blocks (and potentially other HTML blocks) regardless of the type of math block. This can include blocks such as 

```
$$
\begin{pmatrix}
  0 & 1 \\
  2 & 3
\end{pmatrix}
$$
```

or blocks written like this: 

~~~
```math
\begin{pmatrix}
  0 & 1 \\
  2 & 3
\end{pmatrix}
```
~~~

This issue is currently blocking the use of math blocks inside of `details` blocks, as well as other HTML blocks. This limitation prevents users from taking full advantage of these blocks, and should be noted in documentation. To ensure users are not held back, we must actively search for a potential solution to this issue so that math blocks can be displayed in these blocks.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes ISSUE

<!-- If there's an existing issue for your change, please replace ISSUE above with a link to the issue.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

![code](https://user-images.githubusercontent.com/43147705/212746701-bc596a5d-6200-41c7-940e-8889e3bb5a97.png)
![rendered](https://user-images.githubusercontent.com/43147705/212747509-a2eb60ad-21f0-40b0-847b-2475b03cd6b9.png)
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
