### PR TITLE
Fix markdown render error in issue event types

### DIFF
--- a/content/webhooks-and-events/events/issue-event-types.md
+++ b/content/webhooks-and-events/events/issue-event-types.md
@@ -419,6 +419,7 @@ This event is available for the following issue types.
 |Pull requests| {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
 
 {% endrowheaders %}
+
 ## head_ref_force_pushed
 
 The pull request's HEAD branch was force pushed.
@@ -916,6 +917,7 @@ This event is available for the following issue types.
 |Issues| {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
 
 {% endrowheaders %}
+
 ### Properties for unpinned
 
 {% data reusables.issue-events.issue-event-common-properties %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Markdown content is not correctly rendered. Screenshots as follows:

<details>

![image](https://github.com/github/docs/assets/42488585/59bf4deb-6c67-438f-bbf9-ea19ff8b81f7)
![image](https://github.com/github/docs/assets/42488585/a61a11b0-2d88-4172-bdf1-38fe88f12f8c)

</details>

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Seems this is caused due to the missing blank line.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
