### PR TITLE
Fix style-guide.md pat_v1 vs. pat_v2 product name render

### DIFF
--- a/content/contributing/style-guide-and-content-model/style-guide.md
+++ b/content/contributing/style-guide-and-content-model/style-guide.md
@@ -213,7 +213,7 @@ Workflow runs are delayed when too many workflows run at once. Since many users 
 
 Use italics to emphasize words or parts of a sentence. Use emphasis sparingly for terminology or context that someone must be aware of to successfully complete the task that they're working on. Do not use italics to emphasize words that have other formatting applied such as all caps for placeholder text or bold for UI elements.
 
-- **Use:** _{% data variables.product.pat_v2 %}s_ have several security advantages over {% data variables.product.pat_v1_plural %} (classic).
+- **Use:** _{% data variables.product.pat_v2 %}s_ have several security advantages over {% data variables.product.pat_v1_plural %}.
 - **Use:** _For types of packages other than containers_, to the right of the package version click **Delete**.
 - **Avoid:** Next to _**Title**_, add a descriptive label for your new key.
 


### PR DESCRIPTION
Duplicate "(classic)" manually added after the product name variable removed.

### Why:

The product name _(now(?))_ already contains "(classic)"; can be removed from text.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

before:

> ![Screen Shot 2024-02-16 at 19 19 12](https://github.com/github/docs/assets/1784648/c22f03d6-c246-46a7-b764-c58677195985)

after:

> ![Screen Shot 2024-02-16 at 19 54 28](https://github.com/github/docs/assets/1784648/7dd39b7d-33c7-461a-a3d9-820edd35e53d)


https://docs-31682-9bff74.preview.ghdocs.com/en/contributing/style-guide-and-content-model/style-guide#emphasis


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
