### PR TITLE
Update blocking-command-line-pushes-that-expose-your-personal-email-a…

### DIFF
--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/blocking-command-line-pushes-that-expose-your-personal-email-address.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/blocking-command-line-pushes-that-expose-your-personal-email-address.md
@@ -1,28 +1,44 @@
 ---
-title: Blocking command line pushes that expose your personal email address
-intro: 'If you''ve chosen to keep your email address private when performing web-based operations, you can also choose to block command line pushes that may expose your personal email address.'
+title: Site policy documentation
+shortTitle: Site policy
 redirect_from:
-  - /articles/blocking-command-line-pushes-that-expose-your-personal-email-address
-  - /github/setting-up-and-managing-your-github-user-account/blocking-command-line-pushes-that-expose-your-personal-email-address
-  - /github/setting-up-and-managing-your-github-user-account/managing-email-preferences/blocking-command-line-pushes-that-expose-your-personal-email-address
-  - /account-and-profile/setting-up-and-managing-your-github-user-account/managing-email-preferences/blocking-command-line-pushes-that-expose-your-personal-email-address
+  - /categories/61/articles
+  - /categories/site-policy
+  - /github/site-policy
 versions:
   fpt: '*'
-  ghec: '*'
 topics:
-  - Accounts
-  - Notifications
-shortTitle: Block push with personal email
+  - Policy
+  - Legal
+children:
+  - /github-terms
+  - /acceptable-use-policies
+  - /privacy-policies
+  - /other-site-policies
+  - /content-removal-policies
+  - /security-policies
+  - /github-company-policies
+  - /site-policy-deprecated
 ---
-When you push commits from the command line, the email address that you've [set in Git](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address) is associated with your commits. If you enable this setting, each time you push to GitHub, we’ll check the most recent commit. If the author email on that commit is a private email on your GitHub account, we will block the push and warn you about exposing your private email.
-
-{% data reusables.user-settings.about-commit-email-addresses %}
-
-{% data reusables.user-settings.access_settings %}
-{% data reusables.user-settings.emails %}
-{% data reusables.user-settings.keeping_your_email_address_private %}
-1. To keep your email address private in commits you push from the command line, select **Block command line pushes that expose my email**.
-
-## Further reading
-
-- "[AUTOTITLE](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address)"
+---
+title: Site policy documentation
+shortTitle: Site policy
+redirect_from:
+  - /categories/61/articles
+  - /categories/site-policy
+  - /github/site-policy
+versions:
+  fpt: '*'
+topics:
+  - Policy
+  - Legal
+children:
+  - /github-terms
+  - /acceptable-use-policies
+  - /privacy-policies
+  - /other-site-policies
+  - /content-removal-policies
+  - /security-policies
+  - /github-company-policies
+  - /site-policy-deprecated
+---


### PR DESCRIPTION
…ddress.md

---
title: Site policy documentation
shortTitle: Site policy
redirect_from:
  - /categories/61/articles
  - /categories/site-policy
  - /github/site-policy versions:
  fpt: '*'
topics:
  - Policy
  - Legal children:
  - /github-terms
  - /acceptable-use-policies
  - /privacy-policies
  - /other-site-policies
  - /content-removal-policies
  - /security-policies
  - /github-company-policies
  - /site-policy-deprecated ---

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
