### PR TITLE
Note limitation about OAuth client types

### DIFF
--- a/content/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app.md
+++ b/content/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app.md
@@ -52,3 +52,7 @@ topics:
 {% endif %}{% ifversion device-flow-is-opt-in %}
 1. If your OAuth App will use the device flow to identify and authorize users, click **Enable Device Flow**. For more information about the device flow, see "[AUTOTITLE](/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow)."{% endif %}
 1. Click **Register application**.
+
+## Limitations
+
+OAuth specification RFC 6749 [defines two client types](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1): confidential and public. GitHub assumes all OAuth Apps to be confidential clients.


### PR DESCRIPTION
OAuth developers expect to be able to specify client type during OAuth registration, so it's worthwhile to note this limitation.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
