### PR TITLE
Update about-code-owners.md

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -151,9 +151,9 @@ apps/ @octocat
 
 ## CODEOWNERS and branch protection
 
-Repository owners must add branch protection rules to ensure that changed code is reviewed by the owners of the changed files. Specifically the option "Require review from Code Owners" For more information, see "[AUTOTITLE](/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)."
+Repository owners can update branch protection rules to ensure that changed code is reviewed by the owners of the changed files. Edit your branch protection rule and enable the option "Require review from Code Owners". For more information, see "[AUTOTITLE](/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)."
 
-Be aware that you must also specify the CODEOWNERS file/location itself in CODEOWNERS to protect this file and rules from being changed. And it would be wise to protect the highest tier location as well if not used, to stop a CODEOWNERS file being created/modified there ```/.github/CODEOWNERS @owner_username``` or even better ```/.github/ @owner_username``` to protect workflows/actions as well.
+To protect a repository fully against unauthorized changes, you also need to define an owner for the CODEOWNERS file itself. The most secure way method is to define a CODEOWNERS file in the `.github` directory of the repository and define the repository owner as the owner of either the CODEOWNERS file (``/.github/CODEOWNERS @owner_username``) or the whole directory (``/.github/ @owner_username``). 
 
 ## Further reading
 

--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -153,7 +153,7 @@ apps/ @octocat
 
 Repository owners can update branch protection rules to ensure that changed code is reviewed by the owners of the changed files. Edit your branch protection rule and enable the option "Require review from Code Owners". For more information, see "[AUTOTITLE](/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)."
 
-To protect a repository fully against unauthorized changes, you also need to define an owner for the CODEOWNERS file itself. The most secure way method is to define a CODEOWNERS file in the `.github` directory of the repository and define the repository owner as the owner of either the CODEOWNERS file (``/.github/CODEOWNERS @owner_username``) or the whole directory (``/.github/ @owner_username``). 
+To protect a repository fully against unauthorized changes, you also need to define an owner for the CODEOWNERS file itself. The most secure way method is to define a CODEOWNERS file in the `.github` directory of the repository and define the repository owner as the owner of either the CODEOWNERS file (``/.github/CODEOWNERS @owner_username``) or the whole directory (``/.github/ @owner_username``).
 
 ## Further reading
 

--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -153,7 +153,7 @@ apps/ @octocat
 
 Repository owners must add branch protection rules to ensure that changed code is reviewed by the owners of the changed files. Specifically the option "Require review from Code Owners" For more information, see "[AUTOTITLE](/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)."
 
-Be aware that you must also specify the CODEOWNERS file/location itself in CODEOWNERS to protect this file and rules from being changed. And it would be wise to protect the highest tier location as well if not used, to stop a CODEOWNERS file being created there ```/.github/CODEOWNERS @owner_username```
+Be aware that you must also specify the CODEOWNERS file/location itself in CODEOWNERS to protect this file and rules from being changed. And it would be wise to protect the highest tier location as well if not used, to stop a CODEOWNERS file being created/modified there ```/.github/CODEOWNERS @owner_username``` or even better ```/.github/ @owner_username``` to protect workflows/actions as well.
 
 ## Further reading
 

--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -151,7 +151,9 @@ apps/ @octocat
 
 ## CODEOWNERS and branch protection
 
-Repository owners can add branch protection rules to ensure that changed code is reviewed by the owners of the changed files. For more information, see "[AUTOTITLE](/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)."
+Repository owners must add branch protection rules to ensure that changed code is reviewed by the owners of the changed files. Specifically the option "Require review from Code Owners" For more information, see "[AUTOTITLE](/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)."
+
+Be aware that you must also specify the CODEOWNERS file/location itself in CODEOWNERS to protect this file and rules from being changed. And it would be wise to protect the highest tier location as well if not used, to stop a CODEOWNERS file being created there ```/.github/CODEOWNERS @owner_username```
 
 ## Further reading
 


### PR DESCRIPTION


### Why:

Highlights an easily missed security vulnerability


### What's being changed (if available, include any code snippets, screenshots, or gifs):

ive tested this, and unless codeowners is itself protected by codeowners, rules can be changed....

### Check off the following:

- [yes ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [yes ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
