### PR TITLE
Update git-lfs.md

### DIFF
--- a/data/reusables/repositories/git-lfs.md
+++ b/data/reusables/repositories/git-lfs.md
@@ -1,1 +1,1 @@
-If you exceed the limit of {% ifversion ghae %}200 MiB{% else %}5 GB{% endif %}, any new files added to the repository will be rejected silently by Git LFS.
+If you exceed the per file limit of {% ifversion ghae %}200 MiB{% else %}5 GB{% endif %}, the file will be rejected silently by Git LFS.


### PR DESCRIPTION
The previous sentence could be interpreted as a per repo limit, and is ambiguous at best or simply incorrect.

> If you exceed the limit of 5 GB, any new files added to the repository will be rejected silently by Git LFS.

_Files_ that exceed the limit will be silently rejected. I believe the [storage and bandwidth page](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-storage-and-bandwidth-usage) correctly details the quota limits.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Multiple people have inquired about repo limits vs file limits based on this wording. It is confusing and/or incorrect.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

A clarification of LFS per file limits in documentation.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
