### PR TITLE
docs: Add notes about runs-on syntax

### DIFF
--- a/data/reusables/actions/jobs/section-choosing-the-runner-for-a-job.md
+++ b/data/reusables/actions/jobs/section-choosing-the-runner-for-a-job.md
@@ -42,6 +42,12 @@ Use `jobs.<job_id>.runs-on` to define the type of machine to run the job on.
 
 - If you would like to run your workflow on multiple machines, use [`jobs.<job_id>.strategy`](/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategy).
 
+{% note %}
+
+**Note:** When passing strings as the value of `runs-on` they can be quoted but it is not needed, for example `self-hosted`. However expressions like `"${{ inputs.chosen-os }}"` need to be quoted.
+
+{% endnote %}
+
 {% ifversion fpt or ghec or ghes %}
 {% data reusables.actions.enterprise-github-hosted-runners %}
 

--- a/data/reusables/actions/jobs/section-choosing-the-runner-for-a-job.md
+++ b/data/reusables/actions/jobs/section-choosing-the-runner-for-a-job.md
@@ -44,7 +44,7 @@ Use `jobs.<job_id>.runs-on` to define the type of machine to run the job on.
 
 {% note %}
 
-**Note:** When passing strings as the value of `runs-on` they can be quoted but it is not needed, for example `self-hosted`. However expressions like {% raw %} `"${{ inputs.chosen-os }}"`{% endraw %} need to be quoted.
+**Note:** Quotation marks are not required around simple strings like `self-hosted`, but they are required for expressions like {% raw %} `"${{ inputs.chosen-os }}"`{% endraw %}.
 
 {% endnote %}
 

--- a/data/reusables/actions/jobs/section-choosing-the-runner-for-a-job.md
+++ b/data/reusables/actions/jobs/section-choosing-the-runner-for-a-job.md
@@ -44,7 +44,8 @@ Use `jobs.<job_id>.runs-on` to define the type of machine to run the job on.
 
 {% note %}
 
-**Note:** When passing strings as the value of `runs-on` they can be quoted but it is not needed, for example `self-hosted`. However expressions like `"${{ inputs.chosen-os }}"` need to be quoted.
+**Note:** When passing strings as the value of `runs-on` they can be quoted but it is not needed, for example `self-hosted`. However expressions like 
+{% raw %} `"${{ inputs.chosen-os }}"`{% endraw %} need to be quoted.
 
 {% endnote %}
 

--- a/data/reusables/actions/jobs/section-choosing-the-runner-for-a-job.md
+++ b/data/reusables/actions/jobs/section-choosing-the-runner-for-a-job.md
@@ -44,8 +44,7 @@ Use `jobs.<job_id>.runs-on` to define the type of machine to run the job on.
 
 {% note %}
 
-**Note:** When passing strings as the value of `runs-on` they can be quoted but it is not needed, for example `self-hosted`. However expressions like 
-{% raw %} `"${{ inputs.chosen-os }}"`{% endraw %} need to be quoted.
+**Note:** When passing strings as the value of `runs-on` they can be quoted but it is not needed, for example `self-hosted`. However expressions like {% raw %} `"${{ inputs.chosen-os }}"`{% endraw %} need to be quoted.
 
 {% endnote %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

This PR clarifies the need for quotes around expressions on runs-on on the workflow jobs

Closes: https://github.com/github/docs/issues/20495

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Following this https://github.com/github/docs/issues/20495#issuecomment-1717383155

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
