### PR TITLE
Update repository-roles-for-an-organization.md to move placement of note to be more obvious

### DIFF
--- a/content/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization.md
+++ b/content/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization.md
@@ -155,6 +155,12 @@ Some of the features listed below are limited to organizations using {% data var
 
 In this section, you can find the access required for security features, such as {% data variables.product.prodname_advanced_security %} features.
 
+{%note %}
+
+**Note:** Repository writers and maintainers can only see secret scanning alert information for their own commits.
+
+{% endnote %}
+
 {% rowheaders %}
 
 | Repository action | Read | Triage | Write | Maintain | Admin |
@@ -173,12 +179,6 @@ In this section, you can find the access required for security features, such as
 | [Designate additional people or teams to receive {% data variables.secret-scanning.alerts %}](/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository#granting-access-to-security-alerts) in repositories | {% octicon "x" aria-label="No" %} | {% octicon "x" aria-label="No" %} | {% octicon "x" aria-label="No" %} | {% octicon "x" aria-label="No" %} | {% octicon "check" aria-label="Yes" %} |{% endif %}
 
 {% endrowheaders %}
-
-{%note %}
-
-**Note:** Repository writers and maintainers can only see secret scanning alert information for their own commits.
-
-{% endnote %}
 
 ## Further reading
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The note is easily missed and may cause confusion. If you miss the note, it's not clear whether everyone who as write or maintainer roles can access [View and dismiss secret scanning alerts in a repository](https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/managing-alerts-from-secret-scanning)

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
