### PR TITLE
Add section on viewing contributions graph for a specific repository

### DIFF
--- a/content/account-and-profile/setting-up-and-managing-your-github-profile/managing-contribution-settings-on-your-profile/why-are-my-contributions-not-showing-up-on-my-profile.md
+++ b/content/account-and-profile/setting-up-and-managing-your-github-profile/managing-contribution-settings-on-your-profile/why-are-my-contributions-not-showing-up-on-my-profile.md
@@ -45,6 +45,13 @@ In addition, **at least one** of the following must be true:
 - You have opened a pull request or issue in the repository.
 - You have starred the repository.
 
+## Viewing your contributions graph for a specific repository
+
+ - Navigate to the repository’s page on GitHub.
+ - Click on the Insights tab.
+ - In the left sidebar, click on Contributors.
+ - Optionally, you can select a specific time period by clicking and dragging on the graph.
+
 ## Common reasons that contributions are not counted
 
 {% data reusables.pull_requests.pull_request_merges_and_contributions %}


### PR DESCRIPTION
Add a new section to the article that explains how to view users contributions graph for a specific repository. The section includes step-by-step instructions on how to navigate to the repository’s page, where to find the contributions graph, and how to select a specific time period. This information is useful for users who want to see their contributions for a specific repository, rather than their overall contributions

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Adding a section on viewing contributions graph for a specific repository is useful because it provides users with a way to view their contributions for a specific repository, rather than their overall contributions. This can be helpful for users who want to see how active they are in a particular repository, or who want to track their contributions to a specific project. The current problem with viewing contributions graph for a specific repository is that it is not immediately clear how to do so. By adding a section to the article that explains how to view your contributions graph for a specific repository, users will have a clear and concise set of instructions to follow. 
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
