### PR TITLE
Update alias setup language to clarify usage

### DIFF
--- a/content/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli.md
+++ b/content/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli.md
@@ -87,7 +87,7 @@ The following examples show how to add the alias configurations to your Bash, Po
 
 **Bash**
 
-Add the following to your Bash configuration file:
+Run the following to add the aliases to your Bash configuration file:
 
 ```shell copy
 echo 'eval "$(gh copilot alias -- bash)"' >> ~/.bashrc
@@ -95,7 +95,7 @@ echo 'eval "$(gh copilot alias -- bash)"' >> ~/.bashrc
 
 **PowerShell**
 
-Add the following to your PowerShell profile:
+Run the following to add the aliases to your PowerShell profile:
 
 ```shell copy
 $GH_COPILOT_PROFILE = Join-Path -Path $(Split-Path -Path $PROFILE -Parent) -ChildPath "gh-copilot.ps1"
@@ -105,7 +105,7 @@ echo ". $GH_COPILOT_PROFILE" >> $PROFILE
 
 **Zsh**
 
-Add the following to your Zsh configuration file:
+Run the following to add the aliases to your Zsh configuration file:
 
 ```shell copy
 echo 'eval "$(gh copilot alias -- zsh)"' >> ~/.zshrc


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Current language makes it seem like you should add the lines provided into your config file rather than run the command once to append the generated alias to your profile for you. 

Updated the language to make it clear you should run the command rather than append it.

Users who append by mistake will see things working but would add ~1sec to their powershell launch time, and would end up appending duplicate lines to their config file every time they launch their shell.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
