### PR TITLE
Stop silently shooting issues

### DIFF
--- a/.github/workflows/triage-stale-check.yml
+++ b/.github/workflows/triage-stale-check.yml
@@ -37,12 +37,17 @@ jobs:
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # The hope is that by configuring this way, this job will not harass issues
+          stale-issue-message: 'This workflow is misconfigured please complain to staff.'
+          only-issue-labels: 'this-label-intentionally-not-left-blank'
+          exempt-issue-labels: 'never-stale'
+          days-before-issue-clone: -1 # Never close
           stale-pr-message: 'This is a gentle bump for the docs team that this PR is waiting for review.'
           days-before-pr-stale: 14
           days-before-pr-close: -1 # Never close
           remove-stale-when-updated: false
           operations-per-run: 100
-          only-labels: 'waiting for review'
+          only-pr-labels: 'waiting for review'
           # The hope is that by setting the stale-pr-label to the same label
           # as the label that the stale check looks for, this will result in
           # a comment being posted every 14 days as an infinite loop, which is what


### PR DESCRIPTION
### Why:

The stale bot shot my issue https://github.com/github/docs/issues/24441#event-9957042079 without explanation. It appears to be a misconfiguration, and it's really very rude because it doesn't explain why it's doing it.

https://github.com/github/docs/actions/runs/5707249473/job/15463767232
```
[#24441] Issue #24441
  [#24441] Found this issue last updated at: 2023-07-22T16:26:49Z
  [#24441] The option only-labels (​[https://github.com/actions/stale#only-labels​)](https://github.com/actions/stale#only-labels%E2%80%8B)) was specified to only process issues and pull requests with all those labels (1)
  [#24441] ├── All the required labels are present on this issue
  [#24441] └── Continuing the process for this issue
  [#24441] Days before issue stale: 60
  [#24441] The issue is not closed nor locked. Trying to remove the close label...
  [#24441] ├── The close-issue-label (​[https://github.com/actions/stale#close-issue-label​)](https://github.com/actions/stale#close-issue-label%E2%80%8B)) option was not set
  [#24441] └── Skipping the removal of the close label
  [#24441] This issue includes a stale label
  [#24441] The option any-of-labels (​[https://github.com/actions/stale#any-of-labels​)](https://github.com/actions/stale#any-of-labels%E2%80%8B)) was not specified
  [#24441] └── Continuing the process for this issue
  [#24441] This issue has no milestone
  [#24441] └── Skip the milestones checks
  [#24441] This issue has no assignee
  [#24441] └── Skip the assignees checks
  [#24441] This issue is already stale
  [#24441] Checking for label on this issue
  [#24441] Issue marked stale on: 2023-07-22T16:26:49Z
  [#24441] Checking for comments on issue since: 2023-07-22T16:26:49Z
  [#24441] Comments that are not the stale comment or another bot: 0
  [#24441] Issue has been commented on: false
  [#24441] Days before issue close: 7
  [#24441] The option remove-stale-when-updated (​[https://github.com/actions/stale#remove-stale-when-updated​)](https://github.com/actions/stale#remove-stale-when-updated%E2%80%8B)) is: false
  [#24441] The stale label should be removed if all conditions met
  [#24441] Issue has been updated since it was marked stale: false
  [#24441] Issue has been updated in the last 7 days: false
  [#24441] Closing issue because it was last updated on: 2023-07-22T16:26:49Z
  [#24441] Closing issue for being stale
  [#24441] 3 operations consumed for this issue
```

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The `stale_staff` job in the workflow is changed such that the action grows configuration for issues such that it should never harass them as it _appears_ to be the goal of the workflow to harass staff about PRs.

@cmwilson21 https://github.com/github/docs/issues/24441#issuecomment-1658338088

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
