### PR TITLE
Update repo dispatch to show proper `type`

### DIFF
--- a/content/actions/using-workflows/events-that-trigger-workflows.md
+++ b/content/actions/using-workflows/events-that-trigger-workflows.md
@@ -1100,7 +1100,7 @@ When you make a request to create a `repository_dispatch` event, you must specif
 ```yaml
 on:
   repository_dispatch:
-    types: [on-demand-test]
+    types: [test_result]
 ```
 
 {% note %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

This updates the `repository_dispatch` event type example to show the trigger as the same `type` that is in the `payload` example.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Currently the `repository_dispatch` event for events that trigger Actions workflows is confusiong. The trigger example shows a type of `on-demand-test`, however the example of the `client_payload` shows `test_result` as the type instead.

![image](https://github.com/github/docs/assets/2894107/6021608d-2ce8-4eb7-96fe-06a66e65ab3e)

This change corrects this to show the proper `event_type` in the `client_payload` so that users can match the `trigger` to the `payload` more easily:

![image](https://github.com/github/docs/assets/2894107/42f4c2b7-22ae-442c-9fa1-c1144018a83e)

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
