### PR TITLE
Add missing `@` symbol to "using a public action" example

### DIFF
--- a/content/actions/creating-actions/creating-a-docker-container-action.md
+++ b/content/actions/creating-actions/creating-a-docker-container-action.md
@@ -192,7 +192,7 @@ git push --follow-tags
 
 ## Testing out your action in a workflow
 
-Now you're ready to test your action out in a workflow. 
+Now you're ready to test your action out in a workflow.
 
 {% ifversion private-actions %}- When an action is in a private repository, you can control who can access it. For more information, see "[Allowing access to components in a private repository](/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-a-private-repository)."{% else %}- When an action is in a private repository, the action can only be used in workflows in the same repository.{% endif %}
 {% ifversion ghes or ghec or ghae %}{% ifversion internal-actions %}- When an action is in an internal repository, you can control who can access it. For more information, see "[Allowing access to components in an internal repository](/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-an-internal-repository)."{% else %}- When an action is in an internal repository, the action can only be used in workflows in the same repository.{% endif %}{% endif %}
@@ -215,7 +215,7 @@ jobs:
     steps:
       - name: Hello world action step
         id: hello
-        uses: actions/hello-world-docker-action{% ifversion actions-save-state-set-output-envs %}v2{% else %}v1{% endif %}
+        uses: actions/hello-world-docker-action@{% ifversion actions-save-state-set-output-envs %}v2{% else %}v1{% endif %}
         with:
           who-to-greet: 'Mona the Octocat'
       # Use the output from the `hello` step


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes https://github.com/github/docs/issues/23055

### What's being changed (if available, include any code snippets, screenshots, or gifs):

[Example using a public action](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action#example-using-a-public-action) contains `uses: actions/hello-world-docker-action{% ifversion actions-save-state-set-output-envs %}v2{% else %}v1{% endif %}` which is missing a `@` symbol. This PR fixes that. 

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
