### PR TITLE
Exemplify good commit message hygiene

### DIFF
--- a/content/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line.md
+++ b/content/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line.md
@@ -80,7 +80,7 @@ For example, if you and another person both edited the file _styleguide.md_ on t
 1. Commit your changes with a comment.
 
    ```shell
-   git commit -m "Resolved merge conflict by incorporating both suggestions."
+   git commit -m "Resolve merge conflict by incorporating both suggestions"
    ```
 
 You can now merge the branches on the command line or [push your changes to your remote repository](/get-started/using-git/pushing-commits-to-a-remote-repository) on {% data variables.product.product_name %} and [merge your changes](/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request) in a pull request.
@@ -137,7 +137,7 @@ For example, if you edited a file, such as _README.md_, and another person remov
 1. Commit your changes with a comment.
 
    ```shell
-   $ git commit -m "Resolved merge conflict by keeping README.md file."
+   $ git commit -m "Resolve merge conflict by keeping README.md file"
    > [branch-d 6f89e49] Merge branch 'branch-c' into branch-d
    ```
 


### PR DESCRIPTION
Commit messages should be written in the imperative and without terminal punctuation.[1] Follow these practices to set a good example in this documentation.

A search was done for the following regex:

    git.commit.*-m.*\."

Offenders have been corrected.

[1]: https://git.github.io/htmldocs/SubmittingPatches.html

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: n/a

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

(See commit message above.)

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
