### PR TITLE
API documentation: Fixing space new header line bug

### DIFF
--- a/content/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation.md
+++ b/content/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation.md
@@ -49,7 +49,7 @@ In the following example, replace `INSTALLATION_ACCESS_TOKEN` with an installati
 curl --request GET \
 --url "{% data variables.product.api_url_pre %}/meta" \
 --header "Accept: application/vnd.github+json" \
---header "Authorization: Bearer INSTALLATION_ACCESS_TOKEN"{% ifversion api-date-versioning %}\
+--header "Authorization: Bearer INSTALLATION_ACCESS_TOKEN"{% ifversion api-date-versioning %} \
 --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
 ```
 

--- a/content/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app.md
+++ b/content/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app.md
@@ -26,7 +26,7 @@ If a REST API endpoint requires you to authenticate as an app, the documentation
    curl --request GET \
    --url "{% data variables.product.api_url_pre %}/app/installations" \
    --header "Accept: application/vnd.github+json" \
-   --header "Authorization: Bearer YOUR_JWT"{% ifversion api-date-versioning %}\
+   --header "Authorization: Bearer YOUR_JWT"{% ifversion api-date-versioning %} \
    --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
    ```
 

--- a/content/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app.md
+++ b/content/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app.md
@@ -30,7 +30,7 @@ To use a JWT, pass it in the `Authorization` header of an API request. For examp
 curl --request GET \
 --url "{% data variables.product.api_url_pre %}/app" \
 --header "Accept: application/vnd.github+json" \
---header "Authorization: Bearer YOUR_JWT"{% ifversion api-date-versioning %}\
+--header "Authorization: Bearer YOUR_JWT"{% ifversion api-date-versioning %} \
 --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
 ```
 

--- a/content/rest/guides/getting-started-with-the-rest-api.md
+++ b/content/rest/guides/getting-started-with-the-rest-api.md
@@ -326,7 +326,7 @@ To send a header in a `curl` command, use the `--header` or `-H` flag followed b
 curl --request GET \
 --url "https://api.github.com/octocat" \
 --header "Accept: application/vnd.github+json" \
---header "Authorization: Bearer <em>YOUR-TOKEN</em>"{% ifversion api-date-versioning %}\
+--header "Authorization: Bearer <em>YOUR-TOKEN</em>"{% ifversion api-date-versioning %} \
 --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
 ```
 

--- a/content/rest/overview/authenticating-to-the-rest-api.md
+++ b/content/rest/overview/authenticating-to-the-rest-api.md
@@ -23,7 +23,7 @@ You can authenticate your request by sending a token in the `Authorization` head
 ```shell
 curl --request GET \
 --url "{% data variables.product.api_url_code %}/octocat" \
---header "Authorization: Bearer YOUR-TOKEN"{% ifversion api-date-versioning %}\
+--header "Authorization: Bearer YOUR-TOKEN"{% ifversion api-date-versioning %} \
 --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
 ```
 
@@ -61,7 +61,7 @@ For example:
 ```shell
 curl --request POST \
 --url "{% data variables.product.api_url_code %}/authorizations"
---user CLIENT_ID:CLIENT_SECRET{% ifversion api-date-versioning %}\
+--user CLIENT_ID:CLIENT_SECRET{% ifversion api-date-versioning %} \
 --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
 ```
 
@@ -80,7 +80,7 @@ If you want to use the API in a {% data variables.product.prodname_actions %} wo
 ```shell
 curl --request GET \
 --url "{% data variables.product.api_url_code %}/user"
---user USERNAME:PASSWORD{% ifversion api-date-versioning %}\
+--user USERNAME:PASSWORD{% ifversion api-date-versioning %} \
 --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
 ```
 

--- a/content/rest/overview/resources-in-the-rest-api.md
+++ b/content/rest/overview/resources-in-the-rest-api.md
@@ -90,7 +90,7 @@ You can authenticate your request by sending a token in the `Authorization` head
 ```shell
 curl --request GET \
 --url "{% data variables.product.api_url_code %}/octocat" \
---header "Authorization: Bearer YOUR-TOKEN"{% ifversion api-date-versioning %}\
+--header "Authorization: Bearer YOUR-TOKEN"{% ifversion api-date-versioning %} \
 --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
 ```
 

--- a/data/reusables/apps/generate-installation-access-token.md
+++ b/data/reusables/apps/generate-installation-access-token.md
@@ -12,7 +12,7 @@
    curl --request POST \
    --url "{% data variables.product.api_url_pre %}/app/installations/INSTALLATION_ID/access_tokens" \
    --header "Accept: application/vnd.github+json" \
-   --header "Authorization: Bearer JWT"{% ifversion api-date-versioning %}\
+   --header "Authorization: Bearer JWT"{% ifversion api-date-versioning %} \
    --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
    ```
 

--- a/data/reusables/apps/user-access-token-example-request.md
+++ b/data/reusables/apps/user-access-token-example-request.md
@@ -4,6 +4,6 @@
    curl --request GET \
    --url "{% data variables.product.api_url_pre %}/user" \
    --header "Accept: application/vnd.github+json" \
-   --header "Authorization: Bearer USER_ACCESS_TOKEN"{% ifversion api-date-versioning %}\
+   --header "Authorization: Bearer USER_ACCESS_TOKEN"{% ifversion api-date-versioning %} \
    --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
    ```


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Before the line to add the API version header, the `\` to signify a new line doesn't have a space after the previous header, so the request fails.

The doc page:
![image](https://github.com/github/docs/assets/19912012/074bd2c2-8952-4e57-b30d-33bb328cfdd1)

the error message: 
![image](https://github.com/github/docs/assets/19912012/95945fc7-1b55-46e5-870d-0839e5ef0336)

> {
>   "message": "A JSON web token could not be decoded",
>   "documentation_url": "https://docs.github.com/rest"
> }
> curl: (3) URL using bad/illegal format or missing URL

Adding a space works:
![image](https://github.com/github/docs/assets/19912012/e0d094e0-5c27-424e-b25c-15a39eefc90f)


### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Adding a space in several spots in the docs where it is missing before the date/version header. 

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
