### PR TITLE
Fix numeric comparison in Filtering projects

### DIFF
--- a/content/issues/planning-and-tracking-with-projects/customizing-views-in-your-project/filtering-projects.md
+++ b/content/issues/planning-and-tracking-with-projects/customizing-views-in-your-project/filtering-projects.md
@@ -159,7 +159,7 @@ You can use `>`, `>=`, `<`, and `<=` to compare number, date, and iteration fiel
 | <code>field:&gt;<em>VALUE</em></code>  | **priority:&gt;1** will show items with a priority greater than 1.
 | <code>field:&gt;=<em>VALUE</em></code> | **date:&gt;=2022-06-01** will show items with a date of "2022-06-01" or later.
 | <code>field:&lt;<em>VALUE</em></code>  | **iteration:<"Iteration 5"** will show items with an iteration before "Iteration 5."
-| <code>field:&gt;=<em>VALUE</em></code> | **points:&lt;=10** will show items with 10 or less points.
+| <code>field:&lt;=<em>VALUE</em></code> | **points:&lt;=10** will show items with 10 or less points.
 
 You can also use `..` to filter for an inclusive range. When working with a range, `*` can be supplied as a wildcard operator.
 


### PR DESCRIPTION
### Why:

The table looks to incorrectly repeat the `>=` comparison.

Closes: 

https://github.com/github/docs/issues/30783

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fixing the table so that the `>=` qualifier isn't repeated.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
