### PR TITLE
Add an example for docker containers

### DIFF
--- a/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
+++ b/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
@@ -347,6 +347,15 @@ updates:
         # For AWS SDK, ignore all patch updates
       - dependency-name: "aws-sdk"
         update-types: ["version-update:semver-patch"]
+  - package-ecosystem: "docker"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: hashicorp/terraform
+        # Ignore terraform 1.3 docker containers in Dockerfiles
+        versions:
+          - "~> 1.3.0, < 1.4.0"
 ```
 
 {% note %}


### PR DESCRIPTION
It's not clear what version selectors will work with docker containers in Dockerfiles. Therefore this hard won example demonstrates how to ignore a version range in a Dockerfile.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes ISSUE #23340

<!-- If there's an existing issue for your change, please replace ISSUE above with a link to the issue.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Adding the following example to the ignore example:

<img width="538" alt="Screenshot 2023-01-20 at 11 37 27" src="https://user-images.githubusercontent.com/426859/213686463-2626aa00-17c0-4ce4-a2f4-50fd6c3a1b81.png">


### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
