### PR TITLE
[matrix-include.md] Add an example of a matrix with included jobs

### DIFF
--- a/data/reusables/actions/jobs/matrix-include.md
+++ b/data/reusables/actions/jobs/matrix-include.md
@@ -36,3 +36,25 @@ following this logic:
 - `{fruit: apple, shape: circle}` adds `shape: circle` only to the original matrix combinations that include `fruit: apple`.
 - `{fruit: banana}` cannot be added to any original matrix combination without overwriting a value, so it is added as an additional matrix combination.
 - `{fruit: banana, animal: cat}` cannot be added to any original matrix combination without overwriting a value, so it is added as an additional matrix combination. It does not add to the `{fruit: banana}` matrix combination because that combination was not one of the original matrix combinations.
+
+An example closer to reality, will create seven jobs, testing five versions for perl and only two for macos
+
+```yaml
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        perl:
+            - '5.16'
+            - '5.20'
+            - '5.26'
+            - '5.30'
+            - latest
+        include:
+          - os: macos-latest
+            perl: '5.26'
+          - os: macos-latest
+            perl: latest
+```


### PR DESCRIPTION
While going through the documentations it required a bit of fiddling to get it right, this small snippet should be helpful to understand better different variations that one might use, for visual learners

### Why:

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adding a second example of the matrix with include, to help visual learners to understand better what's going on

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
