### PR TITLE
Fix pypi-publish@release version

### DIFF
--- a/content/actions/automating-builds-and-tests/building-and-testing-python.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-python.md
@@ -425,7 +425,7 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: {% raw %}${{ secrets.PYPI_API_TOKEN }}{% endraw %}
 ```


### PR DESCRIPTION
Fixes #31824

### Why:

Example action linking invalid release/tag.

Closes: #31824

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Changing `@v1` to `@release/v1` as used elsewhere in the docs.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
