### PR TITLE
Update for gradle/actions@v3.1.0

### DIFF
--- a/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
@@ -65,21 +65,26 @@ We recommend that you have a basic understanding of Java and the Gradle framewor
    jobs:
      build:
        runs-on: ubuntu-latest
-
        steps:
        - uses: {% data reusables.actions.action-checkout %}
-       - name: Set up JDK 11
+       - name: Set up JDK 17
          uses: {% data reusables.actions.action-setup-java %}
          with:
-           java-version: '11'
+           java-version: '17'
            distribution: 'temurin'
+
+       - name: Setup Gradle
+         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
        - name: Build with Gradle
-         uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
-         with:
-           arguments: build
+         run: ./gradlew build
    ```
 
 {%- endif %}
+{% data reusables.actions.gradle-workflow-steps %}
+1. The "Build with Gradle" step executes the `build` task using the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
+
+The [`gradle/actions/setup-gradle`](https://github.com/gradle/actions) action takes care of caching state between workflow runs, and provides a detailed summary of all Gradle executions.
 
 1. Edit the workflow as required. For example, change the Java version.
 
@@ -108,21 +113,21 @@ steps:
     with:
       java-version: '17'
       distribution: 'temurin'
-  - name: Validate Gradle wrapper
-    uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
-  - name: Run the Gradle package task
-    uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-    with:
-      arguments: -b ci.gradle package
+
+  - name: Setup Gradle
+    uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
+  - name: Build with Gradle
+    run: ./gradlew -b ci.gradle package
 ```
 
 {% ifversion actions-caching %}
 
 ## Caching dependencies
 
-Your build dependencies can be cached to speed up your workflow runs. After a successful run, the `gradle/gradle-build-action` caches important parts of the Gradle user home directory. In future jobs, the cache will be restored so that build scripts won't need to be recompiled and dependencies won't need to be downloaded from remote package repositories.
+Your build dependencies can be cached to speed up your workflow runs. After a successful run, `gradle/actions/setup-gradle` caches important parts of the Gradle user home directory. In future jobs, the cache will be restored so that build scripts won't need to be recompiled and dependencies won't need to be downloaded from remote package repositories.
 
-Caching is enabled by default when using the `gradle/gradle-build-action` action. For more information, see [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action#caching).
+Caching is enabled by default when using the `gradle/actions/setup-gradle` action. For more information, see [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/setup-gradle/README.md#caching-build-state-between-jobs).
 
 {% endif %}
 
@@ -139,13 +144,15 @@ steps:
     with:
       java-version: '17'
       distribution: 'temurin'
-  - name: Validate Gradle wrapper
-    uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+
+  - name: Setup Gradle
+    uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
   - name: Build with Gradle
-    uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-    with:
-      arguments: build
-  - uses: {% data reusables.actions.action-upload-artifact %}
+    run: ./gradlew build
+
+  - name: Upload build artifacts
+    uses: {% data reusables.actions.action-upload-artifact %}
     with:
       name: Package
       path: build/libs

--- a/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
@@ -84,7 +84,6 @@ We recommend that you have a basic understanding of Java and the Gradle framewor
 {% data reusables.actions.gradle-workflow-steps %}
 1. The "Build with Gradle" step executes the `build` task using the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
 
-The [`gradle/actions/setup-gradle`](https://github.com/gradle/actions) action takes care of caching state between workflow runs, and provides a detailed summary of all Gradle executions.
 
 1. Edit the workflow as required. For example, change the Java version.
 

--- a/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-java-with-gradle.md
@@ -84,7 +84,6 @@ We recommend that you have a basic understanding of Java and the Gradle framewor
 {% data reusables.actions.gradle-workflow-steps %}
 1. The "Build with Gradle" step executes the `build` task using the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
 
-
 1. Edit the workflow as required. For example, change the Java version.
 
    {% indented_data_reference reusables.actions.third-party-actions spaces=3 %}

--- a/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
+++ b/content/actions/publishing-packages/publishing-java-packages-with-gradle.md
@@ -96,19 +96,19 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish
+        run: ./gradlew publish
         env:
           MAVEN_USERNAME: {% raw %}${{ secrets.OSSRH_USERNAME }}{% endraw %}
           MAVEN_PASSWORD: {% raw %}${{ secrets.OSSRH_TOKEN }}{% endraw %}
 ```
 
 {% data reusables.actions.gradle-workflow-steps %}
-1. Runs the [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action) action with the `publish` argument to publish to the `OSSRH` Maven repository. The `MAVEN_USERNAME` environment variable will be set with the contents of your `OSSRH_USERNAME` secret, and the `MAVEN_PASSWORD` environment variable will be set with the contents of your `OSSRH_TOKEN` secret.
+1. Executes the Gradle `publish` task to publish to the `OSSRH` Maven repository. The `MAVEN_USERNAME` environment variable will be set with the contents of your `OSSRH_USERNAME` secret, and the `MAVEN_PASSWORD` environment variable will be set with the contents of your `OSSRH_TOKEN` secret.
 
    For more information about using secrets in your workflow, see "[AUTOTITLE](/actions/security-guides/using-secrets-in-github-actions)."
 
@@ -172,18 +172,17 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish
+        run: ./gradlew publish
         env:
           GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 ```
 
 {% data reusables.actions.gradle-workflow-steps %}
-1. Runs the [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action) action with the `publish` argument to publish to {% data variables.product.prodname_registry %}. The `GITHUB_TOKEN` environment variable will be set with the content of the `GITHUB_TOKEN` secret. The `permissions` key specifies the access that the `GITHUB_TOKEN` secret will allow.
+1. Executes the Gradle `publish` task to publish to {% data variables.product.prodname_registry %}. The `GITHUB_TOKEN` environment variable will be set with the content of the `GITHUB_TOKEN` secret. The `permissions` key specifies the access that the `GITHUB_TOKEN` secret will allow.
 
    For more information about using secrets in your workflow, see "[AUTOTITLE](/actions/security-guides/using-secrets-in-github-actions)."
 
@@ -256,12 +255,11 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
       - name: Publish package
-        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
-        with:
-          arguments: publish
+        run: ./gradlew publish
         env: {% raw %}
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
@@ -269,6 +267,6 @@ jobs:
 ```
 
 {% data reusables.actions.gradle-workflow-steps %}
-1. Runs the [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action) action with the `publish` argument to publish to the `OSSRH` Maven repository and {% data variables.product.prodname_registry %}. The `MAVEN_USERNAME` environment variable will be set with the contents of your `OSSRH_USERNAME` secret, and the `MAVEN_PASSWORD` environment variable will be set with the contents of your `OSSRH_TOKEN` secret. The `GITHUB_TOKEN` environment variable will be set with the content of the `GITHUB_TOKEN` secret. The `permissions` key specifies the access that the `GITHUB_TOKEN` secret will allow.
+1. Executes the Gradle `publish` task to publish to the `OSSRH` Maven repository and {% data variables.product.prodname_registry %}. The `MAVEN_USERNAME` environment variable will be set with the contents of your `OSSRH_USERNAME` secret, and the `MAVEN_PASSWORD` environment variable will be set with the contents of your `OSSRH_TOKEN` secret. The `GITHUB_TOKEN` environment variable will be set with the content of the `GITHUB_TOKEN` secret. The `permissions` key specifies the access that the `GITHUB_TOKEN` secret will allow.
 
    For more information about using secrets in your workflow, see "[AUTOTITLE](/actions/security-guides/using-secrets-in-github-actions)."

--- a/data/reusables/actions/gradle-workflow-steps.md
+++ b/data/reusables/actions/gradle-workflow-steps.md
@@ -2,4 +2,4 @@ This workflow performs the following steps:
 
 1. Checks out a copy of project's repository.
 1. Sets up the Java JDK.
-1. Sets up the Gradle environment.
+1. Sets up the Gradle environment. The [`gradle/actions/setup-gradle`](https://github.com/gradle/actions) action takes care of caching state between workflow runs, and provides a detailed summary of all Gradle executions.

--- a/data/reusables/actions/gradle-workflow-steps.md
+++ b/data/reusables/actions/gradle-workflow-steps.md
@@ -2,4 +2,4 @@ This workflow performs the following steps:
 
 1. Checks out a copy of project's repository.
 1. Sets up the Java JDK.
-1. Validates the checksums of any Gradle Wrapper JAR files present in the repository.
+1. Sets up the Gradle environment.


### PR DESCRIPTION


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: updates documentation for recent release of `gradle/actions/setup-gradle`

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

- Switches from using `gradle/gradle-build-action` to `gradle/actions/setup-gradle`. The latter is a replacement for the former, and `gradle-build-action` will be deprecated.
- Update with latest content from `gradle.yml` starter workflow. The docs reference this starter workflow, but the content has diverged.
- Remove use of `wrapper-validation-action`, as this will be rolled into the `setup-gradle` action. This makes the examples simpler.
- Bump version hashes for the latest action release.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
