### PR TITLE
Fixed PowerShell Copilot alias creation script

### DIFF
--- a/content/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli.md
+++ b/content/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli.md
@@ -100,7 +100,7 @@ Add the following to your PowerShell profile:
 ```shell copy
 $GH_COPILOT_PROFILE = Join-Path -Path $(Split-Path -Path $PROFILE -Parent) -ChildPath "gh-copilot.ps1"
 gh copilot alias -- pwsh | Out-File ( New-Item -Path $GH_COPILOT_PROFILE -Force )
-echo ". $GH_COPILOT_PROFILE" >> $PROFILE
+. $GH_COPILOT_PROFILE
 ```
 
 **Zsh**


### PR DESCRIPTION
### Why:

The previous version of the GitHub Copilot alias setup guide for PowerShell was creating a new line in the PowerShell profile after each run.

Closes: 

https://github.com/github/docs/issues/32187

### What's being changed (if available, include any code snippets, screenshots, or gifs):

#### Old:

```pwsh
echo ". $GH_COPILOT_PROFILE" >> $PROFILE
```

#### New:

```pwsh
. $GH_COPILOT_PROFILE
```

As this line is already in the profile, this will have the same effect. I am convinced this was written by AI and not checked.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

- [x] For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.

- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
