### PR TITLE
python-built-in-queries needs python, not cpp

### DIFF
--- a/content/code-security/code-scanning/managing-your-code-scanning-configuration/python-built-in-queries.md
+++ b/content/code-security/code-scanning/managing-your-code-scanning-configuration/python-built-in-queries.md
@@ -18,4 +18,4 @@ topics:
 
 {% data reusables.code-scanning.codeql-query-tables.codeql-version-info %}
 
-{% data reusables.code-scanning.codeql-query-tables.cpp %}
+{% data reusables.code-scanning.codeql-query-tables.python %}


### PR DESCRIPTION
cpp isn't right for the python page :)

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

This page about Python was including C++ CodeQL queries

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Change `cpp` to `python`

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
