### PR TITLE
Fix JSON "repository" object key to "repo" to match actual API call results.

### DIFF
--- a/content/rest/using-the-rest-api/github-event-types.md
+++ b/content/rest/using-the-rest-api/github-event-types.md
@@ -36,10 +36,10 @@ The event objects returned from the Events API endpoints have the same structure
 | `actor.gravatar_id` | `string` | The unique identifier of the Gravatar profile for the actor. |
 | `actor.url` | `string` | The REST API URL used to retrieve the user object, which includes additional user information. |
 | `actor.avatar_url` | `string` | The URL of the actor's profile image. |
-| `repository` | `object` | The repository object where the event occurred.  |
-| `repository.id` | `string` | The unique identifier of the repository. |
-| `repository.name` | `string` | The name of the repository, which includes the owner and repository name. For example, `octocat/hello-world` is the name of the `hello-world` repository owned by the `octocat` personal account. |
-| `repository.url` | `string` | The REST API URL used to retrieve the repository object, which includes additional repository information. |
+| `repo` | `object` | The repository object where the event occurred.  |
+| `repo.id` | `string` | The unique identifier of the repository. |
+| `repo.name` | `string` | The name of the repository, which includes the owner and repository name. For example, `octocat/hello-world` is the name of the `hello-world` repository owned by the `octocat` personal account. |
+| `repo.url` | `string` | The REST API URL used to retrieve the repository object, which includes additional repository information. |
 | `payload` | `object` | The event payload object is unique to the event type. See the event type below for the event API `payload` object. |
 | `public` | `boolean` | Whether the event is visible to all users. |
 | `created_at` | `string` | The date and time when the event was triggered. It is formatted according to ISO 8601. |
@@ -67,7 +67,7 @@ Link: <https://api.github.com/resource?page=2>; rel="next",
     "public": false,
     "payload": {
     },
-    "repository": {
+    "repo": {
       "id": 3,
       "name": "octocat/Hello-World",
       "url": "https://api.github.com/repos/octocat/Hello-World"


### PR DESCRIPTION
Actual API calls are returning repository information under "repo" as the JSON object key in the event, not under "repository" as documented.

### Why: Current documentation is incorrect.

Closes: #32230

### What's being changed (if available, include any code snippets, screenshots, or gifs): Changing `repository` to `repo` to match actual API results.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
