### PR TITLE
Add note for multi lines output paramater in ga.

### DIFF
--- a/content/actions/using-workflows/workflow-commands-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-commands-for-github-actions.md
@@ -784,6 +784,13 @@ This example demonstrates how to set the `SELECTED_COLOR` output parameter and l
 {% endraw %}
 
 {% endpowershell %}
+
+{% note %}
+
+**Note:** Multi-line output values can be set in the same way Multi-line environment variables are. For more information, see "[Multiline strings](#multiline-strings)."
+
+{% endnote %}
+
 {% endif %}
 
 {% ifversion actions-job-summaries %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes #21529 and continue the work of #21599 by taking into account the comment by @cmwilson21 https://github.com/github/docs/pull/21599#issuecomment-1292564504

<!-- If there's an existing issue for your change, please replace ISSUE above with a link to the issue.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Add a `Note` at the end of the [Setting an output parameter](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) that clarifies the possibility of writing a multi line output parameter.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
