### PR TITLE
Fix the command of deleting a remote branch

### DIFF
--- a/content/get-started/using-git/pushing-commits-to-a-remote-repository.md
+++ b/content/get-started/using-git/pushing-commits-to-a-remote-repository.md
@@ -71,7 +71,7 @@ git push REMOTE-NAME --tags
 The syntax to delete a branch is a bit arcane at first glance:
 
 ```shell
-git push REMOTE-NAME:BRANCH-NAME
+git push REMOTE-NAME :BRANCH-NAME
 ```
 
 Note that there is a space before the colon. The command resembles the same steps


### PR DESCRIPTION
### Why:

Closes: #25052

### What's being changed (if available, include any code snippets, screenshots, or gifs):

In https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository#deleting-a-remote-branch-or-tag, a missing whitespace is restored in the command.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
