### PR TITLE
Clarify that MITRE != The CVE Program

### DIFF
--- a/content/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database.md
+++ b/content/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database.md
@@ -116,4 +116,4 @@ The {% data variables.product.prodname_advisory_database %} uses the CVSS levels
 ## Further reading
 
 - "[AUTOTITLE](/code-security/dependabot/dependabot-alerts/about-dependabot-alerts)"
-- MITRE's [definition of "vulnerability"](https://www.cve.org/ResourcesSupport/Glossary#vulnerability)
+- The CVE Program's [definition of "vulnerability"](https://www.cve.org/ResourcesSupport/Glossary#vulnerability)


### PR DESCRIPTION
MITRE is many things, but it is not the CVE Program, so don't propagate that misconception here.

### Why:

MITRE is the CVE Program Secretariat, one of the two CNA Top Level Roots, and the CNA of Last Resort under one of the two CNA Top Level Roots, but it is _not_ the unilaterally the CVE Program. See https://www.cve.org/ProgramOrganization/Structure

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).