### PR TITLE
Update generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md

### DIFF
--- a/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
+++ b/content/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
@@ -74,7 +74,7 @@ If you are a site administrator for {% data variables.location.product_location 
    {% windows %}
 
    ```powershell
-   > Enter a file in which to save the key (c:\Users\YOU\.ssh\id_ALGORITHM):[Press enter]
+   > Enter file in which to save the key (/c/Users/YOU/.ssh/id_ALGORITHM):[Press enter]
    ```
 
    {% endwindows %}
@@ -169,7 +169,7 @@ Before adding a new SSH key to the ssh-agent to manage your keys, you should hav
    {% data reusables.ssh.add-ssh-key-to-ssh-agent %}
 
    ```powershell
-   ssh-add c:\Users\YOU\.ssh\id_ed25519
+   ssh-add c:/Users/YOU/.ssh/id_ed25519
    ```
 
 {% data reusables.ssh.add-public-key-to-github %}


### PR DESCRIPTION
### Why:
Fix some typos regarding what is actually shown in the terminal, and also fix a command which previously didn't work.
"ssh-add c:\Users\YOU\.ssh\id_ed25519" (with backslashes) leads to error "c:UsersYOU.sshid_ed25519: No such file or directory".

### Notes:
I had to run "eval \`ssh-agent -s\`" in bash before being able to run ssh-add [(link)](https://stackoverflow.com/questions/17846529/could-not-open-a-connection-to-your-authentication-agent), should maybe add this to the docs.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
