### PR TITLE
Fix theme mismatch

### DIFF
--- a/components/hooks/useTheme.ts
+++ b/components/hooks/useTheme.ts
@@ -105,14 +105,14 @@ export function useTheme() {
   })
 
   useEffect(() => {
-    // Using setTimeout with a default delay value of 0 interjects one 
-    // additional event cycle, which works around a bug that is the 
+    // Using setTimeout with a default delay value of 0 interjects one
+    // additional event cycle, which works around a bug that is the
     // result of a timing issue. Without the setTimeout function
-    // the page loads, then the docs site switches the color mode to 
-    // match the user's GitHub color mode. Primer React has a useEffect 
+    // the page loads, then the docs site switches the color mode to
+    // match the user's GitHub color mode. Primer React has a useEffect
     // call that overrides this change, causing the site to ignore the
     // user's GitHub color mode and revert to auto.
-    // As a temporary workaround, this code that fetches the user's GitHub 
+    // As a temporary workaround, this code that fetches the user's GitHub
     // color mode will be called after Primer React's useEffect call.
     // The long term solution to this theming issue is to migrate to CSS variables
     // under the hood, which Primer is planning to do in the next couple quarters.

--- a/components/hooks/useTheme.ts
+++ b/components/hooks/useTheme.ts
@@ -116,6 +116,7 @@ export function useTheme() {
     // color mode will be called after Primer React's useEffect call.
     // The long term solution to this theming issue is to migrate to CSS variables
     // under the hood, which Primer is planning to do in the next couple quarters.
+    // Reference: https://github.com/primer/react/issues/2229
     setTimeout(() => {
       const cookieValue = Cookies.get('color_mode')
       const css = getCssTheme(cookieValue)

--- a/components/hooks/useTheme.ts
+++ b/components/hooks/useTheme.ts
@@ -105,6 +105,17 @@ export function useTheme() {
   })
 
   useEffect(() => {
+    // Using setTimeout with a default delay value of 0 interjects one 
+    // additional event cycle, which works around a bug that is the 
+    // result of a timing issue. Without the setTimeout function
+    // the page loads, then the docs site switches the color mode to 
+    // match the user's GitHub color mode. Primer React has a useEffect 
+    // call that overrides this change, causing the site to ignore the
+    // user's GitHub color mode and revert to auto.
+    // As a temporary workaround, this code that fetches the user's GitHub 
+    // color mode will be called after Primer React's useEffect call.
+    // The long term solution to this theming issue is to migrate to CSS variables
+    // under the hood, which Primer is planning to do in the next couple quarters.
     setTimeout(() => {
       const cookieValue = Cookies.get('color_mode')
       const css = getCssTheme(cookieValue)

--- a/components/hooks/useTheme.ts
+++ b/components/hooks/useTheme.ts
@@ -105,10 +105,12 @@ export function useTheme() {
   })
 
   useEffect(() => {
-    const cookieValue = Cookies.get('color_mode')
-    const css = getCssTheme(cookieValue)
-    const component = getComponentTheme(cookieValue)
-    setTheme({ css, component })
+    setTimeout(() => {
+      const cookieValue = Cookies.get('color_mode')
+      const css = getCssTheme(cookieValue)
+      const component = getComponentTheme(cookieValue)
+      setTheme({ css, component })
+    })
   }, [])
 
   return { theme }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Fixes a theme mismatch issue that occurs when the OS color mode doesn't match the user's GitHub color mode (e.g., OS: `dark`, GitHub: `light`).

| Before | After |
| --- | --- |
| ![CleanShot 2023-05-18 at 16 34 36](https://github.com/github/docs/assets/4608155/87448056-ab96-4e5d-8a1a-4eaaf66ffb51) | ![CleanShot 2023-05-18 at 16 35 01](https://github.com/github/docs/assets/4608155/e030eba1-e485-4237-89a5-c259dba46e3b) |

Closes: https://github.com/primer/react/issues/2229

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

This bug was the result of a timing issue. After a page loads, the docs site switches the color mode to match the user's GitHub color mode. However, Primer React has a `useEffect` call that overrides this change, causing the site to ignore the user's GitHub color mode and revert to `auto`. 

As a temporary workaround, I've wrapped the code that fetches the user's GitHub color mode in a `setTimeout()` call to ensure that it's called after Primer React's `useEffect` call. The long term solution to this theming issue is to migrate to CSS variables under the hood, which Primer is planning to do in the next couple quarters.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] ~~For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).~~
