### PR TITLE
Update to remove smimesign from Linux instructions

### DIFF
--- a/content/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key.md
+++ b/content/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key.md
@@ -120,7 +120,17 @@ You can use an existing SSH key to sign commits and tags, or generate a new one 
 
 {% endif %}
 
+{% windows %}
+
 {% data reusables.gpg.x-509-key %}
+
+{% endwindows %}
+
+{% mac %}
+
+{% data reusables.gpg.x-509-key %}
+
+{% endmac %}
 
 ## Further reading
 


### PR DESCRIPTION
### Why:
#31465 was rejected because it added docs for gpgsm (X509 signing that works on Linux) - this at least clears up the fact smimesign does not work on Linux.

Closes: 
https://github.com/github/smimesign/issues/45
Related to:
https://github.com/github/smimesign/issues/30

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Remove smimesign from Linux docs

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
