### PR TITLE
Update get-rest-code-samples.ts curl sample

### DIFF
--- a/components/lib/get-rest-code-samples.ts
+++ b/components/lib/get-rest-code-samples.ts
@@ -83,7 +83,7 @@ export function getShellExample(operation: Operation, codeSample: CodeSample) {
 
   const args = [
     operation.verb !== 'get' && `-X ${operation.verb.toUpperCase()}`,
-    `-H "Accept: ${defaultAcceptHeader}" \\\n  ${authHeader}${apiVersionHeader}`,
+    `-H "Accept: ${defaultAcceptHeader}" \\\n  ${authHeader} ${apiVersionHeader}`,
     contentTypeHeader,
     `${operation.serverUrl}${requestPath}`,
     requestBodyParams,


### PR DESCRIPTION
### Why:

Closes https://github.com/github/rest-api-description/issues/2303

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adds a space, in the Curl sample block, after the authHeader to amend the request code block. Currently the '\\' trails the authHeader with no space leading to a failure from a direct copy of the code block.

See e.g. the curl request block in https://docs.github.com/en/rest/packages?apiVersion=2022-11-28#list-packages-for-an-organization

```
curl -L \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR-TOKEN>"\
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/orgs/ORG/packages?package_type=container
```

should read

```
curl -L \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR-TOKEN>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/orgs/ORG/packages?package_type=container
```

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
