### PR TITLE
Added instruction for ignoring the Gemfile.lock file to prevent unsatisfiable dependencies warning in the creating-a-github-pages-site-with-jekyll page

### DIFF
--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
@@ -102,6 +102,13 @@ Before you can use Jekyll to create a {% data variables.product.prodname_pages %
    The correct version Jekyll will be installed as a dependency of the `github-pages` gem.
 1. Save and close the Gemfile.
 1. From the command line, run `bundle install`.
+1. Open the `.gitignore` file that Jekyll created.
+1. Ignore the gems lock file by adding this line:
+
+   ```gitignore
+   Gemfile.lock
+   ```
+
 1. Optionally, make any necessary edits to the `_config.yml` file. This is required for relative paths when the repository is hosted in a subdirectory.  For more information, see "[AUTOTITLE](/get-started/using-git/splitting-a-subfolder-out-into-a-new-repository)."
 
    ```yaml

--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
@@ -102,8 +102,7 @@ Before you can use Jekyll to create a {% data variables.product.prodname_pages %
    The correct version Jekyll will be installed as a dependency of the `github-pages` gem.
 1. Save and close the Gemfile.
 1. From the command line, run `bundle install`.
-1. Open the `.gitignore` file that Jekyll created.
-1. Ignore the gems lock file by adding this line:
+1. Open the `.gitignore` file that Jekyll created and ignore the gems lock file by adding this line:
 
    ```gitignore
    Gemfile.lock

--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll.md
@@ -104,7 +104,7 @@ Before you can use Jekyll to create a {% data variables.product.prodname_pages %
 1. From the command line, run `bundle install`.
 1. Open the `.gitignore` file that Jekyll created and ignore the gems lock file by adding this line:
 
-   ```gitignore
+   ```shell
    Gemfile.lock
    ```
 

--- a/data/code-languages.yml
+++ b/data/code-languages.yml
@@ -13,6 +13,9 @@ csharp:
 dockerfile:
   name: Dockerfile
   comment: number
+gitignore:
+  name: Gitignore
+  comment: number
 golang:
   name: Go
   comment: slash

--- a/data/code-languages.yml
+++ b/data/code-languages.yml
@@ -13,9 +13,6 @@ csharp:
 dockerfile:
   name: Dockerfile
   comment: number
-gitignore:
-  name: Gitignore
-  comment: number
 golang:
   name: Go
   comment: slash


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: Warning prevention

Closes: #32351

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

- The existing instructions implicitly make you commit and push the `Gemfile.lock` file, and this PR fixes this

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
