### PR TITLE
Incorrect windows syntax & instructions fixed

### DIFF
--- a/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
+++ b/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
@@ -83,7 +83,7 @@ If you are a site administrator for {% data variables.location.product_location 
    {% windows %}
 
    ```powershell
-   > Enter a file in which to save the key (/c/Users/YOU/.ssh/id_ALGORITHM):[Press enter]
+   > Enter a file in which to save the key (/c:\Users\YOU\.ssh\id_ALGORITHM):[Press enter]
    ```
 
    {% endwindows %}
@@ -166,7 +166,7 @@ Before adding a new SSH key to the ssh-agent to manage your keys, you should hav
 
 {% data reusables.desktop.windows_git_bash %}
 
-1. In a new _admin elevated_ terminal window (PowerShell or CMD), ensure the ssh-agent is running. You can use the "Auto-launching the ssh-agent" instructions in "[AUTOTITLE](/articles/working-with-ssh-key-passphrases)", or start it manually:
+1. In a new _admin elevated_ PowerShell window, ensure the ssh-agent is running. You can use the "Auto-launching the ssh-agent" instructions in "[AUTOTITLE](/articles/working-with-ssh-key-passphrases)", or start it manually:
 
    ```powershell
    # start the ssh-agent in the background
@@ -258,7 +258,7 @@ If you are using macOS or Linux, you may need to update your SSH client or insta
    {% windows %}
 
    ```shell
-   > Enter a file in which to save the key (/c/Users/YOU/.ssh/id_{% ifversion ghae %}ecdsa{% else %}ed25519{% endif %}_sk):[Press enter]
+   > Enter a file in which to save the key (/c:\Users\YOU\.ssh\id_{% ifversion ghae %}ecdsa{% else %}ed25519{% endif %}_sk):[Press enter]
    ```
 
    {% endwindows %}

--- a/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
+++ b/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
@@ -83,7 +83,7 @@ If you are a site administrator for {% data variables.location.product_location 
    {% windows %}
 
    ```powershell
-   > Enter a file in which to save the key (/c:\Users\YOU\.ssh\id_ALGORITHM):[Press enter]
+   > Enter a file in which to save the key (c:\Users\YOU\.ssh\id_ALGORITHM):[Press enter]
    ```
 
    {% endwindows %}
@@ -178,7 +178,7 @@ Before adding a new SSH key to the ssh-agent to manage your keys, you should hav
    {% data reusables.ssh.add-ssh-key-to-ssh-agent %}
 
    ```powershell
-   ssh-add /c/Users/YOU/.ssh/id_ed25519
+   ssh-add c:\Users\YOU\.ssh\id_ed25519
    ```
 
 {% data reusables.ssh.add-public-key-to-github %}
@@ -258,7 +258,7 @@ If you are using macOS or Linux, you may need to update your SSH client or insta
    {% windows %}
 
    ```shell
-   > Enter a file in which to save the key (/c:\Users\YOU\.ssh\id_{% ifversion ghae %}ecdsa{% else %}ed25519{% endif %}_sk):[Press enter]
+   > Enter a file in which to save the key (c:\Users\YOU\.ssh\id_{% ifversion ghae %}ecdsa{% else %}ed25519{% endif %}_sk):[Press enter]
    ```
 
    {% endwindows %}


### PR DESCRIPTION
Some of the syntax was incorrect in the instructions regarding the path to your ssh key on windows (/ used instead of \, no : after drive label)

Also corrected an error where the guide suggested to use CMD instead of PowerShell for commands that only work in PowerShell.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: Some of the information regarding SSH connection was incorrect on Windows.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs): Frontslashes changed to backslashes, colon added after drive name, reference to CMD removed in section with PowerShell unique commands.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
