### PR TITLE
Update countries-where-sms-authentication-is-supported.md

### DIFF
--- a/content/authentication/securing-your-account-with-two-factor-authentication-2fa/countries-where-sms-authentication-is-supported.md
+++ b/content/authentication/securing-your-account-with-two-factor-authentication-2fa/countries-where-sms-authentication-is-supported.md
@@ -1,6 +1,6 @@
 ---
-title: Countries where SMS authentication is supported
-intro: 'Because of delivery success rates, {% data variables.product.product_name %} only supports two-factor authentication via SMS for certain countries.'
+title: Countries and regions where SMS authentication is supported
+intro: 'Because of delivery success rates, {% data variables.product.product_name %} only supports two-factor authentication via SMS for certain countries and regions.'
 redirect_from:
   - /articles/countries-where-sms-authentication-is-supported
   - /github/authenticating-to-github/countries-where-sms-authentication-is-supported
@@ -10,13 +10,13 @@ versions:
   ghec: '*'
 topics:
   - 2FA
-shortTitle: Countries supporting SMS
+shortTitle: Countries and regions supporting SMS
 ---
-If we don't support two-factor authentication via text message for your country of residence, you can set up authentication via a TOTP mobile application. For more information, see "[AUTOTITLE](/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication)."
+If we don't support two-factor authentication via text message for your country/region of residence, you can set up authentication via a TOTP mobile application. For more information, see "[AUTOTITLE](/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication)."
 
-## Supported countries for SMS authentication
+## Supported countries and regions for SMS authentication
 
-If your country is not on this list, then we aren't currently able to reliably deliver text messages to your country. We update this list periodically.
+If your country/region is not on this list, then we aren't currently able to reliably deliver text messages to your country/region. We update this list periodically.
 
 <ul style="-webkit-column-count: 3; -moz-column-count: 3; column-count: 3;">
 <li>Aland Islands</li>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: 

This Pull Request replaces the term `country` with `country/region` for disputed areas (such as Taiwan) in the documentation about SMS authentication.

This change follows the practice of other docs from Microsoft, aligns with GitHub's diversity and inclusion values, and avoids political controversy.

#### Reference:

- [Azure Docs](https://github.com/MicrosoftDocs/azure-docs/blob/34f0b2448ab636c55583869401b3bd3b6ff43c8f/articles/cost-management-billing/manage/manage-tax-information.md#add-your-tax-ids)
- [Microsoft 365 Docs](https://github.com/MicrosoftDocs/microsoft-365-docs/blob/public/microsoft-365/admin/includes/country-region-support-dropdown-list.md)
- [Bing Docs](https://github.com/MicrosoftDocs/bing-docs/blob/f5a4c5bb72015d197097a2869fa916ebf186087b/bing-docs/bing-web-search/reference/market-codes.md#market-and-language-codes-used-by-bing-web-search-api)

PS: the [Enable two-factor authentication (2FA) page](https://github.com/settings/two_factor_authentication/setup/intro) should update accordingly

![CleanShot 2023-03-21 at 12 07 44](https://user-images.githubusercontent.com/5123601/226515193-5932b774-6d9e-4e1d-ac85-8c5665477d4c.png)

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
