### PR TITLE
Update GitHub-hosted macOS runners

### DIFF
--- a/content/actions/using-github-hosted-runners/about-github-hosted-runners.md
+++ b/content/actions/using-github-hosted-runners/about-github-hosted-runners.md
@@ -124,9 +124,9 @@ For the overall list of included tools for each runner operating system, see the
 * [Ubuntu 20.04 LTS](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md)
 * [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md)
 * [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md)
+* [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)
 * [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)
 * [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)
-* [macOS 10.15](https://github.com/actions/runner-images/blob/main/images/macos/macos-10.15-Readme.md)
 
 {% data variables.product.prodname_dotcom %}-hosted runners include the operating system's default built-in tools, in addition to the packages listed in the above references. For example, Ubuntu and macOS runners include `grep`, `find`, and `which`, among other default tools.
 


### PR DESCRIPTION
### Why:

- macOS 10.15 is now fully unsupported (actions/runner-images#5583).
- macOS 13 is now available (actions/runner-images#6426).

Closes: #25254

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The link to macOS 10.15 runner specs is removed, and a link to macOS 13 runner specs is added.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
