### PR TITLE
Fix: Add quotes for labels in YAML issue form template

### DIFF
--- a/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
+++ b/content/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms.md
@@ -109,7 +109,7 @@ Links? References? Anything that will give us more context about the issue that 
 name: 🐞 Bug
 description: File a bug/issue
 title: "[BUG] <title>"
-labels: [Bug, Needs Triage]
+labels: ["Bug", "Needs Triage"]
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
### Why:

The YAML issue form template is missing quotes around its labels here: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#yaml-issue-form-template

If users directly copy the template, the issue form won't add those labels to the issues it creates.

![image](https://github.com/github/docs/assets/129512384/5a7a3bde-ba47-499b-96f1-b48e577096fb)

Closes: https://github.com/github/docs/issues/26640

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I've added quotes to those labels.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
