### PR TITLE
Update generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md

### DIFF
--- a/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
+++ b/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
@@ -143,6 +143,12 @@ Before adding a new SSH key to the ssh-agent to manage your keys, you should hav
        Host {% ifversion ghes or ghae %}HOSTNAME{% else %}github.com{% endif %}
          IgnoreUnknown UseKeychain
        ```
+
+     - For MacOS Ventura 13, the above `~/.ssh/config` changes do not work. Passphrases are still needed when trying to push to github remotes. The following command needs to be added to the `.zshrc` file:
+
+       ```
+       ssh-add --apple-load-keychain -q
+       ```
      {% endnote %}
 
 1. Add your SSH private key to the ssh-agent and store your passphrase in the keychain. {% data reusables.ssh.add-ssh-key-to-ssh-agent %}


### PR DESCRIPTION
For MacOS Monterrey, need to run `ssh-add --apple-load-keychain -q` for each terminal session for the passphrase to be added automatically. The ssh config changes do not work anymore. Adding this addition notes. Refer to https://apple.stackexchange.com/questions/444678/macos-12-monterey-m1-keeps-asking-my-ssh-passphrase-every-time, for details.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
