### PR TITLE
Update generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md

### DIFF
--- a/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
+++ b/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
@@ -107,7 +107,7 @@ Before adding a new SSH key to the ssh-agent to manage your keys, you should hav
 
 {% data reusables.command_line.start_ssh_agent %}
 
-1. If you're using macOS Sierra 10.12.2 or later, you will need to modify your `~/.ssh/config` file to automatically load keys into the ssh-agent and store passphrases in your keychain.
+1. If you're using macOS Sierra 10.12.2 or newer, you will need to modify your `~/.ssh/config` file to automatically load keys into the ssh-agent and store passphrases in your keychain.
 
    - First, check to see if your `~/.ssh/config` file exists in the default location.
 


### PR DESCRIPTION
### Why:

The wording can be misleading:
'later' version can be read as 'older' as well as 'newer'

### What's being changed (if available, include any code snippets, screenshots, or gifs):

update wording for more clarity since 'later' can be read as 'older' or 'newer'

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
