### PR TITLE
fix: /app/installations should be GET method

### DIFF
--- a/content/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app.md
+++ b/content/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app.md
@@ -23,7 +23,7 @@ If a REST API endpoint requires you to authenticate as an app, the documentation
 1. Include the JWT in the `Authorization` header of your request. In the following example, replace `YOUR_JWT` with your JWT.
 
    ```shell
-   curl --request POST \
+   curl --request GET \
    --url "{% data variables.product.api_url_pre %}/app/installations" \
    --header "Accept: application/vnd.github+json" \
    --header "Authorization: Bearer YOUR_JWT"{% ifversion api-date-versioning %}\


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
The example for **Github APP JWT Authentication** has a wrong request method `POST`.
According to Github API docs, it should be `GET`.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Change request method to `GET`.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
