### PR TITLE
python: update PyPI publishing example

### DIFF
--- a/content/actions/automating-builds-and-tests/building-and-testing-python.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-python.md
@@ -398,7 +398,6 @@ You can configure your workflow to publish your Python package to PyPI once your
 
 The example workflow below uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) to authenticate with PyPI, eliminating the need for a manually configured API token.
 
-
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
 

--- a/content/actions/automating-builds-and-tests/building-and-testing-python.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-python.md
@@ -451,4 +451,4 @@ jobs:
 ```
 
 For more information about this workflow, including the PyPI settings
-needed, see [AUTOTITLE](/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi.md).
+needed, see [AUTOTITLE](/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi).

--- a/content/actions/automating-builds-and-tests/building-and-testing-python.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-python.md
@@ -420,13 +420,13 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: build release distributions
+      - name: Build release distributions
         run: |
           # NOTE: put your own distribution build steps here.
           python -m pip install build
           python -m build
 
-      - name: upload windows dists
+      - name: Upload distributions
         uses: {% data reusables.actions.action-upload-artifact %}
         with:
           name: release-dists

--- a/content/actions/automating-builds-and-tests/building-and-testing-python.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-python.md
@@ -409,6 +409,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release-build:
     runs-on: ubuntu-latest
@@ -434,10 +437,20 @@ jobs:
 
   pypi-publish:
     runs-on: ubuntu-latest
+
     needs:
       - release-build
+
     permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
 
     steps:
       - name: Retrieve release distributions


### PR DESCRIPTION
### Why:

This updates the "Building and testing Python" guide to reflect the steps already documented in "Configuring OpenID Connect in PyPI", i.e. using Trusted Publishing to publish to PyPI rather than a manually configured API token.

(I don't have a linked issue for this, sorry! -- this was discussed in an email thread with @jhutchings1)

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I've changed the example PyPI publishing workflow to use Trusted Publishing instead of a manually configured secret. I've also tweaked the surrounding paragraphs slightly to include a link to the other GH docs page that references Trusted Publishing via OIDC, as well as to PyPI's own official docs for the feature.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
