### PR TITLE
Added Keeper where LastPass and 1Password are referenced as password …

### DIFF
--- a/content/admin/user-management/managing-users-in-your-enterprise/best-practices-for-user-security.md
+++ b/content/admin/user-management/managing-users-in-your-enterprise/best-practices-for-user-security.md
@@ -24,7 +24,7 @@ For more information on configuring two-factor authentication, see "[About two-f
 
 ## Requiring a password manager
 
-We strongly recommend requiring your users to install and use a password manager--such as [LastPass](https://lastpass.com/) or [1Password](https://1password.com/)--on any computer they use to connect to your enterprise. Doing so ensures that passwords are stronger and much less likely to be compromised or stolen.
+We strongly recommend requiring your users to install and use a password manager--such as [Keeper](https://keepersecurity.com), [LastPass](https://lastpass.com/), or [1Password](https://1password.com/)--on any computer they use to connect to your enterprise. Doing so ensures that passwords are stronger and much less likely to be compromised or stolen.
 
 ## Restrict access to teams and repositories
 

--- a/content/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token.md
+++ b/content/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token.md
@@ -28,7 +28,7 @@ To access {% data variables.product.company_short %} from the command line, cons
 
 When using a {% data variables.product.pat_generic %} in a script, consider storing your token as a secret and running your script through {% data variables.product.prodname_actions %}. For more information, see "[Encrypted secrets](/actions/security-guides/encrypted-secrets)."{%- ifversion ghec or fpt %} You can also store your token as a {% data variables.product.prodname_codespaces %} secret and run your script in {% data variables.product.prodname_codespaces %}. For more information, see "[Managing encrypted secrets for your codespaces](/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces)."{% endif %}
 
-If these options are not possible, consider using another service such as [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
+If these options are not possible, consider using another service such as [Keeper Secrets Manager](https://www.keepersecurity.com/secrets-manager.html) or [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
 
 {% endwarning %}
 

--- a/content/authentication/keeping-your-account-and-data-secure/creating-a-strong-password.md
+++ b/content/authentication/keeping-your-account-and-data-secure/creating-a-strong-password.md
@@ -20,7 +20,7 @@ You must choose or generate a password for your account on {% ifversion ghae %}{
 - 15 characters long with any combination of characters
 
 To keep your account secure, we recommend you follow these best practices:
-- Use a password manager, such as [LastPass](https://lastpass.com/) or [1Password](https://1password.com/), to generate a password of at least 15 characters.
+- Use a password manager, such as [Keeper](https://keepersecurity.com), [LastPass](https://lastpass.com/), or [1Password](https://1password.com/), to generate a password of at least 15 characters.
 - Generate a unique password for {% data variables.product.product_name %}. If you use your {% data variables.product.product_name %} password elsewhere and that service is compromised, then attackers or other malicious actors could use that information to access your account on {% ifversion ghae %}{% data variables.product.product_name %}{% else %}{% data variables.location.product_location %}{% endif %}.
 
 - Configure two-factor authentication for your personal account. For more information, see "[About two-factor authentication](/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)."

--- a/content/authentication/keeping-your-account-and-data-secure/updating-your-github-access-credentials.md
+++ b/content/authentication/keeping-your-account-and-data-secure/updating-your-github-access-credentials.md
@@ -43,7 +43,7 @@ shortTitle: Update access credentials
 
 {% tip %}
 
-To avoid losing your password in the future, we suggest using a secure password manager, like [LastPass](https://lastpass.com/) or [1Password](https://1password.com/).
+To avoid losing your password in the future, we suggest using a secure password manager, like [Keeper](https://keepersecurity.com), [LastPass](https://lastpass.com/), or [1Password](https://1password.com/).
 
 {% endtip %}
 

--- a/content/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication-recovery-methods.md
+++ b/content/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication-recovery-methods.md
@@ -25,6 +25,7 @@ In addition to securely storing your two-factor authentication recovery codes, w
 {% data reusables.two_fa.about-recovery-codes %} You can also download your recovery codes at any point after enabling two-factor authentication.
 
 To keep your account secure, don't share or distribute your recovery codes. We recommend saving them with a secure password manager, such as:
+- [Keeper](https://keepersecurity.com)
 - [1Password](https://1password.com/)
 - [LastPass](https://lastpass.com/)
 

--- a/content/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication.md
+++ b/content/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication.md
@@ -50,6 +50,7 @@ If you're a member of an {% data variables.enterprise.prodname_emu_enterprise %}
 ## Configuring two-factor authentication using a TOTP mobile app
 
 A time-based one-time password (TOTP) application automatically generates an authentication code that changes after a certain period of time. We recommend using cloud-based TOTP apps such as:
+- [Keeper](https://keepersecurity.com)
 - [1Password](https://support.1password.com/one-time-passwords/)
 - [Authy](https://authy.com/guides/github/)
 - [LastPass Authenticator](https://lastpass.com/auth/)

--- a/content/organizations/managing-saml-single-sign-on-for-your-organization/accessing-your-organization-if-your-identity-provider-is-unavailable.md
+++ b/content/organizations/managing-saml-single-sign-on-for-your-organization/accessing-your-organization-if-your-identity-provider-is-unavailable.md
@@ -12,7 +12,7 @@ topics:
 shortTitle: Unavailable identity provider
 ---
 
-Organization administrators can use [one of their downloaded or saved recovery codes](/articles/downloading-your-organization-s-saml-single-sign-on-recovery-codes) to bypass single sign-on. You may have saved these to a password manager, such as [LastPass](https://lastpass.com/) or [1Password](https://1password.com/).
+Organization administrators can use [one of their downloaded or saved recovery codes](/articles/downloading-your-organization-s-saml-single-sign-on-recovery-codes) to bypass single sign-on. You may have saved these to a password manager, such as [Keeper](https://keepersecurity.com), [LastPass](https://lastpass.com/), or [1Password](https://1password.com/).
 
 {% data reusables.saml.recovery-code-caveats %}
 

--- a/content/organizations/managing-saml-single-sign-on-for-your-organization/downloading-your-organizations-saml-single-sign-on-recovery-codes.md
+++ b/content/organizations/managing-saml-single-sign-on-for-your-organization/downloading-your-organizations-saml-single-sign-on-recovery-codes.md
@@ -13,7 +13,7 @@ topics:
 shortTitle: Download SAML recovery codes
 ---
 
-Recovery codes should not be shared or distributed. We recommend saving them with a password manager such as [LastPass](https://lastpass.com/) or [1Password](https://1password.com/).
+Recovery codes should not be shared or distributed. We recommend saving them with a password manager such as [Keeper](https://keepersecurity.com), [LastPass](https://lastpass.com/), or [1Password](https://1password.com/).
 
 {% data reusables.profile.access_org %}
 {% data reusables.profile.org_settings %}

--- a/content/rest/guides/getting-started-with-the-rest-api.md
+++ b/content/rest/guides/getting-started-with-the-rest-api.md
@@ -129,7 +129,7 @@ To keep your token secure, you can store your token as a secret and run your scr
 
 {% ifversion ghec or fpt %}You can also store your token as a {% data variables.product.prodname_codespaces %} secret and run your script in {% data variables.product.prodname_codespaces %}. For more information, see "[Managing encrypted secrets for your codespaces](/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces)."{% endif %}
 
-If these options are not possible, consider using another service such as [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
+If these options are not possible, consider using another service such as [Keeper Secrets Manager](https://www.keepersecurity.com/secrets-manager.html) or [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
 
 {% endwarning %}
 
@@ -154,7 +154,7 @@ To help keep your account secure, you can use {% data variables.product.prodname
 
 {% ifversion ghec or fpt %}You can also store your token as a {% data variables.product.prodname_codespaces %} secret and use the command line through {% data variables.product.prodname_codespaces %}. For more information, see "[Managing encrypted secrets for your codespaces](/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces)."{% endif %}
 
-If these options are not possible, consider using another service such as [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
+If these options are not possible, consider using another service such as [Keeper Secrets Manager](https://www.keepersecurity.com/secrets-manager.html) or [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
 
 {% endwarning %}
 

--- a/content/rest/guides/scripting-with-the-rest-api-and-javascript.md
+++ b/content/rest/guides/scripting-with-the-rest-api-and-javascript.md
@@ -34,7 +34,7 @@ To keep your credentials secure, you can store your credentials as a secret and 
 
 {% ifversion ghec or fpt %}You can also store your credentials as a {% data variables.product.prodname_codespaces %} secret and run your script in {% data variables.product.prodname_codespaces %}. For more information, see "[Managing encrypted secrets for your codespaces](/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces)."{% endif %}
 
-If {% ifversion ghec or fpt %}these options are not possible{% else %}this is not possible{% endif %}, consider using another service such as [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your credentials securely.
+If {% ifversion ghec or fpt %}these options are not possible{% else %}this is not possible{% endif %}, consider using another service such as [Keeper Secrets Manager](https://www.keepersecurity.com/secrets-manager.html) or [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your credentials securely.
 
 {% endwarning %}
 

--- a/content/rest/overview/other-authentication-methods.md
+++ b/content/rest/overview/other-authentication-methods.md
@@ -130,7 +130,7 @@ When you make calls to the OAuth Authorizations API, Basic Authentication requir
 
 `X-GitHub-OTP: required; SMS` or `X-GitHub-OTP: required; app`.  
 
-This header tells you how your account receives its two-factor authentication codes. Depending how you set up your account, you will either receive your OTP codes via SMS or you will use an application like Google Authenticator or 1Password. For more information, see "[Configuring two-factor authentication](/articles/configuring-two-factor-authentication)." Pass the OTP in the header:
+This header tells you how your account receives its two-factor authentication codes. Depending how you set up your account, you will either receive your OTP codes via SMS or you will use an application like Google Authenticator, Keeper or 1Password. For more information, see "[Configuring two-factor authentication](/articles/configuring-two-factor-authentication)." Pass the OTP in the header:
 
 ```shell
 $ curl --request POST \

--- a/content/rest/quickstart.md
+++ b/content/rest/quickstart.md
@@ -129,7 +129,7 @@ You can use Octokit.js to interact with the {% data variables.product.prodname_d
 
    You can also store your token as a {% data variables.product.prodname_codespaces %} secret and run your script in {% data variables.product.prodname_codespaces %}. For more information, see "[Managing encrypted secrets for your codespaces](/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces)."{% endif %}
 
-   If these options are not possible, consider using another service such as [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
+   If these options are not possible, consider using another service such as [Keeper Secrets Manager](https://www.keepersecurity.com/secrets-manager.html) or [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
 
    {% endwarning %}
 
@@ -292,7 +292,7 @@ If you are authenticating with a {% data variables.product.prodname_github_app %
 
    You can also use {% data variables.product.prodname_cli %} instead of `curl`. {% data variables.product.prodname_cli %} will take care of authentication for you. For more information, see the {% data variables.product.prodname_cli %} version of this page.
 
-   If these options are not possible, consider using another service such as [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
+   If these options are not possible, consider using another service such as [Keeper Secrets Manager](https://www.keepersecurity.com/secrets-manager.html) or [the 1Password CLI](https://developer.1password.com/docs/cli/secret-references/) to store your token securely.
 
    {% endwarning %}
 


### PR DESCRIPTION
…managers and secret managers. Keeper is a secure enterprise password management platform with millions of users and thousands of enterprise customers. Keeper is SOC2 Certified, FedRAMP Authorized, audited by 3rd party penetration testers and maintains a public vulnerability disclosure program. Keeper's APIs and SDKs are open source published on Github at https://github.com/Keeper-Security/

Closes https://github.com/github/docs/issues/23825

### Why:

Keeper is an enterprise password management platform which is SOC2 Certified, FedRAMP Authorized, audited by 3rd party penetration testers and maintains a public vulnerability disclosure program. Since 1Password and LastPass are mentioned, we would like to make sure that we're also included.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added reference to Keeper where 1Password and LastPass are mentioned as a password manager or TOTP device.

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
