### PR TITLE
Update MIT License year from 2023 -> 2024

### DIFF
--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2023 GitHub
+Copyright 2024 GitHub
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Year in MIT License is outdated.

Closes: 
N/A

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Year is updated; 2023 -> 2024.

### Check off the following:

- [X ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).

Thank you @yusufsheiqh #25557
