### PR TITLE
Update testing-custom-queries.md

### DIFF
--- a/content/code-security/codeql-cli/using-the-codeql-cli/testing-custom-queries.md
+++ b/content/code-security/codeql-cli/using-the-codeql-cli/testing-custom-queries.md
@@ -157,8 +157,7 @@ which is declared as a dependency for `my-query-tests`. Therefore, `EmptyThen.ql
 
 1. Create a code snippet to test. The following Java code contains an empty `if` statement on the third line. Save it in `custom-queries/java/tests/EmptyThen/Test.java`.
 
-   ```java
-
+```java
 class Test {
   public void problem(String arg) {
     if (arg.isEmpty())
@@ -174,8 +173,7 @@ class Test {
     }
   }
 }
-
-   ```
+```
 
 ### Execute the test
 

--- a/content/code-security/codeql-cli/using-the-codeql-cli/testing-custom-queries.md
+++ b/content/code-security/codeql-cli/using-the-codeql-cli/testing-custom-queries.md
@@ -157,23 +157,23 @@ which is declared as a dependency for `my-query-tests`. Therefore, `EmptyThen.ql
 
 1. Create a code snippet to test. The following Java code contains an empty `if` statement on the third line. Save it in `custom-queries/java/tests/EmptyThen/Test.java`.
 
-```java
-class Test {
-  public void problem(String arg) {
-    if (arg.isEmpty())
-      ;
-    {
-      System.out.println("Empty argument");
+  ```java
+  class Test {
+    public void problem(String arg) {
+      if (arg.isEmpty())
+        ;
+      {
+        System.out.println("Empty argument");
+      }
+    }
+  
+    public void good(String arg) {
+      if (arg.isEmpty()) {
+        System.out.println("Empty argument");
+      }
     }
   }
-
-  public void good(String arg) {
-    if (arg.isEmpty()) {
-      System.out.println("Empty argument");
-    }
-  }
-}
-```
+  ```
 
 ### Execute the test
 


### PR DESCRIPTION
The Java example code block was empty with the code displayed inline below it, I have removed whitespace to fix it as per the bottom image

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: https://github.com/github/docs/issues/26277

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

![2023-06-27 13 07 47 docs github com e925902cb69c](https://github.com/github/docs/assets/94363953/a2f232d4-acd5-41d4-abaf-7cf036f7d55b)

Changing this to put the Java code into the code-block correctly, will also fix other parts below it as the tags were spilling over.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).


