### PR TITLE
Increase clickable area for sidebar tree links

### DIFF
--- a/src/rest/components/RestCollapsibleSection.tsx
+++ b/src/rest/components/RestCollapsibleSection.tsx
@@ -111,6 +111,7 @@ export const RestCollapsibleSection = (props: SectionProps) => {
           }}
           onClick={() => setVisibleAnchor(miniTocAnchor)}
           href={miniTocAnchor}
+          style={{ display: 'block' }}
           className={cx(styles.operationWidth, 'color-fg-default no-underline')}
         >
           {title}


### PR DESCRIPTION
### Why:

Increase clickable area of sidebar item link 

Closes: N/A


### What's being changed:

<img width="328" src="https://github.com/github/docs/assets/17685332/42437cf0-20b6-4942-8a28-78eece14eb9a">


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.
  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
