### PR TITLE
Remove note about codespaces URL containing GitHub handle

### DIFF
--- a/content/codespaces/troubleshooting/troubleshooting-your-connection-to-github-codespaces.md
+++ b/content/codespaces/troubleshooting/troubleshooting-your-connection-to-github-codespaces.md
@@ -23,7 +23,7 @@ Codespaces are set to stop after 30 minutes without any activity. If you try to 
 
 Sometimes you may not be able to access a codespace from your browser. If this happens, go to https://github.com/codespaces and try connecting to the codespace from that page.
 
-- If the codespace is not listed on that page, check that you are the owner of the codespace you are trying to connect to. You can only open a codespace that you created. The URLs for your codespaces always include your {% data variables.product.company_short %} handle.
+- If the codespace is not listed on that page, check that you are the owner of the codespace you are trying to connect to. You can only open a codespace that you created.
 - If the codespace is listed but you cannot connect from that page, check whether you can connect using a different browser.
 
 Your company network may be blocking the connection. If possible, check any logging for rejected connections on your device.


### PR DESCRIPTION
Remove note that says, "The URLs for your codespaces always include your handle."

### Why:

It is no longer true that codespaces URLs contain GitHub handles.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
