### PR TITLE
Navigation in doc about concepts faster

### DIFF
--- a/content/actions/automating-builds-and-tests/building-and-testing-nodejs.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-nodejs.md
@@ -27,10 +27,11 @@ This guide shows you how to create a continuous integration (CI) workflow that b
 
 ## Prerequisites
 
-We recommend that you have a basic understanding of Node.js, YAML, workflow configuration options, and how to create a workflow file. For more information, see:
+We recommend that you have a basic understanding of Node.js, YAML, workflow configuration options, and how to create a workflow file, such as to via starter workflow. For more information, see:
 
 - "[AUTOTITLE](/actions/learn-github-actions)"
 - "[Getting started with Node.js](https://nodejs.org/en/docs/guides/getting-started-guide/)"
+- "[AUTOTITLE](/actions/using-workflows/using-starter-workflows)" 
 
 {% data reusables.actions.enterprise-setup-prereq %}
 


### PR DESCRIPTION
To make navigation between concepts in documentation faster. For new users who read about build and publish but need a refresh on the concept of starter workflows. A direct link to relevant documentation is proposed to be added. Similar acitvity could be done under the "Build&Test" examples for other languages.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes ISSUE

<!-- If there's an existing issue for your change, please replace ISSUE above with a link to the issue.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
