### PR TITLE
Fix quote char on "Planning your migration to GH"

### DIFF
--- a/content/migrations/overview/planning-your-migration-to-github.md
+++ b/content/migrations/overview/planning-your-migration-to-github.md
@@ -103,7 +103,7 @@ Then, use the open-source tool, `git-sizer`, to get this data for your repositor
 1. To clone your repository from the migration origin, run `git clone --mirror`.
 1. Navigate to the directory where you cloned your repository.
 1. To get the size of the largest file in your repository in bytes, run `git-sizer --no-progress -j | jq ".max_blob_size"`.
-1. To get the total size of all files in your repository in bytes, run `git-sizer --no-progress -j | jq “.unique_blob_size”`.
+1. To get the total size of all files in your repository in bytes, run `git-sizer --no-progress -j | jq ".unique_blob_size"`.
 1. Add the values from the previous steps to your inventory.
 
 ## About migration types


### PR DESCRIPTION
Change the quote character `“` to `"` on the `jq` filter of the `git-sizer`'s output.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The filter applied by `jq` on `git-sizer`'s output was using the wrong quotation character to enclose the filtering information and `jq` errored with:

```
jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file (Unix shell quoting issues?) at <top-level>, line 1:
“.unique_blob_size”
```

Closes: #30079

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Use the correct quotation character (hex `22` on ASCII / UTF-8) with `jq` for filtering the output of `git-sizer`.
### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
