### PR TITLE
Clarifying the conditions for Azure sub

### DIFF
--- a/content/billing/managing-billing-for-your-github-account/connecting-an-azure-subscription.md
+++ b/content/billing/managing-billing-for-your-github-account/connecting-an-azure-subscription.md
@@ -22,6 +22,8 @@ shortTitle: Connect an Azure subscription
 
 **Note:** If your enterprise account is on a Microsoft Enterprise Agreement, connecting an Azure subscription is the only way to use {% data variables.product.prodname_actions %} and {% data variables.product.prodname_registry %} beyond the included amounts, or to use {% data variables.product.prodname_github_codespaces %} and {% data variables.product.prodname_copilot_business_short %} at all.
 
+**Note:** If your organisation is a part of an enteprirse account, you will only be able to connect your Azure subscription to enteprise account and not to orgnisation account.
+
 {% endnote %}
 {% endif %}
 After you connect an Azure subscription, you can also manage your spending limits.

--- a/content/billing/managing-billing-for-your-github-account/connecting-an-azure-subscription.md
+++ b/content/billing/managing-billing-for-your-github-account/connecting-an-azure-subscription.md
@@ -15,14 +15,16 @@ shortTitle: Connect an Azure subscription
 
 {% data reusables.enterprise-accounts.billing-azure-subscription %} For more information, see "[AUTOTITLE](/billing/managing-billing-for-github-actions/about-billing-for-github-actions)," "[AUTOTITLE](/billing/managing-billing-for-github-packages/about-billing-for-github-packages)," and "[AUTOTITLE](/billing/managing-billing-for-github-copilot)."
 
+{% ifversion ghec %}
+If your organisation is a part of an enteprirse account, you will only be able to connect your Azure subscription to enteprise account and not to orgnisation account.
+{% endif %}
+
 {% data reusables.enterprise.ghec-trial-azure %}
 
 {% ifversion ghec %}
 {% note %}
 
 **Note:** If your enterprise account is on a Microsoft Enterprise Agreement, connecting an Azure subscription is the only way to use {% data variables.product.prodname_actions %} and {% data variables.product.prodname_registry %} beyond the included amounts, or to use {% data variables.product.prodname_github_codespaces %} and {% data variables.product.prodname_copilot_business_short %} at all.
-
-**Note:** If your organisation is a part of an enteprirse account, you will only be able to connect your Azure subscription to enteprise account and not to orgnisation account.
 
 {% endnote %}
 {% endif %}

--- a/content/billing/managing-billing-for-your-github-account/connecting-an-azure-subscription.md
+++ b/content/billing/managing-billing-for-your-github-account/connecting-an-azure-subscription.md
@@ -16,7 +16,7 @@ shortTitle: Connect an Azure subscription
 {% data reusables.enterprise-accounts.billing-azure-subscription %} For more information, see "[AUTOTITLE](/billing/managing-billing-for-github-actions/about-billing-for-github-actions)," "[AUTOTITLE](/billing/managing-billing-for-github-packages/about-billing-for-github-packages)," and "[AUTOTITLE](/billing/managing-billing-for-github-copilot)."
 
 {% ifversion ghec %}
-If your organisation is a part of an enteprirse account, you will only be able to connect your Azure subscription to enteprise account and not to orgnisation account.
+If your organization is a part of an enterprise account, you can only connect your Azure subscription to the enterprise account, not the organization.
 {% endif %}
 
 {% data reusables.enterprise.ghec-trial-azure %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Organisations will be able to connect to Azure subscription only if they are not a part of an enterprise account. This is not clear from the documentation; the change should clarify that.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
