### PR TITLE
Remove extra 's' at end of "GitHub's plans"

### DIFF
--- a/content/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch.md
+++ b/content/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch.md
@@ -21,7 +21,7 @@ When you create a new organization from scratch, it doesn't have any repositorie
 {% data reusables.user-settings.access_settings %}
 {% data reusables.user-settings.organizations %}
 {% data reusables.organizations.new-organization %}
-1. Follow the prompts to create your organization. {% ifversion fpt or ghec %}For more information about the plans available for your team, see "[AUTOTITLE](/get-started/learning-about-github/githubs-plans)s)."{% endif %}
+1. Follow the prompts to create your organization. {% ifversion fpt or ghec %}For more information about the plans available for your team, see "[AUTOTITLE](/get-started/learning-about-github/githubs-plans))."{% endif %}
 
 ## Further reading
 

--- a/content/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch.md
+++ b/content/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch.md
@@ -21,7 +21,7 @@ When you create a new organization from scratch, it doesn't have any repositorie
 {% data reusables.user-settings.access_settings %}
 {% data reusables.user-settings.organizations %}
 {% data reusables.organizations.new-organization %}
-1. Follow the prompts to create your organization. {% ifversion fpt or ghec %}For more information about the plans available for your team, see "[AUTOTITLE](/get-started/learning-about-github/githubs-plans))."{% endif %}
+1. Follow the prompts to create your organization. {% ifversion fpt or ghec %}For more information about the plans available for your team, see "[AUTOTITLE](/get-started/learning-about-github/githubs-plans)."{% endif %}
 
 ## Further reading
 


### PR DESCRIPTION

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The link text is GitHub's plans, the surrounding prose contains an extra 's':

https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Step 4:

>Follow the prompts to create your organization. For more information about the plans available for your team, see "[GitHub’s plans](https://docs.github.com/en/get-started/learning-about-github/githubs-plans)s)."

Rendered as:

```
Follow the prompts to create your organization. For more information about the plans available for your team, see "GitHub’s planss)."
```

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
