### PR TITLE
doc(oidc): policy example does not work when environments are in use

### DIFF
--- a/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services.md
+++ b/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services.md
@@ -63,6 +63,13 @@ Edit the trust policy to add the `sub` field to the validation conditions. For e
 }
 ```
 
+
+{% note %}
+
+**Note**: In the above example, specifying a branch in the subject claim only works if the branch does not refer to an environment. For more examples of what common subject claims you can use, see the Github documentation "[About security hardening with OpenID Connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims)"
+
+{% endnote %}
+
 In the following example, `StringLike` is used with a wildcard operator (`*`) to allow any branch, pull request merge branch, or environment from the `octo-org/octo-repo` organization and repository to assume a role in AWS.
 
 ```json copy


### PR DESCRIPTION
The documentation depicting how to limit scope of access in the trust policy works for *most* cases. However when a deployment environment is used by a branch, the policy will not work. This is described in the linked documentation here:

https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-subject-claims

You can test your Github actions runs to verify what claim you need using this action: https://github.com/github/actions-oidc-debugger

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: 

Closes: https://github.com/github/docs/issues/28292

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
