### PR TITLE
Remove beta tag from publishing pages with a custom workflow

### DIFF
--- a/content/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site.md
+++ b/content/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site.md
@@ -64,8 +64,6 @@ To find potential errors with either the build or deployment, you can check the 
 
 ## Publishing with a custom {% data variables.product.prodname_actions %} workflow
 
-{% data reusables.pages.pages-custom-workflow-beta %}
-
 To configure your site to publish with {% data variables.product.prodname_actions %}:
 
 {% data reusables.pages.navigate-site-repo %}

--- a/data/reusables/pages/pages-custom-workflow-beta.md
+++ b/data/reusables/pages/pages-custom-workflow-beta.md
@@ -1,9 +1,0 @@
-{% ifversion pages-custom-workflow %}
-
-{% note %}
-
-**Note:** Publishing your {% data variables.product.prodname_pages %} site with a custom {% data variables.product.prodname_actions %} workflow is in beta and subject to change.
-
-{% endnote %}
-
-{% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The button in settings for this feature is no longer marked as beta.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Note being removed:

![image](https://github.com/github/docs/assets/921089/de06c948-e131-4043-a48b-45fba6cf5dcb)


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
