### PR TITLE
Specify scope of default environment variables

### DIFF
--- a/content/actions/learn-github-actions/variables.md
+++ b/content/actions/learn-github-actions/variables.md
@@ -274,6 +274,8 @@ Configuration variables can be accessed across the workflow using `vars` context
 
 The default environment variables that {% data variables.product.prodname_dotcom %} sets are available to every step in a workflow.
 
+Because default environment variables are set by GitHub and not defined in a workflow, they are not accessible through the env context. However, most of the default variables have a corresponding, and similarly named, context property. For example, the value of the GITHUB_REF variable can be read during workflow processing using the ${{ github.ref }} context property.
+
 {% data reusables.actions.environment-variables-are-fixed %} For more information about setting environment variables, see "[Defining environment variables for a single workflow](#defining-environment-variables-for-a-single-workflow)" and "[AUTOTITLE](/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable)."
 
 We strongly recommend that actions use variables to access the filesystem rather than using hardcoded file paths. {% data variables.product.prodname_dotcom %} sets variables for actions to use in all runner environments.
@@ -341,7 +343,6 @@ We strongly recommend that actions use variables to access the filesystem rather
 **Note:**
 
 - If you need to use a workflow run's URL from within a job, you can combine these variables: `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`
-- Most of the default variables have a corresponding, and similarly named, context property. For example, the value of the `GITHUB_REF` variable can be read during workflow processing using the {% raw %}`${{ github.ref }}`{% endraw %} context property.
 
 {% endnote %}
 

--- a/content/actions/learn-github-actions/variables.md
+++ b/content/actions/learn-github-actions/variables.md
@@ -340,9 +340,7 @@ We strongly recommend that actions use variables to access the filesystem rather
 
 {% note %}
 
-**Note:**
-
-- If you need to use a workflow run's URL from within a job, you can combine these variables: `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`
+**Note:** If you need to use a workflow run's URL from within a job, you can combine these variables: `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID`
 
 {% endnote %}
 

--- a/content/actions/learn-github-actions/variables.md
+++ b/content/actions/learn-github-actions/variables.md
@@ -274,7 +274,7 @@ Configuration variables can be accessed across the workflow using `vars` context
 
 The default environment variables that {% data variables.product.prodname_dotcom %} sets are available to every step in a workflow.
 
-Because default environment variables are set by GitHub and not defined in a workflow, they are not accessible through the env context. However, most of the default variables have a corresponding, and similarly named, context property. For example, the value of the GITHUB_REF variable can be read during workflow processing using the ${{ github.ref }} context property.
+Because default environment variables are set by {% data variables.product.prodname_dotcom %} and not defined in a workflow, they are not accessible through the `env` context. However, most of the default variables have a corresponding, and similarly named, context property. For example, the value of the `GITHUB_REF` variable can be read during workflow processing using the {% raw %}`${{ github.ref }}`{% endraw %} context property.
 
 {% data reusables.actions.environment-variables-are-fixed %} For more information about setting environment variables, see "[Defining environment variables for a single workflow](#defining-environment-variables-for-a-single-workflow)" and "[AUTOTITLE](/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable)."
 


### PR DESCRIPTION
It is not obvious that default environment variables will not be available in the `env` context. We add a note to that regard.


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #24895 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
