### PR TITLE
Updating the examples for ghcr.io push command.

### DIFF
--- a/content/packages/learn-github-packages/connecting-a-repository-to-a-package.md
+++ b/content/packages/learn-github-packages/connecting-a-repository-to-a-package.md
@@ -67,7 +67,7 @@ When you publish a package that is scoped to a personal account or an organizati
 
   For example:
   ```shell
-  $ docker tag 38f737a91f39 {% data reusables.package_registry.container-registry-example-hostname %}/monalisa/hello_docker:latest
+  $ docker tag 38f737a91f39 {% data reusables.package_registry.container-registry-hostname %}/monalisa/hello_docker:latest
   ```
 
 5. If you haven't already, authenticate to the {% data variables.product.prodname_container_registry %}. For more information, see "[Authenticating to the {% data variables.product.prodname_container_registry %}](/packages/managing-container-images-with-github-container-registry/pushing-and-pulling-docker-images#authenticating-to-the-container-registry)."
@@ -83,6 +83,6 @@ When you publish a package that is scoped to a personal account or an organizati
   ```
   For example:
   ```shell
-  $ docker push {% data reusables.package_registry.container-registry-example-hostname %}/monalisa/hello_docker:latest
+  $ docker push {% data reusables.package_registry.container-registry-hostname %}/monalisa/hello_docker:latest
   ```
 {% endif %}


### PR DESCRIPTION
The examples of ghcr.io tag, push commands are referring to the older naming convention of the hostname. Proposed changes looks understandable to me as it contains the ghcr.io hostname

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes ISSUE

<!-- If there's an existing issue for your change, please replace ISSUE above with a link to the issue.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
