### PR TITLE
Update all articles where GITHUB_TOKEN should appear as GH_TOKEN

### DIFF
--- a/content/actions/managing-issues-and-pull-requests/adding-labels-to-issues.md
+++ b/content/actions/managing-issues-and-pull-requests/adding-labels-to-issues.md
@@ -46,14 +46,14 @@ In the tutorial, you will first make a workflow file that uses the {% data varia
         steps:
           - run: gh issue edit "$NUMBER" --add-label "$LABELS"
             env:
-              GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+              GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
               GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
               NUMBER: {% raw %}${{ github.event.issue.number }}{% endraw %}
               LABELS: triage
     ```
 
 1. Customize the `env` values in your workflow file:
-   - The `GITHUB_TOKEN`, `GH_REPO`, and `NUMBER` values are automatically set using the `github` and `secrets` contexts. You do not need to change these.
+   - The `GH_TOKEN`, `GH_REPO`, and `NUMBER` values are automatically set using the `github` and `secrets` contexts. You do not need to change these.
    - Change the value for `LABELS` to the list of labels that you want to add to the issue. The label(s) must exist for your repository. Separate multiple labels with commas. For example, `help wanted,good first issue`. For more information about labels, see "[AUTOTITLE](/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-labels-to-issues-and-pull-requests)."
 1. {% data reusables.actions.commit-workflow %}
 

--- a/content/actions/managing-issues-and-pull-requests/commenting-on-an-issue-when-a-label-is-added.md
+++ b/content/actions/managing-issues-and-pull-requests/commenting-on-an-issue-when-a-label-is-added.md
@@ -45,7 +45,7 @@ In the tutorial, you will first make a workflow file that uses the `gh issue com
           - name: Add comment
             run: gh issue comment "$NUMBER" --body "$BODY"
             env:
-              GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+              GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
               GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
               NUMBER: {% raw %}${{ github.event.issue.number }}{% endraw %}
               BODY: >

--- a/content/actions/managing-issues-and-pull-requests/scheduling-issue-creation.md
+++ b/content/actions/managing-issues-and-pull-requests/scheduling-issue-creation.md
@@ -63,7 +63,7 @@ In the tutorial, you will first make a workflow file that uses the {% data varia
                 gh issue pin "$new_issue_url"
               fi
             env:
-              GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+              GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
               GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
               TITLE: Team sync
               ASSIGNEES: monalisa,doctocat,hubot

--- a/content/actions/using-workflows/triggering-a-workflow.md
+++ b/content/actions/using-workflows/triggering-a-workflow.md
@@ -53,13 +53,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - env:
-          GITHUB_TOKEN: {% raw %}${{ secrets.MY_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.MY_TOKEN }}{% endraw %}
           ISSUE_URL: {% raw %}${{ github.event.issue.html_url }}{% endraw %}
         run: |
           gh issue edit $ISSUE_URL --add-label "triage"
 ```
 
-Conversely, the following workflow uses `GITHUB_TOKEN` to add a label to an issue. It will not trigger any workflows that run when a label is added.
+Conversely, the following workflow uses `GH_TOKEN` to add a label to an issue. It will not trigger any workflows that run when a label is added.
 
 ```yaml
 on:
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - env:
-          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           ISSUE_URL: {% raw %}${{ github.event.issue.html_url }}{% endraw %}
         run: |
           gh issue edit $ISSUE_URL --add-label "triage"
@@ -172,7 +172,7 @@ jobs:
     steps:
       - name: "Comment about changes we can't accept"
         env:
-          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           PR: {% raw %}${{ github.event.pull_request.html_url }}{% endraw %}
         run: |
           gh pr edit $PR --add-label 'invalid'

--- a/content/actions/using-workflows/triggering-a-workflow.md
+++ b/content/actions/using-workflows/triggering-a-workflow.md
@@ -59,7 +59,7 @@ jobs:
           gh issue edit $ISSUE_URL --add-label "triage"
 ```
 
-Conversely, the following workflow uses `GH_TOKEN` to add a label to an issue. It will not trigger any workflows that run when a label is added.
+Conversely, the following workflow uses `GITHUB_TOKEN ` to add a label to an issue. It will not trigger any workflows that run when a label is added.
 
 ```yaml
 on:

--- a/content/actions/using-workflows/using-github-cli-in-workflows.md
+++ b/content/actions/using-workflows/using-github-cli-in-workflows.md
@@ -19,7 +19,7 @@ type: how_to
 
 {% data reusables.cli.cli-learn-more %}
 
-{% data variables.product.prodname_cli %} is preinstalled on all {% data variables.product.prodname_dotcom %}-hosted runners. For each step that uses {% data variables.product.prodname_cli %}, you must set an environment variable called `GITHUB_TOKEN` to a token with the required scopes.
+{% data variables.product.prodname_cli %} is preinstalled on all {% data variables.product.prodname_dotcom %}-hosted runners. For each step that uses {% data variables.product.prodname_cli %}, you must set an environment variable called `GH_TOKEN` to a token with the required scopes.
 
 You can execute any {% data variables.product.prodname_cli %} command. For example, this workflow uses the `gh issue comment` subcommand to add a comment when an issue is opened.
 
@@ -35,7 +35,7 @@ jobs:
     steps:
       - run: gh issue comment $ISSUE --body "Thank you for opening this issue!"
         env:
-          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           ISSUE: {% raw %}${{ github.event.issue.html_url }}{% endraw %}
 ```
 
@@ -64,11 +64,11 @@ jobs:
 
           echo 'NUM_OPEN_ISSUES='$numOpenIssues >> $GITHUB_ENV
         env:
-          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           OWNER: {% raw %}${{ github.repository_owner }}{% endraw %}
           REPO: {% raw %}${{ github.event.repository.name }}{% endraw %}
       - run: |
           gh issue create --title "Issue report" --body "$NUM_OPEN_ISSUES issues remaining" --repo $GITHUB_REPOSITORY
         env:
-          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 ```

--- a/content/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow.md
+++ b/content/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow.md
@@ -56,7 +56,7 @@ jobs:
 
       - name: Use the token
         env:
-          GITHUB_TOKEN: {% raw %}${{ steps.generate_token.outputs.token }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ steps.generate_token.outputs.token }}{% endraw %}
         run: |
           gh api octocat
 ```

--- a/content/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions.md
+++ b/content/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions.md
@@ -222,7 +222,7 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
 
 {% endraw %}
@@ -266,7 +266,7 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
 
 {% endraw %}

--- a/content/contributing/writing-for-github-docs/annotating-code-examples.md
+++ b/content/contributing/writing-for-github-docs/annotating-code-examples.md
@@ -87,7 +87,7 @@ jobs:
     steps:
       - run: gh pr comment $PR_URL --body "Welcome to the repository!"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
 ```
 
@@ -117,6 +117,6 @@ jobs:
         steps:
           - run: gh pr comment $PR_URL --body "Welcome to the repository!"
             env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               PR_URL: ${{ github.event.pull_request.html_url }}
     ```

--- a/content/contributing/writing-for-github-docs/using-markdown-and-liquid-in-github-docs.md
+++ b/content/contributing/writing-for-github-docs/using-markdown-and-liquid-in-github-docs.md
@@ -133,7 +133,7 @@ Code annotations only work in articles with the `layout: inline` frontmatter pro
         steps:
           - run: gh pr comment $PR_URL --body "Welcome to the repository!"
             env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               PR_URL: ${{ github.event.pull_request.html_url }}
     ```
 

--- a/content/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions.md
+++ b/content/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions.md
@@ -30,7 +30,7 @@ You may also want to use the **actions/add-to-project** workflow, which is maint
 
 {% note %}
 
-**Note:** `GITHUB_TOKEN` is scoped to the repository level and cannot access {% data variables.projects.projects_v2 %}. To access {% data variables.projects.projects_v2 %} you can either create a {% data variables.product.prodname_github_app %} (recommended for organization projects) or a {% data variables.product.pat_generic %} (recommended for user projects). Workflow examples for both approaches are shown below.
+**Note:** `GITHUB_TOKEN` is scoped to the repository level and cannot access {% data variables.projects.projects_v2 %}. To access {% data variables.projects.projects_v2 %} you can either create a {% data variables.product.prodname_github_app %} (recommended for organization projects) or a {% data variables.product.pat_generic %} (recommended for user projects). Workflow examples for both approaches are shown below. For steps using GitHub CLI commands, set the `GITHUB_TOKEN` environment variable to `GH_TOKEN`.
 
 {% endnote %}
 
@@ -91,7 +91,7 @@ jobs:
       # Replace `YOUR_PROJECT_NUMBER` with your project number. To find the project number, look at the project URL. For example, `https://github.com/orgs/octo-org/projects/5` has a project number of 5.
       - name: Get project data
         env:
-          GITHUB_TOKEN: {% raw %}${{ steps.generate_token.outputs.token }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ steps.generate_token.outputs.token }}{% endraw %}
           ORGANIZATION: YOUR_ORGANIZATION
           PROJECT_NUMBER: YOUR_PROJECT_NUMBER
         # Uses [{% data variables.product.prodname_cli %}](https://cli.github.com/manual/) to query the API for the ID of the project and return the name and ID of the first 20 fields in the project. `fields` returns a union and the query uses inline fragments (`... on`) to return information about any `ProjectV2Field` and `ProjectV2SingleSelectField` fields. The response is stored in a file called `project_data.json`.
@@ -132,10 +132,10 @@ jobs:
           echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
           echo 'TODO_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="Todo") |.id' project_data.json) >> $GITHUB_ENV
 
-# Sets environment variables for this step. `GITHUB_TOKEN` is the token generated in the first step. `PR_ID` is the ID of the pull request that triggered this workflow.
+# Sets environment variables for this step. `GH_TOKEN` is the token generated in the first step. `PR_ID` is the ID of the pull request that triggered this workflow.
       - name: Add PR to project
         env:
-          GITHUB_TOKEN: {% raw %}${{ steps.generate_token.outputs.token }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ steps.generate_token.outputs.token }}{% endraw %}
           PR_ID: {% raw %}${{ github.event.pull_request.node_id }}{% endraw %}
         # Uses [{% data variables.product.prodname_cli %}](https://cli.github.com/manual/) and the API to add the pull request that triggered this workflow to the project. The `jq` flag parses the response to get the ID of the created item.
         run: |
@@ -155,10 +155,10 @@ jobs:
       - name: Get date
         run: echo "DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
 
-# Sets environment variables for this step. `GITHUB_TOKEN` is the token generated in the first step.
+# Sets environment variables for this step. `GH_TOKEN` is the token generated in the first step.
       - name: Set fields
         env:
-          GITHUB_TOKEN: {% raw %}${{ steps.generate_token.outputs.token }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ steps.generate_token.outputs.token }}{% endraw %}
         # Sets the value of the `Status` field to `Todo`. Sets the value of the `Date posted` field.
         run: |
           gh api graphql -f query='
@@ -223,7 +223,7 @@ jobs:
     # Replace `YOUR_PROJECT_NUMBER` with your project number. To find the project number, look at the project URL. For example, `https://github.com/orgs/octo-org/projects/5` has a project number of 5.
       - name: Get project data
         env:
-          GITHUB_TOKEN: {% raw %}${{ secrets.YOUR_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.YOUR_TOKEN }}{% endraw %}
           ORGANIZATION: YOUR_ORGANIZATION
           PROJECT_NUMBER: YOUR_PROJECT_NUMBER
         # Uses [{% data variables.product.prodname_cli %}](https://cli.github.com/manual/) to query the API for the ID of the project and return the name and ID of the first 20 fields in the project. `fields` returns a union and the query uses inline fragments (`... on`) to return information about any `ProjectV2Field` and `ProjectV2SingleSelectField` fields. The response is stored in a file called `project_data.json`.
@@ -267,7 +267,7 @@ jobs:
 # Sets environment variables for this step. Replace `YOUR_TOKEN` with the name of the secret that contains your {% data variables.product.pat_generic %}.
       - name: Add PR to project
         env:
-          GITHUB_TOKEN: {% raw %}${{ secrets.YOUR_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.YOUR_TOKEN }}{% endraw %}
           PR_ID: {% raw %}${{ github.event.pull_request.node_id }}{% endraw %}
         # Uses [{% data variables.product.prodname_cli %}](https://cli.github.com/manual/) and the API to add the pull request that triggered this workflow to the project. The `jq` flag parses the response to get the ID of the created item.
         run: |
@@ -290,7 +290,7 @@ jobs:
 # Sets environment variables for this step. Replace `YOUR_TOKEN` with the name of the secret that contains your {% data variables.product.pat_generic %}.
       - name: Set fields
         env:
-          GITHUB_TOKEN: {% raw %}${{ secrets.YOUR_TOKEN }}{% endraw %}
+          GH_TOKEN: {% raw %}${{ secrets.YOUR_TOKEN }}{% endraw %}
         # Sets the value of the `Status` field to `Todo`. Sets the value of the `Date posted` field.
         run: |
           gh api graphql -f query='

--- a/content/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions.md
+++ b/content/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions.md
@@ -30,7 +30,7 @@ You may also want to use the **actions/add-to-project** workflow, which is maint
 
 {% note %}
 
-**Note:** `GITHUB_TOKEN` is scoped to the repository level and cannot access {% data variables.projects.projects_v2 %}. To access {% data variables.projects.projects_v2 %} you can either create a {% data variables.product.prodname_github_app %} (recommended for organization projects) or a {% data variables.product.pat_generic %} (recommended for user projects). Workflow examples for both approaches are shown below. For steps using GitHub CLI commands, set the `GITHUB_TOKEN` environment variable to `GH_TOKEN`.
+**Note:** `GITHUB_TOKEN` is scoped to the repository level and cannot access {% data variables.projects.projects_v2 %}. To access {% data variables.projects.projects_v2 %} you can either create a {% data variables.product.prodname_github_app %} (recommended for organization projects) or a {% data variables.product.pat_generic %} (recommended for user projects). Workflow examples for both approaches are shown below.
 
 {% endnote %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #21930 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

As agreed upon in the linked issue, all relevant instances of the `GITHUB_TOKEN` environment variable have been changed to `GH_TOKEN` where the variable is set for a GitHub CLI command. This is in accordance with GitHub CLI's order of precedence for the `GH_TOKEN` and `GITHUB_TOKEN` variables, as well as the error message that appears when the variable is set incorrectly.

Only markdown documents with public content were updated; YAML files were disregarded.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
