### PR TITLE
[GitHub Actions] Fail fast from the default shells (bash/sh) in Linux/macOS

### DIFF
--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -712,7 +712,7 @@ For information about the software included on GitHub-hosted runners, see "[AUTO
 For built-in shell keywords, we provide the following defaults that are executed by {% data variables.product.prodname_dotcom %}-hosted runners. You should use these guidelines when running shell scripts.
 
 - `bash`/`sh`:
-  - By default, fail-fast behavior is enfored using `set -e` for `sh` and `bash` both. When `shell: bash` is specified, `-o pipefail` is also appied to enforce early exit from pipelines in case of non-zero exit status.
+  - By default, fail-fast behavior is enforced using `set -e` for `sh` and `bash` both. When `shell: bash` is specified, `-o pipefail` is also applied to enforce early exit from pipelines in case of non-zero exit status.
   - You can take full control over shell parameters by providing a template string to the shell options. For example, `bash {0}`.
   - `sh`-like shells exit with the exit code of the last command executed in a script, which is also the default behavior for actions. The runner will report the status of the step as fail/succeed based on this exit code.
 

--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -687,7 +687,7 @@ steps:
 
 ### Custom shell
 
-You can set the `shell` value to a template string using `command […options] {0} [..more_options]`. {% data variables.product.prodname_dotcom %} interprets the first whitespace-delimited word of the string as the command, and inserts the file name for the temporary script at `{0}`.
+You can set the `shell` value to a template string using `command [options] {0} [more_options]`. {% data variables.product.prodname_dotcom %} interprets the first whitespace-delimited word of the string as the command, and inserts the file name for the temporary script at `{0}`.
 
 For example:
 
@@ -712,9 +712,9 @@ For information about the software included on GitHub-hosted runners, see "[AUTO
 For built-in shell keywords, we provide the following defaults that are executed by {% data variables.product.prodname_dotcom %}-hosted runners. You should use these guidelines when running shell scripts.
 
 - `bash`/`sh`:
-  - Fail-fast behavior using `set -eo pipefail`: This option is set when `shell: bash` is explicitly specified. It is not applied by default.
+  - By default, fail-fast behavior is enfored using `set -e` for `sh` and `bash` both. When `shell: bash` is specified, `-o pipefail` is also appied to enforce early exit from pipelines in case of non-zero exit status.
   - You can take full control over shell parameters by providing a template string to the shell options. For example, `bash {0}`.
-  - sh-like shells exit with the exit code of the last command executed in a script, which is also the default behavior for actions. The runner will report the status of the step as fail/succeed based on this exit code.
+  - `sh`-like shells exit with the exit code of the last command executed in a script, which is also the default behavior for actions. The runner will report the status of the step as fail/succeed based on this exit code.
 
 - `powershell`/`pwsh`
   - Fail-fast behavior when possible. For `pwsh` and `powershell` built-in shell, we will prepend `$ErrorActionPreference = 'stop'` to script contents.

--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -712,7 +712,7 @@ For information about the software included on GitHub-hosted runners, see "[AUTO
 For built-in shell keywords, we provide the following defaults that are executed by {% data variables.product.prodname_dotcom %}-hosted runners. You should use these guidelines when running shell scripts.
 
 - `bash`/`sh`:
-  - By default, fail-fast behavior is enforced using `set -e` for `sh` and `bash` both. When `shell: bash` is specified, `-o pipefail` is also applied to enforce early exit from pipelines in case of non-zero exit status.
+  - By default, fail-fast behavior is enforced using `set -e` for both `sh` and `bash`. When `shell: bash` is specified, `-o pipefail` is also applied to enforce early exit from pipelines that generate a non-zero exit status.
   - You can take full control over shell parameters by providing a template string to the shell options. For example, `bash {0}`.
   - `sh`-like shells exit with the exit code of the last command executed in a script, which is also the default behavior for actions. The runner will report the status of the step as fail/succeed based on this exit code.
 


### PR DESCRIPTION
### Why:

Closes: #23853

### What's being changed (if available, include any code snippets, screenshots, or gifs):

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
