### PR TITLE
Fix permission description in PR from fork doc.

### DIFF
--- a/content/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork.md
+++ b/content/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork.md
@@ -6,7 +6,7 @@ redirect_from:
   - /articles/creating-a-pull-request-from-a-fork
   - /github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork
   - /github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork
-permissions: 'Anyone with write access to a repository can create a pull request from a user-owned fork. {% data reusables.enterprise-accounts.emu-permission-propose %}'
+permissions: 'Anyone with read access to a repository can create a pull request from a user-owned fork. {% data reusables.enterprise-accounts.emu-permission-propose %}'
 versions:
   fpt: '*'
   ghes: '*'


### PR DESCRIPTION
### Why:

Closes: #24454

This PR is opened by a user without write access to the Zimmi48/docs fork to demonstrate that you need neither write-access to the upstream repository nor the fork to open a pull request from a fork. However, when you open a PR from a fork on which you do not have write access, you cannot grant permission to the upstream maintainers to write to the PR branch (for obvious reasons).

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Description of permission.

Note that this PR is incomplete, the `{% data reusables.pull_requests.perms-to-open-pull-request %}` part should be updated as well, but I am not sure where it is defined (and if it is used elsewhere that should not change).

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
