### PR TITLE
fix passkeys.dev site name

### DIFF
--- a/content/authentication/authenticating-with-a-passkey/about-passkeys.md
+++ b/content/authentication/authenticating-with-a-passkey/about-passkeys.md
@@ -26,7 +26,7 @@ Since your passkey is protected by the passkey provider's account system (iCloud
 
 For 2FA users, if you already have passkey-eligible security keys registered to your account for 2FA, you can easily upgrade these existing security keys into passkeys in your account settings. When you use an eligible security key to sign in, you'll also be asked if you want to upgrade it to a passkey. For more information, see "[Upgrading an existing security key to a passkey](/authentication/authenticating-with-a-passkey/managing-your-passkeys#upgrading-an-existing-security-key-to-a-passkey)."
 
-For information on whether your device and operating system support passkeys, see [Device support](https://passkeys.dev/device-support/) in the Passkey.dev documentation, and [Web Authentication API](https://caniuse.com/webauthn) in the CanIUse documentation.
+For information on whether your device and operating system support passkeys, see [Device support](https://passkeys.dev/device-support/) in the Passkeys.dev documentation, and [Web Authentication API](https://caniuse.com/webauthn) in the CanIUse documentation.
 
 ## Enabling and disabling the feature preview for passkeys
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

https://docs.github.com/en/authentication/authenticating-with-a-passkey/about-passkeys has the wrong name of the website (passkey.dev instead of passkeys.dev)

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
