### PR TITLE
#32221: Updating language around the 'Codespaces Network Bridge' exte…

### DIFF
--- a/content/codespaces/developing-in-a-codespace/connecting-to-a-private-network.md
+++ b/content/codespaces/developing-in-a-codespace/connecting-to-a-private-network.md
@@ -25,11 +25,11 @@ There are currently two methods of accessing resources on a private network with
 
 ### Using the GitHub CLI extension to access remote resources
 
-{% note %}
+{% warning %}
 
-**Note**: The {% data variables.product.prodname_cli %} extension is currently in beta and subject to change.
+**Warning**: The {% data variables.product.prodname_cli %} extension is deprecated and no longer supported.
 
-{% endnote %}
+{% endwarning %}
 
 The {% data variables.product.prodname_cli %} extension allows you to create a bridge between a codespace and your local machine, so that the codespace can access any remote resource that is accessible from your machine. The codespace uses your local machine as a network gateway to reach those resources. For more information, see "[Using {% data variables.product.prodname_cli %} to access remote resources](https://github.com/github/gh-net#codespaces-network-bridge)."
 


### PR DESCRIPTION
…nsion to note that it is deprecated

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #32221 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updating Codespaces private network documentation to note that the GH CLI extension used to create a local network bridge is no longer supported.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
