### PR TITLE
Fix user_migrations_intro saying "GitHub Enterprise Server.com"

### DIFF
--- a/data/variables/migrations.yml
+++ b/data/variables/migrations.yml
@@ -1,5 +1,5 @@
 user_migrations_intro: >-
-  You can use these endpoints to review, backup, or migrate your user data stored on {% data variables.product.product_name %}.com.
+  You can use these endpoints to review, backup, or migrate your user data stored on {% data variables.product.prodname_dotcom_the_website %}.com.
 organization_migrations_intro: >-
   You can use these endpoints to move a repository from {% data variables.product.prodname_dotcom_the_website %} to {% data variables.product.prodname_ghe_server %}. For more information, see "[AUTOTITLE]({% ifversion ghae %}/enterprise-server@latest{% endif %}/migrations/using-ghe-migrator/exporting-migration-data-from-githubcom)."
 source_imports_intro: >-

--- a/data/variables/migrations.yml
+++ b/data/variables/migrations.yml
@@ -1,5 +1,5 @@
 user_migrations_intro: >-
-  You can use these endpoints to review, backup, or migrate your user data stored on {% data variables.product.prodname_dotcom_the_website %}.com.
+  You can use these endpoints to review, backup, or migrate your user data stored on {% data variables.product.prodname_dotcom_the_website %}.
 organization_migrations_intro: >-
   You can use these endpoints to move a repository from {% data variables.product.prodname_dotcom_the_website %} to {% data variables.product.prodname_ghe_server %}. For more information, see "[AUTOTITLE]({% ifversion ghae %}/enterprise-server@latest{% endif %}/migrations/using-ghe-migrator/exporting-migration-data-from-githubcom)."
 source_imports_intro: >-


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why

There is a typo that says "GitHub Enterprise Server.com" on https://docs.github.com/en/enterprise-server@3.9/rest/migrations/users?apiVersion=2022-11-28#about-user-migrations

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

| Before |
| --- |
| <img width="1229" alt="image" src="https://github.com/github/docs/assets/923242/ebb270d7-9d6e-4649-a7ff-2b0b75e15650"> |



| After |
| --- |
| <img width="1243" alt="image" src="https://github.com/github/docs/assets/923242/47ec12c6-eabd-4190-a003-8f1e389fac37"> |


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
