### PR TITLE
Added missing "\" in example command

### DIFF
--- a/content/rest/overview/authenticating-to-the-rest-api.md
+++ b/content/rest/overview/authenticating-to-the-rest-api.md
@@ -67,7 +67,7 @@ curl --request POST \
 --url "{% data variables.product.api_url_code %}/applications/YOUR_CLIENT_ID/token" \
 --user "YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"{% ifversion api-date-versioning %} \
 --header "Accept: application/vnd.github+json" \
---header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %} \
+--header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}" \{% endif %}
 --data '{
   "access_token": "ACCESS_TOKEN_TO_CHECK"
 }'

--- a/content/rest/overview/authenticating-to-the-rest-api.md
+++ b/content/rest/overview/authenticating-to-the-rest-api.md
@@ -67,7 +67,7 @@ curl --request POST \
 --url "{% data variables.product.api_url_code %}/applications/YOUR_CLIENT_ID/token" \
 --user "YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"{% ifversion api-date-versioning %} \
 --header "Accept: application/vnd.github+json" \
---header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %}
+--header "X-GitHub-Api-Version: {{ allVersions[currentVersion].latestApiVersion }}"{% endif %} \
 --data '{
   "access_token": "ACCESS_TOKEN_TO_CHECK"
 }'


### PR DESCRIPTION
Added missing "\" in example command on  authenticating-to-the-rest-api.md

### Why:
Currently, Commands throws error - `command not found: --data` as missing backslash to have multi-line curl command

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
