### PR TITLE
Update viewing-your-milestones-progress.md

### DIFF
--- a/content/issues/using-labels-and-milestones-to-track-work/viewing-your-milestones-progress.md
+++ b/content/issues/using-labels-and-milestones-to-track-work/viewing-your-milestones-progress.md
@@ -17,7 +17,7 @@ shortTitle: View progress to milestone
 ---
 {% data reusables.repositories.navigate-to-repo %}
 {% data reusables.repositories.sidebar-issue-pr %}
-1. In the upper-left corner, click **Milestones**.
+1. In the upper-right corner, click **Milestones**.
 
    ![Screenshot of the list of issues for a repository. Above the list, a button, labeled with a signpost icon and "Milestones," is outlined in dark orange.](/assets/images/help/issues/issues-milestone-button.png)
 1. Click the milestone you wish to see more information about.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes:  #29321

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Here, the doc mentions the location of the "milestones" button at the wrong position (upper-left), I changed it to "upper-right".

### Check off the following:

- [✅ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [✅ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
