### PR TITLE
Fix URL syntax in "CI tests with the Checks API"

### DIFF
--- a/content/apps/creating-github-apps/guides/creating-ci-tests-with-the-checks-api.md
+++ b/content/apps/creating-github-apps/guides/creating-ci-tests-with-the-checks-api.md
@@ -98,7 +98,7 @@ Great! Your app has permission to do the tasks you want it to do. Now you can ad
 
 ## Step 1.2. Adding event handling
 
-Now that your app is subscribed to the **Check suite** and **Check run** events, it will start receiving the [`check_suite`](/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite) and [`check_run`](/webhooks-and-events/webhooks/webhook-events-and-payloads#check_run) webhooks. GitHub sends webhook payloads as `POST` requests. Because you forwarded your Smee webhook payloads to `http://localhost/event_handler:3000`, your server will receive the `POST` request payloads at the `post '/event_handler'` route.
+Now that your app is subscribed to the **Check suite** and **Check run** events, it will start receiving the [`check_suite`](/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite) and [`check_run`](/webhooks-and-events/webhooks/webhook-events-and-payloads#check_run) webhooks. GitHub sends webhook payloads as `POST` requests. Because you forwarded your Smee webhook payloads to `http://localhost:3000/event_handler`, your server will receive the `POST` request payloads at the `post '/event_handler'` route.
 
 An empty `post '/event_handler'` route is already included in the `template_server.rb` file, which you downloaded in the [prerequisites](#prerequisites) section. The empty route looks like this:
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

A misformatted URL existed in the [GitHub Apps guide "CI tests with the Checks API" section 1.2](https://docs.github.com/en/apps/creating-github-apps/guides/creating-ci-tests-with-the-checks-api#step-12-adding-event-handling). An URL indicates `domain/path:port` when the expected format is `domain:port/path`.

<!-- Closes: -->

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
A URL displayed as `code` is corrected to display correct format. _`http://localhost/event_handler:3000`_ becomes `http://localhost:3000/event_handler`.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
