### PR TITLE
Added Missing Quotation Marks

### DIFF
--- a/content/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax.md
+++ b/content/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax.md
@@ -249,7 +249,7 @@ You can create multiple levels of nested lists using the same method. For exampl
 
 ![Screenshot of rendered GitHub Markdown showing a list item prefaced by the number 100 followed by a bulleted item nested one level to the right, and another bulleted item nested yet further to the right.](/assets/images/help/writing/nested-list-example-2.png)
 
-For more examples, see the [GitHub Flavored Markdown Spec](https://github.github.com/gfm/#example-265).
+For more examples, see the "[GitHub Flavored Markdown Spec](https://github.github.com/gfm/#example-265)."
 
 {% ifversion task-lists-v1 %}
 
@@ -308,7 +308,7 @@ You can add emoji to your writing by typing `:EMOJICODE:`, a colon followed by t
 
 Typing <kbd>:</kbd> will bring up a list of suggested emoji. The list will filter as you type, so once you find the emoji you're looking for, press **Tab** or **Enter** to complete the highlighted result.
 
-For a full list of available emoji and codes, see [the Emoji-Cheat-Sheet](https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md).
+For a full list of available emoji and codes, see "[the Emoji-Cheat-Sheet](https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md)."
 
 ## Paragraphs
 
@@ -422,7 +422,7 @@ For more information on backslashes, see Daring Fireball's "[Markdown Syntax](ht
 
 ## Further reading
 
-- [{% data variables.product.prodname_dotcom %} Flavored Markdown Spec](https://github.github.com/gfm/)
+- "[{% data variables.product.prodname_dotcom %} Flavored Markdown Spec](https://github.github.com/gfm/)"
 - "[AUTOTITLE](/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/about-writing-and-formatting-on-github)"
 - "[AUTOTITLE](/get-started/writing-on-github/working-with-advanced-formatting)"
 - "[AUTOTITLE](/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/quickstart-for-writing-on-github)"


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: A few hyperlinks seem to be missing quotation marks.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Hyperlinks that are missing quotation marks.
Example:
<img width="358" alt="Captura de Tela 2023-10-20 às 22 54 50" src="https://github.com/github/docs/assets/64154960/fe775615-a51e-4ccd-951b-6aa7ab36aab2">
To:
<img width="358" alt="Captura de Tela 2023-10-20 às 22 55 11" src="https://github.com/github/docs/assets/64154960/72c3c98f-b306-4d20-acc1-4cd9b51d0178">


<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
