### PR TITLE
Add missing line continuation to REST API authentication docs (#25482)

### DIFF
--- a/content/rest/overview/authenticating-to-the-rest-api.md
+++ b/content/rest/overview/authenticating-to-the-rest-api.md
@@ -60,7 +60,7 @@ For example:
 
 ```shell
 curl --request POST \
---url "{% data variables.product.api_url_code %}/authorizations"
+--url "{% data variables.product.api_url_code %}/authorizations" \
 --user CLIENT_ID:CLIENT_SECRET{% ifversion api-date-versioning %} \
 --header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: https://github.com/github/docs/issues/25482

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adding a missing line continuation to REST API authentication docs.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
