### PR TITLE
doc: highlighted config.yml file in issue-template-config

### DIFF
--- a/data/reusables/repositories/issue-template-config.md
+++ b/data/reusables/repositories/issue-template-config.md
@@ -1,1 +1,1 @@
-You can customize the issue template chooser that people see when creating a new issue in your repository by adding a *config.yml* file to the `.github/ISSUE_TEMPLATE` folder.
+You can customize the issue template chooser that people see when creating a new issue in your repository by adding a `config.yml` file to the `.github/ISSUE_TEMPLATE` folder.


### PR DESCRIPTION
changed *config.yml* to `config.yml` so that it is highlighted and clearly visible

### Why: 
I highlighted the `config.yml` so that it's Cleary visible to new users that you need to create this file to configure issue templates

### What's being changed (if available, include any code snippets, screenshots, or gifs):

changed *config.yml* to `config.yml`

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
