### PR TITLE
Fix `job_workflow_ref` format

### DIFF
--- a/content/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect.md
+++ b/content/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect.md
@@ -85,7 +85,7 @@ The following example OIDC token uses a subject (`sub`) that references a job en
   "enterprise": "avocado-corp",{% endif %}{% ifversion actions-OIDC-enterprise_id-claim %}
   "enterprise_id": "2",{% endif %}
   "ref_type": "branch",
-  "job_workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@refs/heads/main",
+  "job_workflow_ref": "octo-org/octo-automation/.github/workflows/oidc.yml@main",
   "iss": "{% ifversion ghes %}https://HOSTNAME/_services/token{% else %}https://token.actions.githubusercontent.com{% endif %}",
   "nbf": 1632492967,
   "exp": 1632493867,


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

In `job_workflow_ref` field, `refs/heads` are usually omitted.

I tried Workload Identity and attribute condition by following the document, but I couldn't pass condition and got `The given credential is rejected by the attribute condition.` error message.
I checked the detailed value for OIDC claim with [actions-oidc-debugger](https://github.com/github/actions-oidc-debugger) and found `refs/heads` were usually omitted in `job_workflow_ref` field.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This PR just change the document a little.
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
