### PR TITLE
Fix broken links in about-github-hosted-runners

### DIFF
--- a/content/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners.md
+++ b/content/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners.md
@@ -147,10 +147,10 @@ For more information, see "[AUTOTITLE](/actions/monitoring-and-troubleshooting-w
 
 For the overall list of included tools for each runner operating system, see the links below:
 
-- [Ubuntu 22.04 LTS](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md)
-- [Ubuntu 20.04 LTS](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md)
-- [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md)
-- [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md)
+- [Ubuntu 22.04 LTS](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)
+- [Ubuntu 20.04 LTS](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md)
+- [Windows Server 2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md)
+- [Windows Server 2019](https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md)
 - [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)
 - [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)
 - [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Some links are broken.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Links are fixed.

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
