### PR TITLE
Update licensing-a-repository.md: Add 0BSD

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository.md
@@ -46,6 +46,7 @@ License | License keyword
 | BSD 2-clause "Simplified" license | `bsd-2-clause` |
 | BSD 3-clause "New" or "Revised" license | `bsd-3-clause` |
 | BSD 3-clause Clear license | `bsd-3-clause-clear` |
+| BSD Zero-Clause license | `0bsd` |
 | Creative Commons license family | `cc` |
 | Creative Commons Zero v1.0 Universal | `cc0-1.0` |
 | Creative Commons Attribution 4.0 | `cc-by-4.0` |


### PR DESCRIPTION
### Why:

The 0BSD is an important license that gains popularity. It's a "Pubic Domain equvalent" category of licenses. It's ideal fo code samples that may be heavily changed and used in a bussiness software but it doesn't require to preserve the copyright holder notice. Many similar projects currently use MIT license but it requires to copy it into sources.

- The license was explicitly approved bu Google, Samsung, Microsoft to use in their repositories.
- The BSD licenses are well known for corporate lawyers and they’ll be fine with it.
- It doesn’t mention the problematic Public Domain but it’s effectively its equivalent.
- It’s quite popular and used even more often by WTFPL.
- It’s very short and doesn’t have many versions.
- It’s old and used since 2006

Closes: 

None

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added the 0BSD license to a list of licenses. This will let know to developers about the option.

### Check off the following:

- [x] I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
