### PR TITLE
Update node's description in *Edge objects

### DIFF
--- a/data/graphql/ghes-3.10/schema.docs-enterprise.graphql
+++ b/data/graphql/ghes-3.10/schema.docs-enterprise.graphql
@@ -17286,6 +17286,10 @@ Represents the language of a repository.
 """
 type LanguageEdge {
   cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
   node: Language!
 
   """
@@ -34083,6 +34087,10 @@ type ReactingUserEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
   node: User!
 
   """
@@ -42567,6 +42575,10 @@ type StargazerEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
   node: User!
 
   """
@@ -42660,6 +42672,10 @@ type StarredRepositoryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
   node: Repository!
 
   """
@@ -44834,6 +44850,10 @@ type TeamMemberEdge {
   The HTTP URL to the organization's member access page.
   """
   memberAccessUrl: URI!
+
+  """
+  The item at the end of the edge.
+  """
   node: User!
 
   """
@@ -45232,6 +45252,10 @@ type TeamRepositoryEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
   node: Repository!
 
   """

--- a/data/graphql/ghes-3.10/schema.docs-enterprise.graphql
+++ b/data/graphql/ghes-3.10/schema.docs-enterprise.graphql
@@ -39588,6 +39588,10 @@ type RepositoryCollaboratorEdge {
   A cursor for use in pagination.
   """
   cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
   node: User!
 
   """


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
'node' field was not displayed at many types in /graphql/reference/objects

Closes: 
https://github.com/github/docs/issues/27327
<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
a description is added to the field which was present in the file but was not displayed due to parsing error
standard description for most of the node fields is used: "The item at the end of the edge."
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
