### PR TITLE
Update using-github-classroom-with-github-cli.md to reflect default s…

### DIFF
--- a/content/education/manage-coursework-with-github-classroom/teach-with-github-classroom/using-github-classroom-with-github-cli.md
+++ b/content/education/manage-coursework-with-github-classroom/teach-with-github-classroom/using-github-classroom-with-github-cli.md
@@ -104,4 +104,4 @@ gh classroom clone student-repos
 
 Clones student repositories from a given assignment. By default, the student repositories are cloned into the current directory a directory named after the assignment slug. To clone into a different directory, use the `--directory` flag. If the directory does not exists, it will be created.
 
-By default, results are paginated by 30. To get a different number of repositories, use the `--per-page NUMBER` flag.
+By default, all student repositories are cloned. To get a different number of repositories, use the `--per-page NUMBER` flag.


### PR DESCRIPTION
…tudent repo cloning behavior

The statement that only 30 student repositories are cloned under default settings is no longer accurate. 

Example: 
```
PS C:\Users\jblak> gh classroom clone student-repos
? Select a classroom: INEG2223 Spring 2024
? Select an assignment: 2223-SP24-AS02-BasketballPlayer-Inheritance
Creating directory:  C:\Users\jblak\2223-sp24-as02-basketballplayer-inheritance-submissions
......
Cloned 68 repos.
```


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: This is needed because there has been a lot of confusion on the gh-classroom issues page on the behavior for student repository cloning.  (https://github.com/github/gh-classroom). Should also consider including the upgrade command on this page of the documentation, since the old behavior limits clones to 30. 

`gh extension upgrade classroom`

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
