### PR TITLE
docs: remove trailing newlines in code blocks

### DIFF
--- a/content/actions/using-workflows/events-that-trigger-workflows.md
+++ b/content/actions/using-workflows/events-that-trigger-workflows.md
@@ -404,7 +404,6 @@ For example, you can run a workflow when the `checks_requested` activity has occ
 on:
   merge_group:
     types: [checks_requested]
-
 ```
 
 {% endif %}

--- a/content/admin/administering-your-instance/command-line-utilities.md
+++ b/content/admin/administering-your-instance/command-line-utilities.md
@@ -208,7 +208,6 @@ This utility lists repositories on your appliance that use {% data variables.pro
 
 ```shell
 ghe-legacy-github-services-report
-
 ```
 
 ### ghe-logs-tail

--- a/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/migrating-from-the-codeql-runner-to-codeql-cli.md
+++ b/content/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/migrating-from-the-codeql-runner-to-codeql-cli.md
@@ -350,7 +350,6 @@ CLI:
       script: 'echo "$TOKEN" | codeql github upload-results --repository=my-org/example-repo \
     --ref=refs/heads/main --commit=deb275d2d5fe9a522a0b7bd8b6b6a1c939552718 \
     --sarif=/temp/example-repo-csharp.sarif --github-auth-stdin'
-
 ```
 
 ### Multiple languages using autobuild (C++, Python)

--- a/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
+++ b/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
@@ -470,7 +470,6 @@ updates:
       - ruby-github # only access to registries associated with this ecosystem/directory
     schedule:
       interval: "monthly"
-
 ```
 
 {% endraw %}

--- a/content/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api.md
+++ b/content/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api.md
@@ -38,7 +38,6 @@ Scala | [Sbt Dependency Submission](https://github.com/marketplace/actions/sbt-d
 For example, the following [Go Dependency Submission](https://github.com/actions/go-dependency-submission) workflow calculates the dependencies for a Go build-target (a Go file with a `main` function) and submits the list to the Dependency submission API.
 
 ```yaml
-
 name: Go Dependency Submission
 on:
   push:
@@ -77,7 +76,6 @@ jobs:
             # used by all build targets for the module. This may
             # include Go dependencies used by tests and tooling.
             go-build-target: go-example/cmd/octocat.go
-
 ```
 
 ### Creating your own action

--- a/content/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/setting-up-your-java-project-for-codespaces.md
+++ b/content/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/setting-up-your-java-project-for-codespaces.md
@@ -84,7 +84,6 @@ The default development container, or "dev container," for {% data variables.pro
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
 }
-
 ```
 
 {% data reusables.codespaces.devcontainer-properties-1 %}

--- a/content/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions.md
+++ b/content/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions.md
@@ -187,7 +187,6 @@ jobs:
                 }
               }
             }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value={% raw %}${{ env.TODO_OPTION_ID }}{% endraw %} -f date_field=$DATE_FIELD_ID -f date_value=$DATE --silent
-
 ```
 
 ## Example workflow authenticating with a {% data variables.product.pat_generic %}

--- a/content/migrations/using-github-enterprise-importer/migrating-organizations-with-github-enterprise-importer/migrating-organizations-from-githubcom-to-github-enterprise-cloud.md
+++ b/content/migrations/using-github-enterprise-importer/migrating-organizations-with-github-enterprise-importer/migrating-organizations-from-githubcom-to-github-enterprise-cloud.md
@@ -48,7 +48,6 @@ query(
     id
   }
 }
-
 ```
 
 {% data reusables.enterprise_migrations.retreive-enterprise-id-graphql %}

--- a/data/reusables/actions/actions-vars-context-example-usage.md
+++ b/data/reusables/actions/actions-vars-context-example-usage.md
@@ -35,7 +35,6 @@ jobs:
       uses: actions/hello-world-javascript-action@main
       with:
         who-to-greet: ${{ vars.GREET_NAME }}
-
 ```
 
 {% endraw %}

--- a/data/reusables/actions/jobs/matrix-add-with-include.md
+++ b/data/reusables/actions/jobs/matrix-add-with-include.md
@@ -25,5 +25,4 @@ jobs:
             datacenter: "site-a"
           - site: "staging"
             datacenter: "site-b"
-
 ```

--- a/data/reusables/discussions/discussion-category-forms-sample.md
+++ b/data/reusables/discussions/discussion-category-forms-sample.md
@@ -54,5 +54,4 @@ body:
       value: |
         ### The thrilling conclusion
         _to our template_
-
 ```

--- a/data/reusables/repositories/actions-scheduled-workflow-example.md
+++ b/data/reusables/repositories/actions-scheduled-workflow-example.md
@@ -7,7 +7,6 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '30 5,17 * * *'
-
 ```
 
 A single workflow can be triggered by multiple `schedule` events. You can access the schedule event that triggered the workflow through the `github.event.schedule` context. This example triggers the workflow to run at 5:30 UTC every Monday-Thursday, but skips the `Not on Monday or Wednesday` step on Monday and Wednesday.


### PR DESCRIPTION
### Why:

Closes: #27989

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Several trailing and a single beginning newlines inside markdown code blocks are removed.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
