### PR TITLE
Update unlinking-your-email-address-from-a-locked-account.md

### DIFF
--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-personal-account/unlinking-your-email-address-from-a-locked-account.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-personal-account/unlinking-your-email-address-from-a-locked-account.md
@@ -1,6 +1,6 @@
 ---
-title: Unlinking your email address from a locked account
-intro: 'You can remove the connection between your email address and a locked account. The email address is then available for you to link it to a new or existing account, maintaining your commit history.'
+title: Unlinking your email address from a 2FA locked account
+intro: 'You can remove the connection between your email address and a 2FA locked account. The email address is then available for you to link it to a new or existing account, maintaining your commit history.'
 redirect_from:
   - /early-access/account-and-profile/unlinking-your-email-address-from-a-locked-account
 versions:
@@ -16,7 +16,7 @@ shortTitle: Unlink your email
 
 **Notes:**
 
-- Following these steps will not provide access to the locked account, but instead unlink the associated email address so it may be used for a different account. If you cannot regain access to the locked account, these steps will permanently break the link between the account and the linked email address. Before continuing with this article, be sure you have lost all access to your account. For more information, see "[AUTOTITLE](/authentication/securing-your-account-with-two-factor-authentication-2fa/recovering-your-account-if-you-lose-your-2fa-credentials)."
+- Following these steps will not provide access to the 2FA locked account, but instead unlink the associated email address so it may be used for a different account. If you cannot regain access to the 2FA locked account, these steps will permanently break the link between the account and the linked email address. Before continuing with this article, be sure you have lost all access to your account. For more information, see "[AUTOTITLE](/authentication/securing-your-account-with-two-factor-authentication-2fa/recovering-your-account-if-you-lose-your-2fa-credentials)."
 
 - If you recover access to your locked account, you can re-link an unlinked email address. For more information, see "[AUTOTITLE](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/adding-an-email-address-to-your-github-account)."
 
@@ -24,7 +24,7 @@ shortTitle: Unlink your email
 
 ## About unlinking your email address
 
-Since an email address can only be associated with a single {% data variables.product.prodname_dotcom %} account, unlinking your email address from a locked account allows you to link that email address to a new or existing account. Additionally, linking a previously used commit email address to a new account will connect your commit history to that account. Unless you have chosen to keep your email address private, your account's commit email address is the same as your account's primary email address. For more information, see "[AUTOTITLE](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address)." Be aware that nothing else associated with your locked account, including your repositories, permissions, and profile, will transfer to your new account.
+Since an email address can only be associated with a single {% data variables.product.prodname_dotcom %} account, unlinking your email address from a 2FA locked account allows you to link that email address to a new or existing account. Additionally, linking a previously used commit email address to a new account will connect your commit history to that account. Unless you have chosen to keep your email address private, your account's commit email address is the same as your account's primary email address. For more information, see "[AUTOTITLE](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address)." Be aware that nothing else associated with your 2FA locked account, including your repositories, permissions, and profile, will transfer to your new account.
 
 {% note %}
 


### PR DESCRIPTION
Added 2FA references to make it clear to users that this option is only available for some accounts where the user has lost access.

### Why:

Closes: https://github.com/github/docs-content/issues/12777

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updates to wording to ensure it is clear to users that this document is only relevant to accounts which have 2FA enabled. 

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
