### PR TITLE
Update syntax-for-issue-forms.md

### DIFF
--- a/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
+++ b/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
@@ -46,7 +46,7 @@ You can set the following top-level keys for each issue form.
 | `description` | A description for the issue form template, which appears in the template chooser interface. | Required | String |
 | `body` | Definition of the input types in the form. | Required | Array |
 | `assignees` | People who will be automatically assigned to issues created with this template. | Optional | Array or comma-delimited string |
-| `labels` | Labels that will automatically be added to issues created with this template. | Optional | Array or comma-delimited string |
+| `labels` | Labels that will automatically be added to issues created with this template. Be aware, that if a label does not already exist on the repository, it will not be automatically suggested on the resulting issue created from the template. | Optional | Array or comma-delimited string |
 | `title` | A default title that will be pre-populated in the issue submission form. | Optional | String |
 
 For the available `body` input types and their syntaxes, see "[AUTOTITLE](/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema)."

--- a/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
+++ b/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
@@ -46,7 +46,7 @@ You can set the following top-level keys for each issue form.
 | `description` | A description for the issue form template, which appears in the template chooser interface. | Required | String |
 | `body` | Definition of the input types in the form. | Required | Array |
 | `assignees` | People who will be automatically assigned to issues created with this template. | Optional | Array or comma-delimited string |
-| `labels` | Labels that will automatically be added to issues created with this template. Be aware, that if a label does not already exist on the repository, it will not be automatically suggested on the resulting issue created from the template. | Optional | Array or comma-delimited string |
+| `labels` | Labels that will automatically be added to issues created with this template. If a label does not already exist in the repository, it will not be automatically added to the issue. | Optional | Array or comma-delimited string |
 | `title` | A default title that will be pre-populated in the issue submission form. | Optional | String |
 
 For the available `body` input types and their syntaxes, see "[AUTOTITLE](/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema)."


### PR DESCRIPTION
Added warning to the label attribute description that the label must already be present on the repository in order for this to be automatically suggested on the resulting issue created from the template

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: 
github/docs-content/issues/10319

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
