### PR TITLE
Updates to docs on Using concurrency

### DIFF
--- a/content/actions/using-jobs/using-concurrency.md
+++ b/content/actions/using-jobs/using-concurrency.md
@@ -13,6 +13,14 @@ versions:
 
 ## Overview
 
+By default, GitHub Actions allows multiple jobs within the same workflow, multiple workflow runs within the same repository, and multiple workflow runs across a repository owner's account to run concurrently (i.e. multiple workflow runs, jobs, or steps can be run at the same time.)
+
+GitHub Actions also allows you to control the concurrency of workflow runs, so that you can ensure that only one run, one job, or one step runs at a time in a specific context. This can be useful for controlling your account's or organisation's resources in situations where running multiple workflows, jobs, or steps at the same time could cause conflicts or consume more Actions minutes and storage than expected.
+
+For example, the ability to run workflows concurrently means that if multiple commits are pushed to a repository in quick succession, each push could trigger a separate workflow run, and these runs will execute concurrently.
+
+Concurrency in GitHub Actions can be controlled at the workflow level or at the job level.
+
 {% data reusables.actions.jobs.section-using-concurrency-jobs %}
 
 {% ifversion github-runner-dashboard %}

--- a/data/reusables/actions/actions-group-concurrency.md
+++ b/data/reusables/actions/actions-group-concurrency.md
@@ -9,19 +9,80 @@ When a concurrent job or workflow is queued, if another job or workflow using th
 
 {% endnote %}
 
-### Examples: Using concurrency and the default behavior
+### Example: Using concurrency and the default behavior
+
+The default behaviour of GitHub Actions is to allow multiple jobs or workflow runs to run concurrently. The `concurrency` keyword allows you to control the concurrency of workflow runs.
+
+For example, you can use the `concurrency` keyword immediately after where trigger conditions are defined to limit the concurrency of entire workflow runs for a specific branch:
 
 {% raw %}
 
 ```yaml
-concurrency: staging_environment
+on:
+  push:
+    branches:
+      - main
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+{% endraw %}
+
+You can also limit the concurrency of jobs within a workflow by using the `concurrency` keyword at the job level:
+
+{% raw %}
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  job-1:
+    runs-on: ubuntu-latest
+    concurrency: 
+      group: example-group
+      cancel-in-progress: true
+```
+{% endraw %}
+
+### Example: Concurrency groups
+
+Concurrency groups provide a way to manage and limit the execution of workflow runs or jobs that share the same concurrency key.
+
+The concurrency key is used to group workflows or jobs together into a concurrency group. When you define a concurrency key, GitHub Actions ensures that only one workflow or job with that key runs at any given time. If a new workflow run or job starts with the same concurrency key, GitHub Actions will cancel any workflow or job already running with that key. The concurrency key can be a hard-coded string, or it can be a dynamic expression that includes context variables.
+
+It is possible to define concurrency conditions in your workflow so that the workflow or job is part of a concurrency group.
+
+This means that when a workflow run or job starts, GitHub will cancel any workflow runs or jobs that are already in progress in the same concurrency group. This is useful in scenarios where you want to prevent parallel runs for a certain set of a workflows or jobs, such as the ones used for deployments to a staging environment, in order to prevent actions that could cause conflicts or consume more resources than necessary.
+
+In this example, `job-1` is part of a concurrency group named `staging_environment`. This means that if a new run of `job-1` is triggered, any runs of the same job already in progress will be cancelled.
+
+{% raw %}
+
+```yaml
+jobs:
+  job-1:
+    runs-on: ubuntu-latest
+    concurrency: 
+      group: staging_environment
+      cancel-in-progress: true
 ```
 
 {% endraw %}
 
+Alternatively, using a dynamic expression sush as `concurrency: ci-${{ github.ref }}` in your workflow means that the workflow or job would be part of a concurrency group named `ci-` followed by the reference of the branch or tag that triggered the workflow. In this example, if a new commit is pushed to the main branch while a previous run is still in progress, the previous run will be cancelled and the new one will start:
+
 {% raw %}
 
 ```yaml
+on:
+  push:
+    branches:
+      - main
+
 concurrency: ci-${{ github.ref }}
 ```
 
@@ -29,15 +90,18 @@ concurrency: ci-${{ github.ref }}
 
 ### Example: Using concurrency to cancel any in-progress job or run
 
+To use concurrency to cancel any in-progress job or run in GitHub Actions, you can use the concurrency keyword with the `cancel-in-progress` option set to `true`:
+
 {% raw %}
 
 ```yaml
 concurrency:
-  group: ${{ github.ref }}
   cancel-in-progress: true
 ```
 
 {% endraw %}
+
+Note that in this example, without defining a particular concurrency group, GitHub Actions will cancel _any_ in-progress run of the job or workflow.
 
 ### Example: Using a fallback value
 


### PR DESCRIPTION
[maintainer edited to remove internal links]
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:



Some of the examples on how it can be used in Actions provided a couple of lines of  `yaml` code, but didn't provide any explanations. 

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

NA

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

https://docs.github.com/en/actions/using-jobs/using-concurrency

What I've added:

* Some background on concurrency 
* Example with the default behaviours
* Example on how to use concurrency groups
* Details on concurrency groups
* Example on using concurrency to cancel any in-progress run

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
