### PR TITLE
Fix link in creating-personal-access-token

### DIFF
--- a/content/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token.md
+++ b/content/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token.md
@@ -28,7 +28,7 @@ shortTitle: 'Create a {% data variables.product.pat_generic %}'
 
 ## About {% data variables.product.pat_generic %}s
 
-{% data variables.product.pat_generic_caps %}s are an alternative to using passwords for authentication to {% data variables.product.product_name %} when using the [GitHub API](/rest/overview/authenticating-to-the-rest-api) or the [command line](#using-a-token-on-the-command-line).
+{% data variables.product.pat_generic_caps %}s are an alternative to using passwords for authentication to {% data variables.product.product_name %} when using the [GitHub API](/rest/overview/authenticating-to-the-rest-api) or the [command line](#using-a-personal-access-token-on-the-command-line).
 
 {% data variables.product.pat_generic_caps %}s are intended to access {% data variables.product.company_short %} resources on behalf of yourself. To access resources on behalf of an organization, or for long-lived integrations, you should use a {% data variables.product.prodname_github_app %}. For more information, see "[AUTOTITLE](/apps/creating-github-apps/creating-github-apps/about-apps)."
 


### PR DESCRIPTION
### Why:

Closes: #25000 

### What's being changed (if available, include any code snippets, screenshots, or gifs):

In the https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token, there's a text, "command line", which directs to `#using-a-token-on-the-command-line`. 

It's changed to `#using-a-personal-access-token-on-the-command-line`

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
