### PR TITLE
Fix call to Ruby OpenSSL::HMAC.hexdigest

### DIFF
--- a/content/webhooks/using-webhooks/securing-your-webhooks.md
+++ b/content/webhooks/using-webhooks/securing-your-webhooks.md
@@ -90,7 +90,7 @@ For example, you can define the following `verify_signature` function:
 
 ``` ruby
 def verify_signature(payload_body)
-  signature = 'sha256=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), ENV['SECRET_TOKEN'], payload_body)
+  signature = 'sha256=' + OpenSSL::HMAC.hexdigest('sha256', ENV['SECRET_TOKEN'], payload_body)
   return halt 500, "Signatures didn't match!" unless Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE_256'])
 end
 ```


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs/issues/28258

### What's being changed (if available, include any code snippets, screenshots, or gifs):

  Ruby code sample for checking the webhook signature.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
