### PR TITLE
Update SPM url in building-and-testing-swift.md

### DIFF
--- a/content/actions/automating-builds-and-tests/building-and-testing-swift.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-swift.md
@@ -28,7 +28,7 @@ This guide shows you how to build and test a Swift package.
 
 You should already be familiar with YAML syntax and how it's used with {% data variables.product.prodname_actions %}. For more information, see "[AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions)."
 
-We recommend that you have a basic understanding of Swift packages. For more information, see "[Swift Packages](https://developer.apple.com/documentation/swift_packages)" in the Apple developer documentation.
+We recommend that you have a basic understanding of Swift packages. For more information, see "[Swift Packages](https://developer.apple.com/documentation/xcode/swift-packages)" in the Apple developer documentation.
 
 ## Using a Swift starter workflow
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Apple has changes the url for Swift Packages in their documentation.

Closes: [#30749](https://github.com/github/docs/issues/30749)

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Old url:
https://developer.apple.com/documentation/swift_packages
New url:
https://developer.apple.com/documentation/xcode/swift-packages

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
