### PR TITLE
Update splitting-a-subfolder-out-into-a-new-repository.md, adding com…

### DIFF
--- a/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
+++ b/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
@@ -66,17 +66,6 @@ If you create a new clone of the repository, you won't lose any of your Git hist
    ```shell
    $ git filter-repo --subdirectory-filter FOLDER-NAME
    # Filter the specific branch by using a single sub-directory as the root for the new repository
-   > Parsed 82 commits
-   > New history written in 0.44 seconds; now repacking/cleaning...
-   > Repacking your repo and cleaning out old unneeded objects
-   > HEAD is now at 968d5a5 +: Print example / Notifier part 1
-   > Enumerating objects: 101, done.
-   > Counting objects: 100% (101/101), done.
-   > Delta compression using up to 6 threads
-   > Compressing objects: 100% (58/58), done.
-   > Writing objects: 100% (101/101), done.
-   > Total 101 (delta 44), reused 73 (delta 36), pack-reused 0
-   > Completely finished after 1.01 seconds.
    ```
 
 1. [Create a new repository](/repositories/creating-and-managing-repositories/creating-a-new-repository) on {% data variables.product.product_name %}.

--- a/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
+++ b/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
@@ -55,8 +55,6 @@ If you create a new clone of the repository, you won't lose any of your Git hist
    ```shell
    $ git filter-repo --path FOLDER-NAME/
    # Filter the specified branch in your directory and remove empty commits
-   > Rewrite 48dc599c80e20527ed902928085e7861e6b3cbe6 (89/89)
-   > Ref 'refs/heads/BRANCH-NAME' was rewritten
    ```
 
    The repository should now only contain the files that were in your subfolder(s).

--- a/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
+++ b/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
@@ -64,6 +64,17 @@ If you create a new clone of the repository, you won't lose any of your Git hist
    If you want one specific subfolder to be the new root folder of the new repository, the following command can be used:
    ```shell
    $ git filter-repo --subdirectory-filter FOLDER-NAME
+   > Parsed 82 commits
+   > New history written in 0.44 seconds; now repacking/cleaning...
+   > Repacking your repo and cleaning out old unneeded objects
+   > HEAD is now at 968d5a5 +: Print example / Notifier part 1
+   > Enumerating objects: 101, done.
+   > Counting objects: 100% (101/101), done.
+   > Delta compression using up to 6 threads
+   > Compressing objects: 100% (58/58), done.
+   > Writing objects: 100% (101/101), done.
+   > Total 101 (delta 44), reused 73 (delta 36), pack-reused 0
+   > Completely finished after 1.01 seconds.
    ```
 
 1. [Create a new repository](/repositories/creating-and-managing-repositories/creating-a-new-repository) on {% data variables.product.product_name %}.

--- a/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
+++ b/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
@@ -61,7 +61,7 @@ If you create a new clone of the repository, you won't lose any of your Git hist
 
    The repository should now only contain the files that were in your subfolder(s).
 
-   If you want one specific subfolder to be the new root folder of the new repository, the following command can be used:
+   If you want one specific subfolder to be the new root folder of the new repository, you can use the following command:
 
    ```shell
    $ git filter-repo --subdirectory-filter FOLDER-NAME

--- a/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
+++ b/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
@@ -62,7 +62,7 @@ If you create a new clone of the repository, you won't lose any of your Git hist
    The repository should now only contain the files that were in your subfolder(s).
 
    If you want one specific subfolder to be the new root folder of the new repository, the following command can be used:
-   
+
    ```shell
    $ git filter-repo --subdirectory-filter FOLDER-NAME
    # Filter the specific branch by using a single sub-directory as the root for the new repository

--- a/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
+++ b/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
@@ -61,6 +61,11 @@ If you create a new clone of the repository, you won't lose any of your Git hist
 
    The repository should now only contain the files that were in your subfolder(s).
 
+   If you want one specific subfolder to be the new root folder of the new repository, the following command can be used:
+   ```shell
+   $ git filter-repo --subdirectory-filter FOLDER-NAME
+   ```
+
 1. [Create a new repository](/repositories/creating-and-managing-repositories/creating-a-new-repository) on {% data variables.product.product_name %}.
 
 1. At the top of your new repository on {% ifversion ghae %}{% data variables.product.product_name %}{% else %}{% data variables.location.product_location %}{% endif %}'s Quick Setup page, click {% octicon "copy" aria-label="Copy to clipboard" %} to copy the remote repository URL.

--- a/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
+++ b/content/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository.md
@@ -62,8 +62,10 @@ If you create a new clone of the repository, you won't lose any of your Git hist
    The repository should now only contain the files that were in your subfolder(s).
 
    If you want one specific subfolder to be the new root folder of the new repository, the following command can be used:
+   
    ```shell
    $ git filter-repo --subdirectory-filter FOLDER-NAME
+   # Filter the specific branch by using a single sub-directory as the root for the new repository
    > Parsed 82 commits
    > New history written in 0.44 seconds; now repacking/cleaning...
    > Repacking your repo and cleaning out old unneeded objects


### PR DESCRIPTION
…mand to create a repository out of a single subdirectory

The sub-directory will be the new root directory of the resulting repository

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Adding the command for a common use case, where the split off sub-folder should become the root folder for the new repository.

Closes: #29639

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Adding a code snipped (shell code)

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
