### PR TITLE
Added some details on how to solve a `configure-pages` permission problem.

### DIFF
--- a/content/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages.md
+++ b/content/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages.md
@@ -28,25 +28,25 @@ To use the action place this snippet under your `jobs` in the desired workflow.
 
 This action helps support deployment from any static site generator to {% data variables.product.prodname_pages %}. To make this process less repetitive you can use starter workflows for some of the most widely used static site generators. For more information, see "[AUTOTITLE](/actions/learn-github-actions/using-starter-workflows)."
 
-{% note %}
+{% warning %}
 
 **Warning:** If this action throws an error similar to the following:
 
-```
-Error: Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the `enablement` parameter for this action.
+`
+Error: Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the enablement parameter for this action.
 Error: HttpError: Resource not accessible by integration
-```
+`
 
 This means that `GITHUB_TOKEN` which is used by default in the `configure-pages` action does not have the required permission. In this case, you need to set up a [{% data variables.product.pat_generic_caps %}](/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#about-personal-access-tokens) that has writing access to {% data variables.product.prodname_pages %}. This token should be stored in [secrets](/actions/security-guides/using-secrets-in-github-actions) then used in the argument `token`:
 
-```
+```yaml
 - name: Configure GitHub Pages
   uses: actions/configure-pages@v3
   with:
     token: ${{ secrets.PAGES_TOKEN }}
 ```
 
-{% endnote %}
+{% endwarning %}
 
 ## Configuring the `upload-pages-artifact` action
 

--- a/content/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages.md
+++ b/content/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages.md
@@ -28,6 +28,26 @@ To use the action place this snippet under your `jobs` in the desired workflow.
 
 This action helps support deployment from any static site generator to {% data variables.product.prodname_pages %}. To make this process less repetitive you can use starter workflows for some of the most widely used static site generators. For more information, see "[AUTOTITLE](/actions/learn-github-actions/using-starter-workflows)."
 
+{% note %}
+
+**Warning:** If this action throws an error similar to the following:
+
+```
+Error: Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the `enablement` parameter for this action.
+Error: HttpError: Resource not accessible by integration
+```
+
+This means that `GITHUB_TOKEN` which is used by default in the `configure-pages` action does not have the required permission. In this case, you need to set up a [{% data variables.product.pat_generic_caps %}](/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#about-personal-access-tokens) that has writing access to {% data variables.product.prodname_pages %}. This token should be stored in [secrets](/actions/security-guides/using-secrets-in-github-actions) then used in the argument `token`:
+
+```
+- name: Configure GitHub Pages
+  uses: actions/configure-pages@v3
+  with:
+    token: ${{ secrets.PAGES_TOKEN }}
+```
+
+{% endnote %}
+
 ## Configuring the `upload-pages-artifact` action
 
 The `upload-pages-artifact` actions enables you to package and upload artifacts. The {% data variables.product.prodname_pages %} artifact should be a compressed `gzip` archive containing a single `tar` file. The `tar` file must be under 10GB in size and should not contain any symbolic or hard links. For more information, see the [`upload-pages-artifact`](https://github.com/marketplace/actions/upload-github-pages-artifact) action.


### PR DESCRIPTION


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: https://github.com/actions/starter-workflows/issues/332

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

There were no details in the documentation about the problem that happens when trying to use `configure-pages` without arguments. The default `GITHUB_TOKEN` does not have the required permission to make it work. I added some information to explain how to solve this problem because it happened to me and I solved it.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
