### PR TITLE
#32401 docs: Add missing > in OpenID Connect GCP doc, Update README.md, Add links to generic information for CodeQL & Rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ In addition to the README you're reading right now, this repo includes other REA
 - [data/README.md](data/README.md)
 - [data/reusables/README.md](data/reusables/README.md)
 - [data/variables/README.md](data/variables/README.md)
-- [src/pageinfo/README.md](src/pageinfo/README.md)
 - [src/README.md](src/README.md)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ That's how you can easily become a member of the GitHub Docs community. :sparkle
 
 In addition to the README you're reading right now, this repo includes other READMEs that describe the purpose of each subdirectory in more detail:
 
+- [src/codeql-cli/README.md](src/codeql-cli/README.md)
+- [src/rest/README.md](src/rest/README.md)
 - [content/README.md](content/README.md)
 - [content/graphql/README.md](content/graphql/README.md)
 - [content/rest/README.md](content/rest/README.md)
@@ -40,6 +42,7 @@ In addition to the README you're reading right now, this repo includes other REA
 - [data/README.md](data/README.md)
 - [data/reusables/README.md](data/reusables/README.md)
 - [data/variables/README.md](data/variables/README.md)
+- [src/pageinfo/README.md](src/pageinfo/README.md)
 - [src/README.md](src/README.md)
 
 ## License

--- a/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform.md
+++ b/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform.md
@@ -57,7 +57,7 @@ The `google-github-actions/auth` action receives a JWT from the {% data variable
 
 This example has a job called `Get_OIDC_ID_token` that uses actions to request a list of services from GCP.
 
-- `<example-workload-identity-provider>`: Replace this with the path to your identity provider in GCP. For example, `projects/<example-project-id>/locations/global/workloadIdentityPools/<name-of-pool/providers/<name-of-provider>`
+- `<example-workload-identity-provider>`: Replace this with the path to your identity provider in GCP. For example, `projects/<example-project-id>/locations/global/workloadIdentityPools/<name-of-pool>/providers/<name-of-provider>`
 - `<example-service-account>`: Replace this with the name of your service account in GCP.
 - `<project-id>`: Replace this with the ID of your GCP project.
 

--- a/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform.md
+++ b/content/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform.md
@@ -57,7 +57,7 @@ The `google-github-actions/auth` action receives a JWT from the {% data variable
 
 This example has a job called `Get_OIDC_ID_token` that uses actions to request a list of services from GCP.
 
-- `<example-workload-identity-provider>`: Replace this with the path to your identity provider in GCP. For example, `projects/<example-project-id>/locations/global/workloadIdentityPools/<name-of-pool>/providers/<name-of-provider>`
+- `<example-workload-identity-provider>`: Replace this with the path to your identity provider in GCP. For example, `projects/<example-project-id>/locations/global/workloadIdentityPools/<name-of-pool/providers/<name-of-provider>`
 - `<example-service-account>`: Replace this with the name of your service account in GCP.
 - `<project-id>`: Replace this with the ID of your GCP project.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
- Adds missing >
- Add additional read me links to main README.md - Allow users to navigate to other useful components and documentation such as CodeQL & Rest from the main `README.md`.

| **Source** | **Preview** | **Production** | **What Changed** |
|:----------- |:----------- |:----------- |:----------- |
| [`actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform.md`](https://github.com/github/docs/blob/3d62a9a6fb9a70437e6f5709d4e4f41ccfe7ce11/content%2Factions%2Fdeployment%2Fsecurity-hardening-your-deployments%2Fconfiguring-openid-connect-in-google-cloud-platform.md) | [fpt](https://docs-32406-213295.preview.ghdocs.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform)<br>[ghec](https://docs-32406-213295.preview.ghdocs.com/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform)<br>ghes@ [3.12](https://docs-32406-213295.preview.ghdocs.com/enterprise-server@3.12/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform) [3.11](https://docs-32406-213295.preview.ghdocs.com/enterprise-server@3.11/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform) [3.10](https://docs-32406-213295.preview.ghdocs.com/enterprise-server@3.10/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform) [3.9](https://docs-32406-213295.preview.ghdocs.com/enterprise-server@3.9/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform) <br> | [fpt](https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform)<br>[ghec](https://docs.github.com/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform)<br>ghes@ [3.12](https://docs.github.com/enterprise-server@3.12/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform) [3.11](https://docs.github.com/enterprise-server@3.11/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform) [3.10](https://docs.github.com/enterprise-server@3.10/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform) [3.9](https://docs.github.com/enterprise-server@3.9/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform) | Typo Fix |

### Closes: 
#32401

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).