### PR TITLE
Update upgrading-to-the-github-customer-agreement.md

### DIFF
--- a/content/organizations/managing-organization-settings/upgrading-to-the-github-customer-agreement.md
+++ b/content/organizations/managing-organization-settings/upgrading-to-the-github-customer-agreement.md
@@ -28,5 +28,5 @@ You can upgrade to the {% data variables.product.company_short %} Customer Agree
 ## Further reading
 
 - "[AUTOTITLE](/free-pro-team@latest/site-policy/github-terms/github-terms-of-service)"
-- "[AUTOTITLE](https://github.com/customer-terms)."
+- The [GitHub Customer Terms](https://github.com/customer-terms)
 - "[AUTOTITLE](/free-pro-team@latest/site-policy/github-terms/github-corporate-terms-of-service)"

--- a/content/organizations/managing-organization-settings/upgrading-to-the-github-customer-agreement.md
+++ b/content/organizations/managing-organization-settings/upgrading-to-the-github-customer-agreement.md
@@ -27,4 +27,6 @@ You can upgrade to the {% data variables.product.company_short %} Customer Agree
 
 ## Further reading
 
+- "[AUTOTITLE](/free-pro-team@latest/site-policy/github-terms/github-terms-of-service)"
+- "[AUTOTITLE](https://github.com/customer-terms)."
 - "[AUTOTITLE](/free-pro-team@latest/site-policy/github-terms/github-corporate-terms-of-service)"


### PR DESCRIPTION
Add links (in "Further Reading") to "Standard Terms" and "Customer Terms". 

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
They are mentioned in the first paragraph of the text, while only the "Corporate Terms" (deprecated and seemingly not as important here) were linked to.

Someone may want to incorporate the links within the text as well/instead, but I realize that may not be desirable for some reason so did not propose that here.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Just adding two links.

### Check off the following:

- [x ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

(I could not find this "view deployment" feature "in this PR's timeline". I'm submitting this change via the github web UI. Since I'm following the pattern of a line already there, I'm going to ASSUME it would render ok. I confirmed my NEW links worked the same as the existing link whose pattern I used. )

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
