### PR TITLE
Consistent style-guide.md repository link styling

### DIFF
--- a/content/contributing/style-guide-and-content-model/style-guide.md
+++ b/content/contributing/style-guide-and-content-model/style-guide.md
@@ -579,7 +579,7 @@ For more information, follow the "[LEARNING PATH TITLE](/)" learning path.
 
 ### Links to external resources
 
-When linking to an external site, choose the most useful resource for the context of the link - you can link to a whole site if it's a general reference or to a specific page if that would be more helpful.
+When linking to an external site, choose the most useful resource for the context of the link—you can link to a whole site if it's a general reference or to a specific page if that would be more helpful.
 
 It's not necessary to link to an external product’s website when we mention an external product.
 

--- a/content/contributing/style-guide-and-content-model/style-guide.md
+++ b/content/contributing/style-guide-and-content-model/style-guide.md
@@ -655,7 +655,7 @@ Examples:
 
 Use full product names. Do not abbreviate or shorten product names unless directly reproducing content from the product (e.g. UI copy or API responses). Product names are never possessive.
 
-Use product name variables to render product names - do not write product names in plain text. This makes product name changes easier to implement across the site and avoids typos in our product names. For more information about product name variables, see “[Reusables and variables](#reusables-and-variables)” in this document and the data directory of the [`github/docs`](https://github.com/github/docs) repository.
+Use product name variables to render product names - do not write product names in plain text. This makes product name changes easier to implement across the site and avoids typos in our product names. For more information about product name variables, see “[Reusables and variables](#reusables-and-variables)” in this document and the [data directory](https://github.com/github/docs/tree/main/data) of the [`github/docs`](https://github.com/github/docs) repository.
 
 Product names are always singular.
 - **Use:** {% data variables.product.prodname_actions %} helps you automate your software development workflows.

--- a/content/contributing/style-guide-and-content-model/style-guide.md
+++ b/content/contributing/style-guide-and-content-model/style-guide.md
@@ -87,7 +87,7 @@ Style your CTAs using the following format.
 Keep lines in code samples to about 60 characters, to avoid requiring readers to scroll horizontally in the code block. Locate explanatory text before the code block, rather than using comments inside the code block. See "[AUTOTITLE](/contributing/syntax-and-versioning-for-github-docs/using-markdown-and-liquid-in-github-docs#code-sample-syntax-highlighting)" for more information on the syntax and formatting of code blocks.
 
 Within code blocks:
-- Specify the language of the sample after the first code fence. For a list of all supported languages, see "[Code languages](https://github.com/github/docs/blob/main/data/code-languages.yml)" in the `github/docs` repository.
+- Specify the language of the sample after the first code fence. For a list of all supported languages, see "[Code languages](https://github.com/github/docs/blob/main/data/code-languages.yml)" in the [`github/docs`](https://github.com/github/docs) repository.
 - Do not use HTML to style or markup a code block.
 - Style any placeholders that people need to replace with their own values in all caps.
   - **Use:** `git checkout -b BRANCH-NAME`
@@ -655,7 +655,7 @@ Examples:
 
 Use full product names. Do not abbreviate or shorten product names unless directly reproducing content from the product (e.g. UI copy or API responses). Product names are never possessive.
 
-Use product name variables to render product names - do not write product names in plain text. This makes product name changes easier to implement across the site and avoids typos in our product names. For more information about product name variables, see “[Reusables and variables](#reusables-and-variables)” in this document and the data directory of the github/docs repository.
+Use product name variables to render product names - do not write product names in plain text. This makes product name changes easier to implement across the site and avoids typos in our product names. For more information about product name variables, see “[Reusables and variables](#reusables-and-variables)” in this document and the data directory of the [`github/docs`](https://github.com/github/docs) repository.
 
 Product names are always singular.
 - **Use:** {% data variables.product.prodname_actions %} helps you automate your software development workflows.
@@ -999,7 +999,7 @@ To signal to readers that you've added or changed a note, or to indicate the pub
 
 ## Reusables and variables
 
-Use reusable strings for individual nouns (e.g. product names) or for complete sentences or paragraphs. Sentence fragments and phrases should not be contained in reusable strings as they can cause problems when content is localized. For more information, see the [data directory](https://github.com/github/docs/tree/main/data) in the github/docs repository, "[Creating reusable content](/contributing/writing-for-github-docs/creating-reusable-content)", and the “[Product names](#product-names)” section of this document.
+Use reusable strings for individual nouns (e.g. product names) or for complete sentences or paragraphs. Sentence fragments and phrases should not be contained in reusable strings as they can cause problems when content is localized. For more information, see the [data directory](https://github.com/github/docs/tree/main/data) in the [`github/docs`](https://github.com/github/docs) repository, "[Creating reusable content](/contributing/writing-for-github-docs/creating-reusable-content)", and the “[Product names](#product-names)” section of this document.
 
 ## Sectional TOCs
 

--- a/content/contributing/style-guide-and-content-model/style-guide.md
+++ b/content/contributing/style-guide-and-content-model/style-guide.md
@@ -655,7 +655,7 @@ Examples:
 
 Use full product names. Do not abbreviate or shorten product names unless directly reproducing content from the product (e.g. UI copy or API responses). Product names are never possessive.
 
-Use product name variables to render product names - do not write product names in plain text. This makes product name changes easier to implement across the site and avoids typos in our product names. For more information about product name variables, see “[Reusables and variables](#reusables-and-variables)” in this document and the [data directory](https://github.com/github/docs/tree/main/data) of the [`github/docs`](https://github.com/github/docs) repository.
+Use product name variables to render product names—do not write product names in plain text. This makes product name changes easier to implement across the site and avoids typos in our product names. For more information about product name variables, see “[Reusables and variables](#reusables-and-variables)” in this document and the [data directory](https://github.com/github/docs/tree/main/data) of the [`github/docs`](https://github.com/github/docs) repository.
 
 Product names are always singular.
 - **Use:** {% data variables.product.prodname_actions %} helps you automate your software development workflows.


### PR DESCRIPTION
Repository names have set style https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide#repository-names yet the page itself doesn't follow it. This makes all occurrences consistent. 

### Why:

So that "Style guide" page actually matches the style guide;)

### What's being changed (if available, include any code snippets, screenshots, or gifs):

before:

> ![Screen Shot 2024-02-16 at 18 45 18](https://github.com/github/docs/assets/1784648/a0d1e984-2155-4c12-95e9-867a02bccd23)

after:

> ![Screen Shot 2024-02-16 at 18 54 18](https://github.com/github/docs/assets/1784648/e15069db-b67e-409c-ab78-f8d3b27a8759)

https://docs-31680-6a03af.preview.ghdocs.com/en/contributing/style-guide-and-content-model/style-guide#product-names

& "data directory" repo link
& correct hyphen in product name reusable definition and external linking

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
