### PR TITLE
Update configuring-two-factor-authentication.md with 1 line: the step…

### DIFF
--- a/content/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication.md
+++ b/content/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication.md
@@ -70,6 +70,8 @@ A time-based one-time password (TOTP) application automatically generates an aut
 {% data reusables.two_fa.save_your_recovery_codes_during_2fa_setup %}
 {% data reusables.two_fa.backup_options_during_2fa_enrollment %}
 
+Clicking the 'Done' button at the bottom of the confirmation page is necessary to complete the process and enable 2FA on your account.
+
 ### Manually configuring a TOTP app
 
 {% data reusables.two_fa.manual-totp-app-setup %}


### PR DESCRIPTION
… to click 'Done' button to complete process

I found when enabling 2FA on my account that I could go through the whole process (TOTP app, download recovery codes, etc) and even get the confirmation screen (with confetti), however, 2FA was not enabled. My conclusion (when going through the process a 2nd time) was that it was necessary to click 'Done' button on the confirmation/confetti page. I don't think i bothered to do this the first time, as it wasn't obvious that it was necessary (thought it was just to go back to home screen or something of convenience). Clicked 'Done' the second time, got a confirmation email, and 2FA is successfully enabled.  This is the quickest 'help' I could think of for others, as changing the process to not depend on a 'Done' button is a bigger task. Feel free to edit or put this in another .md, but I think it needs to be noted somewhere for users.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
