### PR TITLE
docs(notifications) add approval_requested reason type

### DIFF
--- a/content/rest/activity/notifications.md
+++ b/content/rest/activity/notifications.md
@@ -48,6 +48,7 @@ There are a few potential `reason`s for receiving a notification.
 
 Reason Name | Description
 ------------|------------
+`approval_requested` | You were requested to review and approve a deployment.
 `assign` | You were assigned to the issue.
 `author` | You created the thread.
 `comment` | You commented on the thread.

--- a/content/rest/activity/notifications.md
+++ b/content/rest/activity/notifications.md
@@ -48,7 +48,7 @@ There are a few potential `reason`s for receiving a notification.
 
 Reason Name | Description
 ------------|------------
-`approval_requested` | You were requested to review and approve a deployment.
+`approval_requested` | You were requested to review and approve a deployment. For more information, see "[AUTOTITLE](/actions/managing-workflow-runs/reviewing-deployments)."
 `assign` | You were assigned to the issue.
 `author` | You created the thread.
 `comment` | You commented on the thread.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: https://github.com/github/docs/issues/31691

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Document the `approval_requested` notification reason type.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
