### PR TITLE
Fix rendering of SSH key instructions for Windows and Linux

### DIFF
--- a/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
+++ b/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
@@ -185,10 +185,9 @@ Before adding a new SSH key to the ssh-agent to manage your keys, you should hav
    ```
 
 1. Add your SSH private key to the ssh-agent. {% data reusables.ssh.add-ssh-key-to-ssh-agent %}
-   {% data reusables.ssh.add-ssh-key-to-ssh-agent-commandline %}
+{% data reusables.ssh.add-ssh-key-to-ssh-agent-commandline %}
 
 {% data reusables.ssh.add-public-key-to-github %}
-
 {% endwindows %}
 
 {% linux %}
@@ -196,7 +195,7 @@ Before adding a new SSH key to the ssh-agent to manage your keys, you should hav
 {% data reusables.command_line.start_ssh_agent %}
 
 1. Add your SSH private key to the ssh-agent. {% data reusables.ssh.add-ssh-key-to-ssh-agent %}
-   {% data reusables.ssh.add-ssh-key-to-ssh-agent-commandline %}
+{% data reusables.ssh.add-ssh-key-to-ssh-agent-commandline %}
 
 {% data reusables.ssh.add-public-key-to-github %}
 


### PR DESCRIPTION
### Why:

Closes: github/docs#27153

Fixing the linked issue caused the Linux instructions to incorrectly render as well. That fix is part of this PR as well.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I only removed white spacing in the template file.

![Docs-Windows](https://github.com/github/docs/assets/72265290/c392ed83-06f5-4365-b8d4-fb4ab7aa9654)

![Docs-Linux](https://github.com/github/docs/assets/72265290/a15f67c6-9567-4a80-a747-1bec1335312d)

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
