### PR TITLE
Remove unnecessary $ symbols

### DIFF
--- a/content/authentication/managing-commit-signature-verification/generating-a-new-gpg-key.md
+++ b/content/authentication/managing-commit-signature-verification/generating-a-new-gpg-key.md
@@ -29,11 +29,11 @@ topics:
 3. Generate a GPG key pair. Since there are multiple versions of GPG, you may need to consult the relevant [_man page_](https://en.wikipedia.org/wiki/Man_page) to find the appropriate key generation command.
     - If you are on version 2.1.17 or greater, paste the text below to generate a GPG key pair.
       ```shell{:copy}
-      $ gpg --full-generate-key
+      gpg --full-generate-key
       ```
     - If you are not on version 2.1.17 or greater, the `gpg --full-generate-key` command doesn't work. Paste the text below and skip to step 6.
       ```shell{:copy}
-      $ gpg --default-new-key-algo rsa4096 --gen-key
+      gpg --default-new-key-algo rsa4096 --gen-key
       ```
 4. At the prompt, specify the kind of key you want, or press `Enter` to accept the default.
 5. At the prompt, specify the key size you want, or press `Enter` to accept the default.
@@ -51,8 +51,8 @@ topics:
 {% data reusables.gpg.list-keys-with-note %}
 {% data reusables.gpg.copy-gpg-key-id %}
 10. Paste the text below, substituting in the GPG key ID you'd like to use. In this example, the GPG key ID is `3AA5C34371567BD2`:
- ```shell{:copy}
- $ gpg --armor --export 3AA5C34371567BD2
+ ```shell
+ gpg --armor --export 3AA5C34371567BD2
  # Prints the GPG key ID, in ASCII armor format
  ```
 11. Copy your GPG key, beginning with `-----BEGIN PGP PUBLIC KEY BLOCK-----` and ending with `-----END PGP PUBLIC KEY BLOCK-----`.


### PR DESCRIPTION
### Why:
This allows copy pasting without the `bash: $: command not found` error

Closes: https://github.com/github/docs/issues/25820

### What's being changed (if available, include any code snippets, screenshots, or gifs):
`$` are removed in https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key in front of every command

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
