### PR TITLE
Add AWS OIDC config when used with environment

### DIFF
--- a/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services.md
+++ b/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services.md
@@ -73,6 +73,16 @@ In the following example, `StringLike` is used with a wildcard operator (`*`) to
 }
 ```
 
+The `sub` will not contain the branch name if you are using a workflow with an environment. Here, the `ref:refs/heads/branchName` will not work. You need to update the `sub` to contain the reference to the environment's name. Detailed information in [OIDC - Filtering for a specific branch](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#filtering-for-a-specific-branch)
+
+```json{:copy}
+"Condition": {
+  "StringEquals": {
+    "{% ifversion ghes %}HOSTNAME/_services/token{% else %}token.actions.githubusercontent.com{% endif %}:aud": "sts.amazonaws.com",
+    "{% ifversion ghes %}HOSTNAME/_services/token{% else %}token.actions.githubusercontent.com{% endif %}:sub": "repo:octo-org/octo-repo:environment:prod"
+  }
+}
+```
 
 ## Updating your {% data variables.product.prodname_actions %} workflow
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

I spent time to figure out why I got this error: "Error: Not authorized to perform sts:AssumeRoleWithWebIdentity". I found an issue on the AWS Credentials Action repository: https://github.com/aws-actions/configure-aws-credentials/issues/511#issuecomment-1289602876. 

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Add one more example of AWS trusted entity configuration corresponding to the case where environment is used in GitHub Actions.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
