### PR TITLE
Clarify the process for publishing an action to the marketplace when you are not an organization owner

### DIFF
--- a/content/actions/creating-actions/publishing-actions-in-github-marketplace.md
+++ b/content/actions/creating-actions/publishing-actions-in-github-marketplace.md
@@ -43,7 +43,7 @@ To draft a new release and publish the action to {% data variables.product.prodn
 
    {% note %}
    
-   The "Publish" checkbox is disabled if the user or organization that owns the repository has not yet accepted the {% data variables.product.prodname_marketplace %} Developer Agreement. If you own the repository or are an organization owner, a link to "accept the GitHub Marketplace Developer Agreement" is displayed. Click this link and accept the agreement to continue. If there is no link, send the organization owner a link to this "Release Action" page and ask them to accept the agreement.
+   **Note**: The "Publish" checkbox is disabled if the account that owns the repository has not yet accepted the {% data variables.product.prodname_marketplace %} Developer Agreement. If you own the repository or are an organization owner, click the link to "accept the GitHub Marketplace Developer Agreement", then accept the agreement. If there is no link, send the organization owner a link to this "Release Action" page and ask them to accept the agreement.
 
    {% endnote %}
 1. If the labels in your metadata file contain any problems, you will see an error message. Address them by updating your metadata file. Once complete, you will see an "Everything looks good!" message.

--- a/content/actions/creating-actions/publishing-actions-in-github-marketplace.md
+++ b/content/actions/creating-actions/publishing-actions-in-github-marketplace.md
@@ -41,7 +41,11 @@ To draft a new release and publish the action to {% data variables.product.prodn
 1. Navigate to the action metadata file in your repository (`action.yml` or `action.yaml`), and you'll see a banner to publish the action to {% data variables.product.prodname_marketplace %}. Click **Draft a release**.
 1. Under "Release Action", select **Publish this Action to the {% data variables.product.prodname_marketplace %}**.
 
-   If you can't select the checkbox, you must first click the link to read and accept the {% data variables.product.prodname_marketplace %} Developer Agreement.
+   {% note %}
+   
+   The "Publish" checkbox is disabled if the user or organization that owns the repository has not yet accepted the {% data variables.product.prodname_marketplace %} Developer Agreement. If you own the repository or are an organization owner, a link to "accept the GitHub Marketplace Developer Agreement" is displayed. Click this link and accept the agreement to continue. If there is no link, send the organization owner a link to this "Release Action" page and ask them to accept the agreement.
+
+   {% endnote %}
 1. If the labels in your metadata file contain any problems, you will see an error message. Address them by updating your metadata file. Once complete, you will see an "Everything looks good!" message.
 1. Select the **Primary Category** dropdown menu and click a category that will help people find your action in {% data variables.product.prodname_marketplace %}.
 1. Optionally, select the **Another Category** dropdown menu and click a secondary category.


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs/issues/20784

This update is intended to clarify the behavior of the UI if the user is not the owner of an organization.

The note has turned out a little longer than I'd hoped. Feel free to tell me that this would be better as an additional step instead.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Add a note to clarify that for repositories in an organization, only an organization owner can see a link to accept the agreement.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
