### PR TITLE
Disable line wrapping in base64 encoding

### DIFF
--- a/content/actions/security-guides/using-secrets-in-github-actions.md
+++ b/content/actions/security-guides/using-secrets-in-github-actions.md
@@ -405,7 +405,7 @@ You can use Base64 encoding to store small binary blobs as secrets. You can then
 On MacOS, you could run:
 
    ```shell
-      base64 -i cert.der -o cert.base64
+   base64 -i cert.der -o cert.base64
    ```
 
 On Linux, you could run:

--- a/content/actions/security-guides/using-secrets-in-github-actions.md
+++ b/content/actions/security-guides/using-secrets-in-github-actions.md
@@ -402,13 +402,13 @@ You can use Base64 encoding to store small binary blobs as secrets. You can then
 
 1. Use `base64` to encode your file into a Base64 string. For example:
 
-On MacOS, you could run:
+   On MacOS, you could run:
 
    ```shell
    base64 -i cert.der -o cert.base64
    ```
 
-On Linux, you could run:
+   On Linux, you could run:
 
    ```shell
    base64 -w 0 cert.der > cert.base64

--- a/content/actions/security-guides/using-secrets-in-github-actions.md
+++ b/content/actions/security-guides/using-secrets-in-github-actions.md
@@ -403,7 +403,7 @@ You can use Base64 encoding to store small binary blobs as secrets. You can then
 1. Use `base64` to encode your file into a Base64 string. For example:
 
    ```shell
-   base64 -i cert.der -o cert.base64
+   base64 -w 0 cert.der > cert.base64
    ```
 
 1. Create a secret that contains the Base64 string. For example:

--- a/content/actions/security-guides/using-secrets-in-github-actions.md
+++ b/content/actions/security-guides/using-secrets-in-github-actions.md
@@ -402,6 +402,14 @@ You can use Base64 encoding to store small binary blobs as secrets. You can then
 
 1. Use `base64` to encode your file into a Base64 string. For example:
 
+On MacOS, you could run:
+
+   ```shell
+      base64 -i cert.der -o cert.base64
+   ```
+
+On Linux, you could run:
+
    ```shell
    base64 -w 0 cert.der > cert.base64
    ```


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

This PR corrects 2 separate issues within the same line:

1. at least on linux, the command `base64` does not have a `-o` switch: https://www.man7.org/linux/man-pages/man1/base64.1.html, and redirecting with `>` is the way to go
2. the option `-w 0` removes line wrapping (which by default is every 76 chars). Line wrapping can cause issues while running `base64 --decode`

I also removed the `-i` option as, to be honest, I fail to see why that would be useful in this case.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Disable line wrapping in base64 encoding (for storing binary blobs as secrets). 

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
