### PR TITLE
Update authorizing-github-apps.md

### DIFF
--- a/content/apps/using-github-apps/authorizing-github-apps.md
+++ b/content/apps/using-github-apps/authorizing-github-apps.md
@@ -46,7 +46,7 @@ When an app acts on your behalf, it will attribute the activity to you in conjun
 
 ![Screenshot of a comment that has a user avatar with an overlaid app identicon badge. The avatar is highlighted with an orange outline.](/assets/images/help/apps/github-app-acting-on-your-behalf.png)
 
-Similarly, if the activity triggers a corresponding entry in the audit logs and security logs, the logs will list you as the actor but will state that the "programmatic_access_type" is "GitHub App user-to-server token".
+Similarly, if the activity triggers a corresponding entry in the audit logs and security logs, the logs will list you as the actor but will state that the "programmatic_access_type" is "GitHub App user-to-server token" or "OAuth access token".
 
 ## Difference between authorization and installation
 


### PR DESCRIPTION
### Why:

We see programmatic_access_type as "OAuth access token" in our logs for GitHub Enterprise


### What's being changed (if available, include any code snippets, screenshots, or gifs):

Change the documentation to include the additional value.

### Check off the following:

- [X ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ X] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
