### PR TITLE
Fix sections in the "Configure dependabot.yml" docs being affected by a recent unrelated change.

### DIFF
--- a/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
+++ b/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
@@ -376,7 +376,9 @@ You can use the `ignore` option to customize which dependencies are updated. The
 | `versions` | Use to ignore specific versions or ranges of versions. If you want to define a range, use the standard pattern for the package manager.</br>For example, for npm, use `^1.0.0`; for Bundler, use `~> 2.0`; for Docker, use Ruby version syntax; for NuGet, use `7.*`. |
 | <code><span style="white-space: nowrap;">update-types</span></code> | Use to ignore types of updates, such as semver `major`, `minor`, or `patch` updates on version updates (for example: `version-update:semver-patch` will ignore patch updates). You can combine this with `dependency-name: "*"` to ignore particular `update-types` for all dependencies.</br>Currently, `version-update:semver-major`, `version-update:semver-minor`, and `version-update:semver-patch` are the only supported options. |
 
-{% data reusables.dependabot.option-affects-security-updates %}
+When used alone, the `ignore.versions` key affects both {% data variables.product.prodname_dependabot %} updates, but the `ignore.update-types` key affects only {% data variables.product.prodname_dependabot_version_updates %}.
+
+However, if `versions` and `update-types` are used together in the same `ignore` rule, both {% data variables.product.prodname_dependabot %} updates are affected, unless the configuration uses `target-branch` to check for version updates on a non-default branch.
 
 ```yaml
 # Use `ignore` to specify dependencies that should not be updated

--- a/data/reusables/dependabot/option-affects-security-updates.md
+++ b/data/reusables/dependabot/option-affects-security-updates.md
@@ -1,3 +1,1 @@
-When used alone, the `ignore.versions` key affects both {% data variables.product.prodname_dependabot %} updates, but the `ignore.update-types` key affects only {% data variables.product.prodname_dependabot_version_updates %}. 
-
-However, if `versions` and `update-types` are used together in the same `ignore` rule, both {% data variables.product.prodname_dependabot %} updates are affected, unless the configuration uses `target-branch` to check for version updates on a non-default branch.
+Setting this option will also affect pull requests for security updates to the manifest files of this package manager, unless you use `target-branch` to check for version updates on a non-default branch.


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs/issues/27863

### What's being changed (if available, include any code snippets, screenshots, or gifs):

A recent commit, 7b8fd5e374b9eb41b91fd5967dd5575ba7b23455, updated the `reusables.dependabot.option-affects-security-updates` template.  This had the intended affect of updating the section being edited, but had a (presumably) unintended side-effect of affecting all other sections that used that template.

This PR reverts the changes to the `reusables.dependabot.option-affects-security-updates`, sparing all other sections that received the unintended change, while moving the originally-intended content directly to the section it was intended for.

Before this PR:

![image](https://github.com/github/docs/assets/1426304/e098c08e-73ba-46e0-93ba-2678a29bf15a)

After:

![image](https://github.com/github/docs/assets/1426304/12831694-a90f-4f56-931f-d3eed34ce2ac)

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
