### PR TITLE
Add missing example octicon

### DIFF
--- a/content/contributing/style-guide-and-content-model/style-guide.md
+++ b/content/contributing/style-guide-and-content-model/style-guide.md
@@ -649,7 +649,7 @@ Examples:
 - Under your organization name, click **Settings**.
 - To confirm your change, click **Remove credit card**.
 - Optionally, to see your plan’s details, click **Show details**.
-- Under "{% data variables.product.prodname_sponsors %}", to the right of the sponsored open source contributor, click [down arrow octicon] next to your sponsored amount, then click **Change tier**.
+- Under "{% data variables.product.prodname_sponsors %}", to the right of the sponsored open source contributor, click {% octicon "triangle-down" aria-label="More options" %} next to your sponsored amount, then click **Change tier**.
 
 ## Product names
 


### PR DESCRIPTION
Adds missing octicon markup in Style guide example.

### Why:

When moving around contributing docs, this was probably forgotten as a placeholder and never resolved:

> Under "GitHub Sponsors", to the right of the sponsored open source contributor, click [down arrow octicon] next to your sponsored amount, then click Change tier.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

updated to:

> ![Screen Shot 2024-02-16 at 21 14 50](https://github.com/github/docs/assets/1784648/cda28c11-9463-4995-aaca-2b1c6b064e6b)

https://docs-31688-1c0047.preview.ghdocs.com/en/contributing/style-guide-and-content-model/style-guide#procedural-steps

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
