### PR TITLE
Fix less-than signs in copy-ssh-public-key.md

### DIFF
--- a/data/reusables/gpg/copy-ssh-public-key.md
+++ b/data/reusables/gpg/copy-ssh-public-key.md
@@ -4,7 +4,7 @@
 {% mac %}
 
    ```shell
-   $ pbcopy &lt; ~/.ssh/id_{% ifversion ghae %}rsa{% else %}ed25519{% endif %}.pub
+   $ pbcopy < ~/.ssh/id_{% ifversion ghae %}rsa{% else %}ed25519{% endif %}.pub
    # Copies the contents of the id_{% ifversion ghae %}rsa{% else %}ed25519{% endif %}.pub file to your clipboard
    ```
 
@@ -17,7 +17,7 @@
 {% windows %}
 
    ```shell
-   $ clip &lt; ~/.ssh/id_{% ifversion ghae %}rsa{% else %}ed25519{% endif %}.pub
+   $ clip < ~/.ssh/id_{% ifversion ghae %}rsa{% else %}ed25519{% endif %}.pub
    # Copies the contents of the id_{% ifversion ghae %}rsa{% else %}ed25519{% endif %}.pub file to your clipboard
    ```
 


### PR DESCRIPTION
Recent updates to the rendering/representation of the BASH/command-line instructions have caused the HTML escaped (&lt;) less-than sign not to be rendered properly.
