### PR TITLE
Fix spacing for cURL code samples

### DIFF
--- a/src/rest/components/get-rest-code-samples.ts
+++ b/src/rest/components/get-rest-code-samples.ts
@@ -88,7 +88,7 @@ export function getShellExample(operation: Operation, codeSample: CodeSample) {
 
   const args = [
     operation.verb !== 'get' && `-X ${operation.verb.toUpperCase()}`,
-    `-H "Accept: ${defaultAcceptHeader}" \\\n  ${authHeader}${apiVersionHeader}`,
+    `-H "Accept: ${defaultAcceptHeader}" \\\n  ${authHeader} ${apiVersionHeader}`,
     contentTypeHeader,
     `${operation.serverUrl}${requestPath}`,
     requestBodyParams,


### PR DESCRIPTION
### Why:
The cURL code samples in the API docs are missing a space before the escape character on the authorization header line. This can cause confusion if you copy/paste the code snippet and get an unexpected error.

Closes issue [#26708](https://github.com/github/docs/issues/26708).

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The authorization header line in the cURL code samples will now have a space before the backslash escape character at the end of the line: 
`-H "Authorization: Bearer <YOUR-TOKEN>"\` --> `-H "Authorization: Bearer <YOUR-TOKEN>" \`

This allows users to copy/paste the command without errors.

#### Screenshots
Before:

<img width="618" alt="Screenshot 2023-07-14 at 10 30 13 AM" src="https://github.com/github/docs/assets/57506040/9e87a703-3f61-415a-8846-d403f193c1eb">


After:

<img width="606" alt="Screenshot 2023-07-14 at 10 30 52 AM" src="https://github.com/github/docs/assets/57506040/485f95ca-361a-49f6-b32f-0cab4701d1f1">

### Alternate Solution

Alternatively, you could split the args on [line 91](https://github.com/github/docs/blob/main/src/rest/components/get-rest-code-samples.ts#L91), and let ```${args.join(' \\\n  ')}``` on [line 96](https://github.com/github/docs/blob/main/src/rest/components/get-rest-code-samples.ts#L96) join them with the proper spacing, escape characters, and newlines. I've created [a branch](https://github.com/WhiteFruit/docs/blob/alternate-patch-for-cURL-code-samples/src/rest/components/get-rest-code-samples.ts#L76C1-L99C2) with those changes if that is the preferred direction.

```TypeScript
  if (operation.subcategory === 'management-console' || operation.subcategory === 'manage-ghes') {
    authHeader = '-u "api_key:your-password"'
    apiVersionHeader = ''
  } else {
    authHeader = '-H "Authorization: Bearer <YOUR-TOKEN>"'

    apiVersionHeader =
      allVersions[currentVersion].apiVersions.length > 0 &&
      allVersions[currentVersion].latestApiVersion
        ? `-H "X-GitHub-Api-Version: ${allVersions[currentVersion].latestApiVersion}"`
        : ''
  }

  const args = [
    operation.verb !== 'get' && `-X ${operation.verb.toUpperCase()}`,
    `-H "Accept: ${defaultAcceptHeader}"`,
    authHeader,
    apiVersionHeader,
    contentTypeHeader,
    `${operation.serverUrl}${requestPath}`,
    requestBodyParams,
  ].filter(Boolean)
  return `curl -L \\\n  ${args.join(' \\\n  ')}`
}
```


### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
