### PR TITLE
Update workflow-syntax-for-github-actions.md

### DIFF
--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -1088,12 +1088,12 @@ The characters `*`, `[`, and `!` are special characters in YAML. If you start a 
 
 ```yaml
 # Valid
-branches:
+paths:
   - '**/README.md'
 
 # Invalid - creates a parse error that
 # prevents your workflow from running.
-branches:
+paths:
   - **/README.md
 
 # Valid


### PR DESCRIPTION
### Why:

Filter pattern cheat sheet notes incorrect yaml key for file path pattern examples.

Closes: No existing issue exists

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fixed "Filter pattern cheat sheet" noting "branches" instead of "paths" in the pattern examples.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
