### PR TITLE
Fixed Contributing Guide link (top link) within  /contributing/README.md

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -1,6 +1,6 @@
 # Contributing to github/docs
 
-Check out our [contributing guide](../CONTRIBUTING.md) to see all the ways you can participate in the GitHub docs community :sparkling_heart:
+Check out our [contributing guide](../.github/CONTRIBUTING.md) to see all the ways you can participate in the GitHub docs community :sparkling_heart:
 
 Visit "[Contributing to GitHub Docs documentation](https://docs.github.com/en/contributing)" for additional information about how to write and collaborate the GitHub Docs way.
 


### PR DESCRIPTION
### Why:

Closes: #30584 

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Link to the contributing guide at the top of the README is broken

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.
