### PR TITLE
Fix typo in Azure deploy

### DIFF
--- a/.github/workflows/azure-preview-env-deploy.yml
+++ b/.github/workflows/azure-preview-env-deploy.yml
@@ -213,7 +213,7 @@ jobs:
             dockerRegistryUsername="${{ env.NONPROD_REGISTRY_USERNAME }}"
             dockerRegistryPassword="${{ secrets.NONPROD_REGISTRY_PASSWORD }}"
 
-      - name: Check that it can reached
+      - name: Check that it can be reached
         # This introduces a necessary delay. Because the preview evironment
         # URL is announced to the pull request as soon as all the steps
         # finish, what sometimes happens is that a viewer of the PR clicks


### PR DESCRIPTION

### Why:

Fixes grammatical error in the name of a  build step.

Closes: N/A

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fixes "Check that it can reached" to "Check that it can be reached"

### Check off the following:

- [ ] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
