### PR TITLE
Markdown syntax / Alert section: fix number of alert types

### DIFF
--- a/content/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax.md
+++ b/content/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax.md
@@ -355,7 +355,7 @@ Alerts are an extension of the blockquote syntax that you can use to emphasize c
 
 We recommend restricting the use of alerts to one or two per article to avoid overloading the reader. Consecutive alerts should be avoided.
 
-Three types of alert are available. You can add an alert with a special blockquote line that specifies the alert type, and then add the alert information in a standard blockquote immediately after.
+Multiple types of alerts are available. You can add an alert with a special blockquote line that specifies the alert type, and then add the alert information in a standard blockquote immediately after.
 
 ```markdown
 > [!NOTE]


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #30163

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The [Alerts section](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) mentions that "Three types of alert are available" but then describes five types of alerts (Note, Tip, Important, Warning, Caution).

I believe that originally there were indeed 3 types (Note, Important, Warning), but then additional types were added but the "Three" remained in place. Practically, the exact number doesn't matter much, but rather the distinction that there are multiple types available.

Hence, the suggested fix is simply to change "Three" to "Multiple".

Additionally, this changes "alert" to "alerts", since this appears (at least to me) more suitable within that context.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
