### PR TITLE
managing_the_display_of_members: Fix incorrect heading reference

### DIFF
--- a/content/organizations/managing-organization-settings/managing-the-display-of-member-names-in-your-organization.md
+++ b/content/organizations/managing-organization-settings/managing-the-display-of-member-names-in-your-organization.md
@@ -28,5 +28,5 @@ You may not be able to configure this setting for your organization, if an enter
 {% data reusables.profile.access_org %}
 {% data reusables.profile.org_settings %}
 {% data reusables.organizations.member-privileges %}
-1. Under "Admin repository permissions", select or deselect **Allow members to see comment author's profile name in private repositories**.
+1. Under "Repository Comments", select or deselect **Allow members to see comment author's profile name in private repositories**.
 1. Click **Save**.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
The referenced section was incorrect when compared to the live UI. This update corrects the documentation to follow the actual UI section heading.

Closes:  --skipping due to overhead for a simple name update--

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
The referenced section was incorrect when compared to the live UI. This update corrects the documentation to follow the actual UI section heading.
![image](https://github.com/github/docs/assets/96086763/d4d079b9-debc-4810-9e08-519bbfbf7c3d)

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
