### PR TITLE
Update scopes-for-oauth-apps.md

### DIFF
--- a/content/developers/apps/building-oauth-apps/scopes-for-oauth-apps.md
+++ b/content/developers/apps/building-oauth-apps/scopes-for-oauth-apps.md
@@ -39,8 +39,8 @@ X-Accepted-OAuth-Scopes: user
 ## Available scopes
 
 Name | Description
------|-----------|{% ifversion not ghae %}
-**`(no scope)`** | Grants read-only access to public information (including user profile info, repository info, and gists){% endif %}{% ifversion ghes or ghae %}
+-----|-----------|
+**`(no scope)`** | {% ifversion not ghae %}Grants read-only access to public information (including user profile info, repository info, and gists){% endif %}{% ifversion ghes or ghae %}
 **`site_admin`** | Grants site administrators access to [{% data variables.product.prodname_ghe_server %} Administration API endpoints](/rest/reference/enterprise-admin).{% endif %}
 **`repo`** | Grants full access to public{% ifversion ghec or ghes or ghae %}, internal,{% endif %} and private repositories including read and write access to code, commit statuses, repository invitations, collaborators, deployment statuses, and repository webhooks. **Note**: In addition to repository related resources, the `repo` scope also grants access to manage organization-owned resources including projects, invitations, team memberships and webhooks. This scope also grants the ability to manage projects owned by users.
 &emsp;`repo:status`| Grants read/write access to commit statuses in {% ifversion fpt %}public and private{% elsif ghec or ghes %}public, private, and internal{% elsif ghae %}private and internal{% endif %} repositories. This scope is only necessary to grant other users or services access to private repository commit statuses *without* granting access to the code.


### PR DESCRIPTION
### Why:

Closes none

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Patch the misplaced `{% ifversion not ghae %}` at the start of the table who was destroying it of the url: [https://docs.github.com/fr/developers/apps/building-oauth-apps/scopes-for-oauth-apps](https://docs.github.com/fr/developers/apps/building-oauth-apps/scopes-for-oauth-apps)

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review). (no content change)
