### PR TITLE
'cleanup caches' example workflow is wrong and harmful!

### DIFF
--- a/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
+++ b/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
@@ -345,6 +345,10 @@ jobs:
           
           REPO={% raw %}${{ github.repository }}{% endraw %}
           BRANCH={% raw %}${{ github.ref }}{% endraw %}
+            ## This is wrong!!
+            ## If invoked by a closing PR, BRANCH ends up to be the base branch, e.g. master.
+            ## This job will then remove exactly the wrong caches.
+            ## HARMFUL EXAMPLE, should be fixed immediately by some knowledgeable person.
 
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )


### PR DESCRIPTION
It will delete the caches of the base branch, not the PR branch.  Needs fixing! I added an alert in comments that this example doesn't work.

Evidence here: https://github.com/agda/agda/actions/runs/4025940394/jobs/6919801891#step:3:5
(Note: these logs will be removed by github after some time.)
