### PR TITLE
Add dismissed to Reviewed event state

### DIFF
--- a/content/webhooks-and-events/events/issue-event-types.md
+++ b/content/webhooks-and-events/events/issue-event-types.md
@@ -780,7 +780,7 @@ Name | Type | Description
 `body` | `string` | The review summary text.
 `commit_id` | `string` | The SHA of the latest commit in the pull request at the time of the review.
 `submitted_at` | `string` | The timestamp indicating when the review was submitted.
-`state` | `string` | The state of the submitted review. Can be one of: `commented`, `changes_requested`, or `approved`.
+`state` | `string` | The state of the submitted review. Can be one of: `commented`, `changes_requested`, `approved` or `dismissed`.
 `html_url` | `string` | The HTML URL of the review.
 `pull_request_url` | `string` | The REST API URL to retrieve the pull request.
 `author_association` | `string` | The permissions the user has in the issue's repository. For example, the value would be `"OWNER"` if the owner of repository created a comment.


### PR DESCRIPTION
### Why:
This adds the `dismissed` state to the list of possible states for the state field on the Reviewed event. `dismissed` happens when someone dismisses a previous review on a pull request.

Closes:  https://github.com/github/docs/issues/20216


### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updated the docs to show the `dismissed` state
<img width="1024" alt="Screenshot 2023-08-14 at 07 48 47" src="https://github.com/github/docs/assets/341159/79a9183e-5e48-4893-abef-4f28b9413bf5">


### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
