### PR TITLE
Update release_properties.md

### DIFF
--- a/data/reusables/webhooks/release_properties.md
+++ b/data/reusables/webhooks/release_properties.md
@@ -1,3 +1,3 @@
 `changes[body][from]` |`string` | The previous version of the body if the action was `edited`.
 `changes[name][from]` |`string` | The previous version of the name if the action was `edited`.
-`release`|`object` | The [release](/rest/repos#get-a-release) object.
+`release`|`object` | The [release](/rest/releases/releases#get-a-release) object.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Currently on the [GitHub event types](https://docs.github.com/en/webhooks-and-events/events/github-event-types) page under the [ReleaseEvent](https://docs.github.com/en/webhooks-and-events/events/github-event-types#event-payload-object-for-releaseevent) part there is a hyperlink on the word "release" that points to the REST API / Repositories [page](https://docs.github.com/en/rest/repos#get-a-release). This should be pointing to the Releases part of the documentation instead.

Closes: #27058

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The only change in this PR is the path for the hyperlink to point to the page I believe it should be pointing to: REST API / [Releases](https://docs.github.com/en/rest/releases/releases#get-a-release).

In my local environment it successfully redirected to the page.
<img width="791" alt="image" src="https://github.com/github/docs/assets/53257021/90a8e38e-9751-4967-9b55-aa1977811b58">


<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
