### PR TITLE
Fix syntax error in types-of-webhooks.md

### DIFF
--- a/content/webhooks/types-of-webhooks.md
+++ b/content/webhooks/types-of-webhooks.md
@@ -36,7 +36,7 @@ You can use the {% data variables.product.prodname_dotcom %} web interface or th
 
 ## Organization webhooks
 
-You can create webhooks in an organization to subscribe to events that occur in that organization. Organization webhooks can subscribe to events that happen in all repositories owned by the organization. They are can also subscribe to events that happen at the organization level that are outside of any particular repository, like when a new member is added to the organization.
+You can create webhooks in an organization to subscribe to events that occur in that organization. Organization webhooks can subscribe to events that happen in all repositories owned by the organization. They can also subscribe to events that happen at the organization level that are outside of any particular repository, like when a new member is added to the organization.
 
 You must be an organization owner to create and manage webhooks in an organization.
 


### PR DESCRIPTION
Change "They are can" to "They can".

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: Fix English syntax error

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Changed the sentence "They **are can** also subscribe to events that happen..." to "They **can** also subscribe to events that happen..."

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
