### PR TITLE
fix: add necessary permissions to example workflow

### DIFF
--- a/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
+++ b/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
@@ -343,13 +343,15 @@ This example workflow uses `gh-actions-cache` to delete up to 100 caches created
 ```yaml
 name: cleanup caches by a branch
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Cleanup
         run: |
@@ -369,7 +371,7 @@ jobs:
         env:
           GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           REPO: {% raw %}${{ github.repository }}{% endraw %}
-          BRANCH: refs/pull/{% raw %}${{ github.event.pull_request.number }}{% endraw %}/merge
+          BRANCH: {% raw %}${{ github.ref_name }}{% endraw %} 
 ```
 
 Alternatively, you can use the API to automatically list or delete all caches on your own cadence. For more information, see "[AUTOTITLE](/rest/actions/cache#about-the-cache-in-github-actions)."

--- a/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
+++ b/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
@@ -371,7 +371,7 @@ jobs:
         env:
           GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           REPO: {% raw %}${{ github.repository }}{% endraw %}
-          BRANCH: {% raw %}${{ github.ref_name }}{% endraw %} 
+          BRANCH: {% raw %}${{ github.ref_name }}{% endraw %}
 ```
 
 Alternatively, you can use the API to automatically list or delete all caches on your own cadence. For more information, see "[AUTOTITLE](/rest/actions/cache#about-the-cache-in-github-actions)."

--- a/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
+++ b/content/actions/using-workflows/caching-dependencies-to-speed-up-workflows.md
@@ -371,7 +371,7 @@ jobs:
         env:
           GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           REPO: {% raw %}${{ github.repository }}{% endraw %}
-          BRANCH: {% raw %}${{ github.ref_name }}{% endraw %}
+          BRANCH: {% raw %}${{ github.head_ref }}{% endraw %}
 ```
 
 Alternatively, you can use the API to automatically list or delete all caches on your own cadence. For more information, see "[AUTOTITLE](/rest/actions/cache#about-the-cache-in-github-actions)."


### PR DESCRIPTION
### Why:

Closes #31321

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Uses the diff from https://github.com/github/docs/pull/31322/
but adds explicit permissions as well
which allows it to be tested with
`workflow_dispatch:` if users desire so

Also use `github.ref_name` instead of the pull_request.number to query the branch
I couldn't get the original to work in local tests
but with `ref_name` it works flawlessly.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
