### PR TITLE
Fix style-guide.md endraw rendering

### DIFF
--- a/content/contributing/style-guide-and-content-model/style-guide.md
+++ b/content/contributing/style-guide-and-content-model/style-guide.md
@@ -710,7 +710,7 @@ Code examples that use third-party actions must include the following disclaimer
 # documentation.
 ```
 
-To insert this disclaimer, use the `{% raw %}{% data reusables.actions.actions-not-certified-by-github-comment %}{% endnote %}` reusable.
+To insert this disclaimer, use the `{% raw %}{% data reusables.actions.actions-not-certified-by-github-comment %}{% endnote %}{% endraw %}` reusable.
 
 For {% data variables.product.prodname_docs %} purposes, a third-party action is any action that doesn't have the `actions/`, `github/` or `octo-org/` prefix. For example, this is a first-party action:
 


### PR DESCRIPTION
Properly closing raw/endraw to render following variables again

### Why:

Example reusables and product names after https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide#disclaimers-for-third-party-actions don't render. The culprit being missing endraw above them.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

before/after:

> ![Screen Shot 2024-02-16 at 21 36 53](https://github.com/github/docs/assets/1784648/e5672858-575e-4363-825f-d1fba8462de2)

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
