### PR TITLE
Changing number to string in example yaml

### DIFF
--- a/content/actions/automating-builds-and-tests/building-and-testing-go.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-go.md
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: {% data reusables.actions.action-setup-go %}
         with:
-          go-version: 1.15
+          go-version: '1.15'
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
This example shows supplying go-version as a number 1.15, this works for version up to 1.19, but with 1.20, it will turn it into a number (1.2) and then back into a string "1.2" making the action use Go 1.2 instead of 1.20.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
I saw someone face this issue and realized the problem came from this example on the docs.

Closes: #25145 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Go version type from 1.5 to '1.5' to prevent wrong version after conversion to number.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
