### PR TITLE
Fix doc for opening a new tab

### DIFF
--- a/content/copilot/using-github-copilot/getting-started-with-github-copilot.md
+++ b/content/copilot/using-github-copilot/getting-started-with-github-copilot.md
@@ -139,7 +139,7 @@ You may not want to accept an entire suggestion from {% data variables.product.p
    {% indented_data_reference reusables.copilot.java-int-snippet spaces=3 %}
 1. Open a new tab with multiple additional suggestions.
 
-   - On macOS, press <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>A</kbd>, then click **Open GitHub Copilot**, or press <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>\</kbd> to open the new tab immediately.
+   - On macOS, press <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>A</kbd>, then click **Open GitHub Copilot**, or press <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>\\</kbd> to open the new tab immediately.
    - On Windows or Linux, press <kbd>Ctrl</kbd>+<kbd>Enter</kbd>, then click **Open GitHub Copilot**.
 
 1. To accept a suggestion, above the suggestion, click **Accept Solution**. To reject all suggestions, close the tab.


### PR DESCRIPTION
### Why:

Markdown renders incorrectly because a HTML tag is proceeded by a backslash character.

Closes: 

None that I know of.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The backslash is intended to be a literal character, not an escape sequence. I added a second backslash to correctly escape it so that it renders as a backslash character in the markdown.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
