### PR TITLE
Update create_properties.md to reference `repository` and `pusher_type`.

### DIFF
--- a/data/reusables/webhooks/create_properties.md
+++ b/data/reusables/webhooks/create_properties.md
@@ -1,6 +1,7 @@
 Key | Type | Description
 ----|------|-------------
-`ref`|`string` | The [`git ref`](/rest/git#get-a-reference) resource.
-`ref_type`|`string` | The type of Git ref object created in the repository. Can be either `branch` or `tag`.
+`ref`|`string` | The [`git ref`](/rest/git#get-a-reference) resource, or `null` if `ref_type` is `repository`.
+`ref_type`|`string` | The type of Git ref object created in the repository. Can be either `branch`, `tag`, or `repository`.
 `master_branch`|`string` | The name of the repository's default branch (usually `main`).
 `description`|`string` | The repository's current description.
+`pusher_type`|`string` | Always `user`.

--- a/data/reusables/webhooks/create_properties.md
+++ b/data/reusables/webhooks/create_properties.md
@@ -4,4 +4,4 @@ Key | Type | Description
 `ref_type`|`string` | The type of Git ref object created in the repository. Can be either `branch`, `tag`, or `repository`.
 `master_branch`|`string` | The name of the repository's default branch (usually `main`).
 `description`|`string` | The repository's current description.
-`pusher_type`|`string` | Always `user`.
+`pusher_type`|`string` | Can be either `user` or a deploy key.


### PR DESCRIPTION
It looks like if a CreateEvent is generated specifically when a repository is created, separate from the main branch being created. In that event, the `ref_type` is `repository` and `ref` is null.

Additionally, out of the 22,000 events I looked at for a particular hour a day ago, all of them had `pusher_type=user`. Not sure how valuable it is to include in the table if it's always the same value, but it's there.

Here's an example CreateEvent payload:

```json
"payload":{"ref":null,"ref_type":"repository","master_branch":"main","description":null,"pusher_type":"user"}
```

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: https://github.com/github/docs/issues/28994

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Just a bit of the docs at this page: https://docs.github.com/en/rest/overview/github-event-types?apiVersion=2022-11-28#event-payload-object-for-createevent

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
