### PR TITLE
Increase readability by using cat EOF

### DIFF
--- a/content/actions/learn-github-actions/expressions.md
+++ b/content/actions/learn-github-actions/expressions.md
@@ -255,7 +255,15 @@ jobs:
     steps:
       - id: set-matrix{% endraw %}
 {%- ifversion actions-save-state-set-output-envs %}
-        run: echo "matrix={\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}" >> $GITHUB_OUTPUT
+        run: |
+          cat <<EOF >> $GITHUB_OUTPUT
+          matrix={
+            "include": [
+              {"project": "foo", "config": "Debug"},
+              {"project": "bar", "config": "Release"}
+            ]
+          }
+          EOF
 {%- else %}
         run: echo "::set-output name=matrix::{\"include\":[{\"project\":\"foo\",\"config\":\"Debug\"},{\"project\":\"bar\",\"config\":\"Release\"}]}"
 {%- endif %}{% raw %}


### PR DESCRIPTION
### Why:

Closes: -

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Previously a nested and highly escaped YAML structure was printed. Now one can follow the structure of what is printed more easily by using `cat <<EOF` syntax. The escaping is gone.

I wonder if `fromJSON` on the other hand works with a multi-line input.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
