### PR TITLE
Fix stale message spelling of `because`

### DIFF
--- a/.github/workflows/triage-stale-check.yml
+++ b/.github/workflows/triage-stale-check.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'A stale label has been added to this issue becuase it has been open for 60 days with no activity. To keep this issue open, add a comment within 3 days.'
+          stale-issue-message: 'A stale label has been added to this issue because it has been open for 60 days with no activity. To keep this issue open, add a comment within 3 days.'
           days-before-issue-stale: 60
           days-before-issue-close: 3
           exempt-issue-labels: 'help wanted,never-stale,waiting for review'


### PR DESCRIPTION
### Why:

because because is misspelled by the stale bot and I hate misspellings more than I hate the stale bot.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
