### PR TITLE
Remove --cask option to actually install git-credential-manager-core

### DIFF
--- a/content/get-started/getting-started-with-git/caching-your-github-credentials-in-git.md
+++ b/content/get-started/getting-started-with-git/caching-your-github-credentials-in-git.md
@@ -49,7 +49,7 @@ For more information about authenticating with {% data variables.product.prodnam
 
    ```shell
    brew tap microsoft/git
-   brew install --cask git-credential-manager-core
+   brew install --cask git-credential-manager
    ```
 
   For MacOS, you don't need to run `git config` because GCM automatically configures Git for you.

--- a/content/get-started/getting-started-with-git/caching-your-github-credentials-in-git.md
+++ b/content/get-started/getting-started-with-git/caching-your-github-credentials-in-git.md
@@ -49,7 +49,7 @@ For more information about authenticating with {% data variables.product.prodnam
 
    ```shell
    brew tap microsoft/git
-   brew install --cask git-credential-manager
+   brew install git-credential-manager-core
    ```
 
   For MacOS, you don't need to run `git config` because GCM automatically configures Git for you.


### PR DESCRIPTION
UPDATE: It appears removing `--cask` actually is the correct answer, as noted here: https://github.com/git-ecosystem/git-credential-manager/issues/1132#issuecomment-1447072074

~~From what I see, -core is not available and brew prompts you to install just manager with no `-core` suffix:~~

![image](https://github.com/github/docs/assets/157695/93b6f896-3516-48cd-8711-cff70f924c07)


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: n/a

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Look at the change 🤷‍♂️

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
