### PR TITLE
fix github-action dependabot directory

### DIFF
--- a/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
+++ b/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
@@ -90,7 +90,7 @@ updates:
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github/workflows"
     schedule:
       interval: "weekly"
 
@@ -129,9 +129,7 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
-    directory: "/"
+    directory: "/.github/workflows"
     schedule:
       interval: "weekly"
 ```

--- a/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
+++ b/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
@@ -157,7 +157,7 @@ version: 2
 updates:
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github/workflows"
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

According to <https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions>, workflow files must always be stored in `.github/workflows`. Thus the directory for dependabot should be adjusted accordingly.

The current way this is written is confusing:

```yaml
  # Maintain dependencies for GitHub Actions
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

```yaml
  - package-ecosystem: "github-actions"
    # Workflow files stored in the
    # default location of `.github/workflows`
    directory: "/"
    schedule:
      interval: "weekly"
```

Closes: #28102

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The directory for github-actions is changed from "/" to the correct location of "/.github/workflows".

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
