### PR TITLE
Correct rendering of actions variables and upload-pages-artifact version

### DIFF
--- a/content/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages.md
+++ b/content/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages.md
@@ -114,7 +114,6 @@ jobs:
 
 In certain cases, you might choose to combine everything into a single job, especially if there is no need for a build process. Consequently, you would solely focus on the deployment step.
 
-{% raw %}
 ```yaml
 ...
 
@@ -123,7 +122,7 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{steps.deployment.outputs.page_url}}
+      url: {% raw %}${{steps.deployment.outputs.page_url}}{% endraw %}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -141,6 +140,5 @@ jobs:
 
 ...
 ```
-{% endraw %}
 
 You can define your jobs to be run on different runners, sequentially, or in parallel. For more information, see "[AUTOTITLE](/actions/using-jobs)."

--- a/content/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages.md
+++ b/content/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages.md
@@ -50,6 +50,7 @@ The `deploy-pages` action handles the necessary setup for deploying artifacts. T
 
 For more information, see the [`deploy-pages`](https://github.com/marketplace/actions/deploy-github-pages-site) action.
 
+{% raw %}
 ```yaml
 ...
 
@@ -61,14 +62,16 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     needs: jekyll-build
-    environment: github-pages
-    url: ${{steps.deployment.outputs.page_url}}
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
     steps:
       - name: Deploy artifact
         id: deployment
         uses: actions/deploy-pages@v1
 ...
 ```
+{% endraw %}
 
 ## Linking separate build and deploy jobs
 
@@ -93,13 +96,13 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
 
   # Deployment job
   deploy:
     environment:
       name: github-pages
-      url: ${{steps.deployment.outputs.page_url}}
+      url: {% raw %}${{steps.deployment.outputs.page_url}}{% endraw %}
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -111,6 +114,7 @@ jobs:
 
 In certain cases, you might choose to combine everything into a single job, especially if there is no need for a build process. Consequently, you would solely focus on the deployment step.
 
+{% raw %}
 ```yaml
 ...
 
@@ -127,7 +131,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v2
         with:
           # upload entire directory
           path: '.'
@@ -137,5 +141,6 @@ jobs:
 
 ...
 ```
+{% endraw %}
 
 You can define your jobs to be run on different runners, sequentially, or in parallel. For more information, see "[AUTOTITLE](/actions/using-jobs)."


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The [Using custom workflows with GitHub Pages](https://docs.github.com/en/enterprise-cloud@latest/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages) documentation has the following issues:

* Invalid environment configuration in the first example (`url` should be under `environment`)
* The `${{steps.deployment.outputs.page_url}}` variable is being eaten by the templating engine
* The third example references a nonexistent version of `actions/upload-pages-artifact`

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

* Invalid syntax in first example has been updated
* Code blocks marked as raw to skip the templating engine
* Version of  `actions/upload-pages-artifact` has been set to v2

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
