### PR TITLE
Fix tiny typo

### DIFF
--- a/content/codespaces/codespaces-reference/using-the-github-codespaces-plugin-for-jetbrains.md
+++ b/content/codespaces/codespaces-reference/using-the-github-codespaces-plugin-for-jetbrains.md
@@ -14,7 +14,7 @@ topics:
 
 ## About the {% data variables.product.prodname_github_codespaces %} plugin
 
-The JetBrains client application is launched when you connect to a codespace from the JetBrains Gateway application. It allows you to use {% data variables.product.prodname_github_codespaces %} with you favorite JetBrains IDE. For more information, see "[AUTOTITLE](/codespaces/developing-in-codespaces/using-github-codespaces-in-your-jetbrains-ide)."
+The JetBrains client application is launched when you connect to a codespace from the JetBrains Gateway application. It allows you to use {% data variables.product.prodname_github_codespaces %} with your favorite JetBrains IDE. For more information, see "[AUTOTITLE](/codespaces/developing-in-codespaces/using-github-codespaces-in-your-jetbrains-ide)."
 
 The {% data variables.product.prodname_github_codespaces %} plugin is already installed in the JetBrains client when you connect to a codespace from the JetBrains Gateway. The plugin adds the {% data variables.product.prodname_github_codespaces %} tool window to the user interface.
 


### PR DESCRIPTION
### Why:

Found a tiny typo while reviewing https://github.com/github/docs-strategy/pull/1719

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fixes the typo

### Check off the following:

- [X] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [X] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
