### PR TITLE
Fixing dead/broken links for rest api docs

### DIFF
--- a/content/rest/about-the-rest-api/about-the-rest-api.md
+++ b/content/rest/about-the-rest-api/about-the-rest-api.md
@@ -9,6 +9,8 @@ versions:
   ghae: '*'
 topics:
   - API
+redirect_from:
+  - /rest/overview/about-the-rest-api
 ---
 
 You can use {% data variables.product.company_short %}'s API to build scripts and applications that automate processes, integrate with {% data variables.product.company_short %}, and extend {% data variables.product.company_short %}. For example, you could use the API to triage issues, build an analytics dashboard, or manage releases.

--- a/content/rest/index.md
+++ b/content/rest/index.md
@@ -3,7 +3,7 @@ title: GitHub REST API documentation
 shortTitle: REST API
 intro: 'Create integrations, retrieve data, and automate your workflows with the {% data variables.product.prodname_dotcom %} REST API.'
 introLinks:
-  overview: /rest/overview/about-the-rest-api
+  overview: /rest/about-the-rest-api/about-the-rest-api
   quickstart: /rest/quickstart
 featuredLinks:
   startHere:


### PR DESCRIPTION
Fix dead link: https://docs.github.com/en/rest/overview/about-the-rest-api

Changed to: https://docs.github.com/en/rest/about-the-rest-api/about-the-rest-api

Added redirect for the old broken/dead link as well, just in case if it's referenced elsewhere. 

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #30836 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Before:
![Screenshot 2023-12-27 at 2 13 35 pm](https://github.com/github/docs/assets/88225527/b3c73cca-6e7e-478c-af70-0ea39f3ca7cf)

After:
![Screenshot 2023-12-27 at 2 26 01 pm](https://github.com/github/docs/assets/88225527/0aa676cf-59d5-4197-b42a-d60ed367f296)

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
