### PR TITLE
docs(arc): remove metrics which are not exposed

### DIFF
--- a/content/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller.md
+++ b/content/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller.md
@@ -561,8 +561,6 @@ The following table shows the metrics emitted by the controller-manager and list
 | controller-manager | pending_ephemeral_runners      | gauge     | Number of ephemeral runners in a pending state                                                                      |
 | controller-manager | running_ephemeral_runners      | gauge     | Number of ephemeral runners in a running state                                                                      |
 | controller-manager | failed_ephemeral_runners       | gauge     | Number of ephemeral runners in a failed state                                                                       |
-| listener           | available_jobs                 | gauge     | Number of jobs where `runs-on` matches the runner scale set name and the job is not yet assigned to the runner scale set. |
-| listener           | acquired_jobs                  | gauge     | Number of jobs acquired by the runner scale set                                                                     |
 | listener           | assigned_jobs                  | gauge     | Number of jobs assigned to the runner scale set                                                                     |
 | listener           | running_jobs                   | gauge     | Number of jobs running or queued to run                                                                        |
 | listener           | registered_runners             | gauge     | Number of runners registered by the runner scale set                                                                |


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Current arc docs lists two metrics which are not exposed.
In the pr which added these metrics `available_jobs` and `acquired_jobs` are actually commented:
https://github.com/actions/actions-runner-controller/commit/a0a3916c806cd0a3b729fc4366cc0607c9489f59#diff-45afc66b23a4ce69ef91a1ee70fd48b378fa89ad649c7c2275ccff5516f9e497R54-R70

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Remove metrics from the docs (until the metrics are actually exposed by the controller),

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
