### PR TITLE
Remove a confusing sentence from `about-code-owners.md`

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -1,7 +1,7 @@
 ---
 title: About code owners
 intro: You can use a CODEOWNERS file to define individuals or teams that are responsible for code in a repository.
-permissions: People with write permissions for the repository can create or edit the CODEOWNERS file and can be listed as code owners in it. People with admin or owner permissions can require that pull requests by approved by code owners before they can be merged.
+permissions: 'People with write permissions for the repository can create or edit the CODEOWNERS file and be listed as code owners. People with admin or owner permissions can require that pull requests have to be approved by code owners before they can be merged.'
 redirect_from:
   - /articles/about-codeowners
   - /articles/about-code-owners

--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -1,6 +1,7 @@
 ---
 title: About code owners
 intro: You can use a CODEOWNERS file to define individuals or teams that are responsible for code in a repository.
+permissions: People with write permissions for the repository can create or edit the CODEOWNERS file and can be listed as code owners in it. People with admin or owner permissions can require that pull requests by approved by code owners before they can be merged.
 redirect_from:
   - /articles/about-codeowners
   - /articles/about-code-owners
@@ -15,8 +16,6 @@ versions:
 topics:
   - Repositories
 ---
-People with admin or owner permissions can set up a CODEOWNERS file in a repository.
-
 The people you choose as code owners must have write permissions for the repository. When the code owner is a team, that team must be visible and it must have write permissions, even if all the individual members of the team already have write permissions directly, through organization membership, or through another team membership.
 
 ## About code owners


### PR DESCRIPTION
The CODEOWNERS docs start with the statement:

> People with admin or owner permissions can set up a CODEOWNERS file in a repository.

However, this is confusing because people with write permissions can create and edit the `CODEOWNERS` file itself whereas admin/owner permissions are required to _enforce_ reviews from code owners with branch protection settings.

See this discussion: [About CODEOWNERS - User with Write permissions also can setup?](https://github.com/orgs/community/discussions/36497#discussioncomment-3901570)

I'm proposing to remove the sentence because the doc already explains how to enforce reviews from code owners in this paragraph below:

> When someone with admin or owner permissions has enabled required reviews, they also can optionally require approval from a code owner before the author can merge a pull request in the repository. For more information, see "[About protected branches.](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-pull-request-reviews-before-merging)"

* * *

[Preview](https://docs-25692-f98a3d.preview.ghdocs.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

* * *

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

I actually took that sentence at face value for a while and _didn't consider using CODEOWNERS_ at my company in a context where it wouldn't have worked for only repo admins to be able to edit the file!

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
