### PR TITLE
Update commit-exists-on-github-but-not-in-my-local-clone.md

### DIFF
--- a/content/pull-requests/committing-changes-to-your-project/troubleshooting-commits/commit-exists-on-github-but-not-in-my-local-clone.md
+++ b/content/pull-requests/committing-changes-to-your-project/troubleshooting-commits/commit-exists-on-github-but-not-in-my-local-clone.md
@@ -82,6 +82,13 @@ $ git fetch upstream recover-B
 # Fetch commit into your local repository.
 ```
 
+You can also easily fetch it yourself explicitly:
+
+```shell
+$ git fetch upstream [COMMIT_HASH]
+$ git checkout [COMMIT_HASH]
+```
+
 ## Avoid force pushes
 
 Avoid force pushing to a repository unless absolutely necessary. This is especially true if more than one person can push to the repository. If someone force pushes to a repository, the force push may overwrite commits that other people based their work on. Force pushing changes the repository history and can corrupt pull requests.


### PR DESCRIPTION
Added instruction on how to fetch an orphaned commit.

### Why:

Closes: 

No open issue. The documentation felt lacking. 

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added an example of a quicker and easier method to fetch a commit. 

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
