### PR TITLE
Better specify GitHub policy about name squatting

### DIFF
--- a/content/site-policy/other-site-policies/github-username-policy.md
+++ b/content/site-policy/other-site-policies/github-username-policy.md
@@ -27,3 +27,5 @@ If you believe someone's account is violating your trademark rights, you can fin
 ## Name Squatting Policy
 
 GitHub prohibits account name squatting, and account names may not be reserved or inactively held for future use. Accounts violating this name squatting policy may be removed or renamed without notice. Attempts to sell, buy, or solicit other forms of payment in exchange for account names are prohibited and may result in permanent account suspension.
+
+At the time of writing (14 November 2023), GitHub no longer accepts requests to release dormant usernames.


### PR DESCRIPTION
While looking for a [place to report](https://support.github.com/contact/account) a [name squatting](https://docs.github.com/en/site-policy/other-site-policies/github-username-policy#name-squatting-policy) case, I bumped upon an alert:

![image](https://github.com/github/docs/assets/396782/2cb1aefa-1e97-4915-80bd-cfc5f3b9547c)

Having this information directly into the docs would have been easier to understand that there's no chance of freeing that handle.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
