### PR TITLE
Update troubleshooting-404-errors-for-github-pages-sites.md

### DIFF
--- a/content/pages/getting-started-with-github-pages/troubleshooting-404-errors-for-github-pages-sites.md
+++ b/content/pages/getting-started-with-github-pages/troubleshooting-404-errors-for-github-pages-sites.md
@@ -71,4 +71,13 @@ Check whether your repository meets the following requirements.
 - The repository must have a commit pushed to it by someone with admin permissions for the repository, such as the repository owner.
 - Switching the repository's visibility from public to private or vice versa will change the URL of your {% data variables.product.prodname_pages %} site, which will result in broken links until the site is rebuilt.
 
+### Folder name
+
+Your folder names should not begin with underscore. Jekyll silently ignores such folders. Solution could be put `.nojekyll` empty file into root folder. 
+Another solution: add `_config.yml` with content
+```
+include:
+  - _next
+```
+
 If you are still receiving a 404 error, start a [{% data variables.product.prodname_github_community %} discussion](https://github.com/orgs/community/discussions/categories/pages) in the Pages category.

--- a/content/pages/getting-started-with-github-pages/troubleshooting-404-errors-for-github-pages-sites.md
+++ b/content/pages/getting-started-with-github-pages/troubleshooting-404-errors-for-github-pages-sites.md
@@ -73,8 +73,9 @@ Check whether your repository meets the following requirements.
 
 ### Folder name
 
-Your folder names should not begin with underscore. Jekyll silently ignores such folders. Solution could be put `.nojekyll` empty file into root folder. 
+Your folder names should not begin with underscore. Jekyll silently ignores such folders. The solution could be put ".nojekyll" empty file into the root folder. 
 Another solution: add `_config.yml` with content
+
 ```
 include:
   - _next


### PR DESCRIPTION
Add "Folder name" chapter. To say about Jekyll behavior with underscore named folders

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Just one more chapter in "Troubleshooting 404 errors for GitHub Pages sites" file

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
