### PR TITLE
Clarify, in about-code-owners.md, which `CODEOWNERS` file GitHub will respect if a repo contains more than one

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -34,7 +34,7 @@ If a file has a code owner, you can see who the code owner is before you open a 
 
 ## CODEOWNERS file location
 
-To use a CODEOWNERS file, create a new file called `CODEOWNERS` in the root, `docs/`, or `.github/` directory of the repository, in the branch where you'd like to add the code owners.
+To use a CODEOWNERS file, create a new file called `CODEOWNERS` in the `.github/`, root, or `docs/` directory of the repository, in the branch where you'd like to add the code owners. If `CODEOWNERS` files exist in more than one of those locations, GitHub will search for them in that order and use the first one it finds.
 
 Each CODEOWNERS file assigns the code owners for a single branch in the repository. Thus, you can assign different code owners for different branches, such as `@octo-org/codeowners-team` for a code base on the default branch and `@octocat` for a {% data variables.product.prodname_pages %} site on the `gh-pages` branch.
 

--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -34,7 +34,7 @@ If a file has a code owner, you can see who the code owner is before you open a 
 
 ## CODEOWNERS file location
 
-To use a CODEOWNERS file, create a new file called `CODEOWNERS` in the `.github/`, root, or `docs/` directory of the repository, in the branch where you'd like to add the code owners. If `CODEOWNERS` files exist in more than one of those locations, GitHub will search for them in that order and use the first one it finds.
+To use a CODEOWNERS file, create a new file called `CODEOWNERS` in the `.github/`, root, or `docs/` directory of the repository, in the branch where you'd like to add the code owners. If `CODEOWNERS` files exist in more than one of those locations, {% data variables.product.prodname_dotcom %} will search for them in that order and use the first one it finds.
 
 Each CODEOWNERS file assigns the code owners for a single branch in the repository. Thus, you can assign different code owners for different branches, such as `@octo-org/codeowners-team` for a code base on the default branch and `@octocat` for a {% data variables.product.prodname_pages %} site on the `gh-pages` branch.
 


### PR DESCRIPTION
### Why:

Since GitHub allows `CODEOWNERS` files to exist in 3 locations, we wondered which one would be preferred if the file existed in more than one of those locations. We couldn't find the answer in the docs, so we tested it out with a private repo, and are clarifying the docs.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added one sentence.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
