### PR TITLE
Fix casing of BibTeX

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files.md
@@ -184,6 +184,6 @@ inst/CITATION
 
 ## Citation formats
 
-We currently support APA and BibTex file formats.
+We currently support APA and BibTeX file formats.
 
 Are you looking for additional citation formats? {% data variables.product.company_short %} uses a Ruby library, to parse the `CITATION.cff` files. You can request additional formats in the [ruby-cff](https://github.com/citation-file-format/ruby-cff) repository, or contribute them yourself.


### PR DESCRIPTION
Fix typo

### Why:

Consistent casing

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Typo

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
