### PR TITLE
Add Typescript example to securing-your-webhooks.md

### DIFF
--- a/content/webhooks-and-events/webhooks/securing-your-webhooks.md
+++ b/content/webhooks-and-events/webhooks/securing-your-webhooks.md
@@ -112,4 +112,31 @@ def verify_signature(payload_body, secret_token, signature_header):
         raise HTTPException(status_code=403, detail="Request signatures didn't match!")
 ```
 
+### Typescript example
+
+For example, you can define the following `verify_signature` function and call it when you receive a webhook payload:
+
+```javascript{:copy}
+import * as crypto from "crypto";
+
+const WEBHOOK_SECRET: string = process.env.WEBHOOK_SECRET;
+
+const verify_signature = (req: Request) => {
+  const signature = crypto
+    .createHmac("sha256", WEBHOOK_SECRET)
+    .update(JSON.stringify(req.body))
+    .digest("hex");
+  return `sha256=${signature}` === req.headers.get("x-hub-signature-256");
+};
+
+//
+const handleWebhook = (req: Request, res: Response) => {
+  if (!verify_signature(req)) {
+    res.status(401).send("Unauthorized");
+    return;
+  }
+  // The rest of your logic here
+};
+```
+
 [secure_compare]: https://rubydoc.info/github/rack/rack/main/Rack/Utils:secure_compare

--- a/content/webhooks-and-events/webhooks/securing-your-webhooks.md
+++ b/content/webhooks-and-events/webhooks/securing-your-webhooks.md
@@ -129,7 +129,6 @@ const verify_signature = (req: Request) => {
   return `sha256=${signature}` === req.headers.get("x-hub-signature-256");
 };
 
-//
 const handleWebhook = (req: Request, res: Response) => {
   if (!verify_signature(req)) {
     res.status(401).send("Unauthorized");


### PR DESCRIPTION
### Why:

The existing [Securing your webhooks](https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks) page includes examples for Python and Ruby, but not Typescript. This PR adds a Typescript example that hopefully saves X minutes off future webhook receivers that prefer to code in TS/JS.

Closes: [25789](https://github.com/github/docs/issues/25789)


### What's being changed (if available, include any code snippets, screenshots, or gifs):

An example for verifying webhook payloads written in Typescript is included on the [Securing your webhooks](https://docs.github.com/en/webhooks-and-events/webhooks/securing-your-webhooks) page

<img width="757" alt="image" src="https://github.com/github/docs/assets/3053339/32e3445a-0ef9-4038-a2f0-47d4ccd9045c">


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
