### PR TITLE
Fix actions importer install copy

### DIFF
--- a/data/reusables/actions/installing-actions-importer.md
+++ b/data/reusables/actions/installing-actions-importer.md
@@ -1,7 +1,7 @@
 1. Install the {% data variables.product.prodname_actions_importer %} CLI extension:
 
    ```bash{:copy}
-   $ gh extension install github/gh-actions-importer
+   gh extension install github/gh-actions-importer
    ```
 1. Verify that the extension is installed:
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The copy button includes the `$ ` in the copied command.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fixes the command to install the `gh-actions-importer` extension

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
