### PR TITLE
Update outdated CLI edit releases information

### DIFF
--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -81,11 +81,11 @@ If you @mention any {% data variables.product.product_name %} users in the notes
 
 1. To edit a release, use the `gh release edit` subcommand. Replace `tag` with the tag representing the release you wish to edit. For example, to edit a given release's title:
 
-```shell
-gh release edit <tag> -t "New title"
-```
+   ```shell
+   gh release edit <tag> -t "New title"
+   ```
 
-For more information about possible arguments, see [the {% data variables.product.prodname_cli %} manual](https://cli.github.com/manual/gh_release_edit)
+   For more information about possible arguments, see [the {% data variables.product.prodname_cli %} manual](https://cli.github.com/manual/gh_release_edit)
 
 {% endcli %}
 

--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -82,7 +82,7 @@ If you @mention any {% data variables.product.product_name %} users in the notes
 1. To edit a release, use the `gh release edit` subcommand. Replace `tag` with the tag representing the release you wish to edit. For example, to edit a given release's title:
 
    ```shell
-   gh release edit <tag> -t "New title"
+   gh release edit TAG -t "New title"
    ```
 
    For more information about possible arguments, see [the {% data variables.product.prodname_cli %} manual](https://cli.github.com/manual/gh_release_edit)

--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -85,7 +85,7 @@ To edit releases using the {% data variables.product.prodname_cli %}:
 gh release edit TAG
 ```
 
-For more information about possible arguments, see [the {% data variables.product.prodname_cli % manual](https://cli.github.com/manual/gh_release_edit)
+For more information about possible arguments, see [the {% data variables.product.prodname_cli %} manual](https://cli.github.com/manual/gh_release_edit)
 
 Releases cannot currently be edited with {% data variables.product.prodname_cli %}.
 

--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -79,7 +79,7 @@ If you @mention any {% data variables.product.product_name %} users in the notes
 
 {% cli %}
 
-1. To edit a release, use the `gh release edit` subcommand. Replace `tag` with the tag representing the release you wish to edit. For example, to edit a given release's title:
+1. To edit a release, use the `gh release edit` subcommand. Replace `TAG` with the tag representing the release you wish to edit. For example, to edit a given release's title, use the following code:
 
    ```shell
    gh release edit TAG -t "New title"

--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -79,10 +79,10 @@ If you @mention any {% data variables.product.product_name %} users in the notes
 
 {% cli %}
 
-To edit releases using the {% data variables.product.prodname_cli %}:
+1. To edit a release, use the `gh release edit` subcommand. Replace `tag` with the tag representing the release you wish to edit. For example, to edit a given release's title:
 
 ```shell
-gh release edit TAG
+gh release edit <tag> -t "New title"
 ```
 
 For more information about possible arguments, see [the {% data variables.product.prodname_cli %} manual](https://cli.github.com/manual/gh_release_edit)

--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -79,10 +79,10 @@ If you @mention any {% data variables.product.product_name %} users in the notes
 
 {% cli %}
 
-1. To edit a release, use the `gh release edit` subcommand. Replace `TAG` with the tag representing the release you wish to edit. For example, to edit a given release's title, use the following code:
+1. To edit a release, use the `gh release edit` subcommand. Replace `TAG` with the tag representing the release you wish to edit. For example, to edit the title for a release, use the following code, replacing `NEW-TITLE` with the updated title:
 
    ```shell
-   gh release edit TAG -t "New title"
+   gh release edit TAG -t "NEW-TITLE"
    ```
 
    For more information about possible arguments, see [the {% data variables.product.prodname_cli %} manual](https://cli.github.com/manual/gh_release_edit).

--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -79,6 +79,14 @@ If you @mention any {% data variables.product.product_name %} users in the notes
 
 {% cli %}
 
+To edit releases using the {% data variables.product.prodname_cli %}:
+
+```shell
+gh release edit TAG
+```
+
+For more information about possible arguments, see [the {% data variables.product.prodname_cli % manual](https://cli.github.com/manual/gh_release_edit)
+
 Releases cannot currently be edited with {% data variables.product.prodname_cli %}.
 
 {% endcli %}

--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -85,7 +85,7 @@ If you @mention any {% data variables.product.product_name %} users in the notes
    gh release edit TAG -t "New title"
    ```
 
-   For more information about possible arguments, see [the {% data variables.product.prodname_cli %} manual](https://cli.github.com/manual/gh_release_edit)
+   For more information about possible arguments, see [the {% data variables.product.prodname_cli %} manual](https://cli.github.com/manual/gh_release_edit).
 
 {% endcli %}
 

--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -87,8 +87,6 @@ gh release edit TAG
 
 For more information about possible arguments, see [the {% data variables.product.prodname_cli %} manual](https://cli.github.com/manual/gh_release_edit)
 
-Releases cannot currently be edited with {% data variables.product.prodname_cli %}.
-
 {% endcli %}
 
 ## Deleting a release


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The website documentation is outdated - GitHub CLI does support editing releases.

Closes: #30245

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Following the convention in the "Create releases" section, show an example and a link to the GitHub CLI manual for the command:

<img width="846" alt="Screenshot 2023-11-29 at 19 38 51" src="https://github.com/github/docs/assets/5477014/847f5754-6202-4dc5-96d8-75c41e20fcc4">

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
