### PR TITLE
OIDC: add initial PyPI docs

### DIFF
--- a/content/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect.md
+++ b/content/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect.md
@@ -458,6 +458,12 @@ To configure the repository to use the organization's template, a repository adm
 You can now update your YAML workflows to use OIDC access tokens instead of secrets. Popular cloud providers have published their official login actions that make it easy for you to get started with OIDC. For more information about updating your workflows, see the cloud-specific guides listed below in "[Enabling OpenID Connect for your cloud provider](#enabling-openid-connect-for-your-cloud-provider)."
 
 
+## Enabling OpenID Connect for Python package publishing
+
+The [Python Package Index (PyPI)](https://pypi.org) supports "token exchange" with OpenID connect: you can configure a GitHub workflow in a repository as a trusted publisher for a PyPI project, allowing OIDC access tokens to be exchanged for temporary PyPI API tokens.
+
+See the guide in "[AUTOTITLE](/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi)" for more information, as well as PyPI's [own documentation on OIDC publishing](https://pypi.org/help/#openid-connect).
+
 ## Enabling OpenID Connect for your cloud provider
 
 To enable and configure OIDC for your specific cloud provider, see the following guides:

--- a/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi.md
+++ b/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi.md
@@ -1,0 +1,102 @@
+---
+title: Configuring OpenID Connect in PyPI
+shortTitle: OpenID Connect in PyPI
+intro: Use OpenID Connect within your workflows to authenticate with PyPI
+versions:
+  fpt: '*'
+  ghec: '*'
+  ghes: '>=3.5'
+type: tutorial
+topics:
+  - Security
+---
+
+{% data reusables.actions.enterprise-beta %}
+{% data reusables.actions.enterprise-github-hosted-runners %}
+
+## Overview
+
+OpenID Connect (OIDC) allows your {% data variables.product.prodname_actions %} workflows to authenticate with [PyPI](https://pypi.org) to publish Python packages.
+
+This guide gives an overview of how to configure PyPI to trust {% data variables.product.prodname_dotcom %}'s OIDC as a federated identity, and demonstrates how to use this configuration in the [`pypa/gh-action-pypa-publish`](https://github.com/pypa/gh-action-pypa-publish) action to publish packages to PyPI (or other Python package indices) without any manual API token management.
+
+{% ifversion ghes %}
+{% note %}
+
+**Note:** PyPI currently only supports OIDC federation with GitHub's own hosted OIDC IdP, which is identified by its issuer (`https://token.actions.githubusercontent.com`). Self-hosted GitHub Enterprise instances are not supported.
+
+{% endnote %}
+{% endif %}
+
+## Prerequisites
+
+{% data reusables.actions.oidc-link-to-intro %}
+
+{% data reusables.actions.oidc-security-notice %}
+
+## Adding the identity provider to PyPI
+
+To use OIDC with PyPI, you will need to add a trust configuration that links each project on PyPI to each repository and workflow combination that's allowed to publish for it.
+
+To configure a PyPI project to allow OIDC publishing:
+
+1. Log into PyPI, and navigate to the OIDC publishing settings for the project you'd like to configure. For a project named `myproject`, this will be at `https://pypi.org/manage/project/myproject/settings/publishing/`.
+
+2. Configure a trust relationship between the PyPI project and a GitHub repository (and workflow within the repository). For example, if your GitHub repository is at `myorg/myproject` and your release workflow is defined in `release.yml`,
+then you should use the following settings for your GitHub OIDC publisher on PyPI:
+
+    * Owner: `myorg`
+    * Repository name: `myproject`
+    * Workflow name: `release.yml`
+
+    Take care to enter these values correctly: giving the incorrect user, repository, or workflow
+    the ability to publish to your PyPI project is equivalent to sharing an API token.
+
+## Updating your {% data variables.product.prodname_actions %} workflow
+
+Once your OIDC publisher is registered on PyPI, you can update your release workflow to use OIDC publishing.
+
+The [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypa-publish) has built-in support for OIDC publishing, which can be enabled by giving its containing job the `id-token: write` permission and omitting the ordinary `username` and `password` action settings.
+
+The following example uses `pypa/gh-action-pypi-publish` to exchange an OIDC token for a PyPI API token, which is then used to upload a package's release distributions to PyPI.
+
+```yaml{:copy}
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: build release distributions
+        run: |
+          # NOTE: put your own distribution build steps here.
+          python -m build
+
+      - name: upload windows dists
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v3
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+```


### PR DESCRIPTION
**This is a work in progress.**

### Why:

Closes #24594.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This adds some documentation and a guide for OIDC federation between GitHub and [PyPI](https://pypi.org), the Python Package Index. PyPI's OIDC publishing support is currently in a closed beta, so these changes are not 100% ready for public consumption yet; I'm just pushing this up for visibility + to get the ball rolling for when they become generally available 🙂 

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
