### PR TITLE
fix a typo on git-filter-repo command

### DIFF
--- a/content/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository.md
+++ b/content/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository.md
@@ -104,7 +104,7 @@ To illustrate how `git filter-repo` works, we'll show you how to remove your fil
     - Remove some configurations, such as the remote URL, stored in the *.git/config* file. You may want to back up this file in advance for restoration later.
     - **Overwrite your existing tags**
         ```shell
-        $ git filter-repo --invert-paths --path PATH-TO-YOUR-FILE-WITH-SENSITIVE-DATA
+        $ git-filter-repo --invert-paths --path PATH-TO-YOUR-FILE-WITH-SENSITIVE-DATA
         Parsed 197 commits
         New history written in 0.11 seconds; now repacking/cleaning...
         Repacking your repo and cleaning out old unneeded objects


### PR DESCRIPTION
In line 107 $git filter-repo --invert-paths ... should be  $git-filter-repo --invert-paths ... as we are using the tool and not git itself

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
