### PR TITLE
Update managing-a-merge-queue.md

### DIFF
--- a/content/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue.md
+++ b/content/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue.md
@@ -32,11 +32,11 @@ For more information on merging a pull request using a merge queue, see "[AUTOTI
 
 ### Triggering merge group checks with {% data variables.product.prodname_actions %}
 
-You **must** use the `merge_group` event to trigger your {% data variables.product.prodname_actions %}  workflow when a pull request is added to a merge queue.
+You can use the `push` or `merge_group` event to trigger your {% data variables.product.prodname_actions %}  workflow when a pull request is added to a merge queue. If you have both `push` and `merge_group` listed, the `merge_group` run will be automatically canceled in favor of the `push` run.
 
 {% note %}
 
-**Note:** If your repository uses {% data variables.product.prodname_actions %} to perform required checks on pull requests in your repository, you need to update the workflows to include the `merge_group` event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. The merge will fail as the required status check will not be reported. The `merge_group` event is separate from the `pull_request` and `push` events.
+**Note:** If your repository uses {% data variables.product.prodname_actions %} to perform required checks on pull requests in your repository based on the `pull_request` event, you need to update the workflows to include the `merge_group` event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. The merge will fail as the required status check will not be reported. The `merge_group` event is separate from the `pull_request` event.
 
 {% endnote %}
 
@@ -46,6 +46,13 @@ A workflow that reports a check which is required by the target branch's protect
 on:
   pull_request:
   merge_group:
+```
+
+Or like this:
+
+```yaml
+on:
+  push:
 ```
 
 For more information on the `merge_group` event, see "[AUTOTITLE](/actions/using-workflows/events-that-trigger-workflows#merge_group)."


### PR DESCRIPTION
Clarify when `merge_group` is needed

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The note mentioned both `pull_request` and `push` but seems to be relevant only to `pull_request`.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Clarify the language in Managing a Merge Queue article

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
