### PR TITLE
Quote $GH_COPILOT_PROFILE

### DIFF
--- a/content/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli.md
+++ b/content/copilot/github-copilot-in-the-cli/using-github-copilot-in-the-cli.md
@@ -100,7 +100,7 @@ Run the following to add the aliases to your PowerShell profile:
 ```shell copy
 $GH_COPILOT_PROFILE = Join-Path -Path $(Split-Path -Path $PROFILE -Parent) -ChildPath "gh-copilot.ps1"
 gh copilot alias -- pwsh | Out-File ( New-Item -Path $GH_COPILOT_PROFILE -Force )
-echo ". $GH_COPILOT_PROFILE" >> $PROFILE
+echo ". `"$GH_COPILOT_PROFILE`"" >> $PROFILE
 ```
 
 **Zsh**


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

This pull request includes a small change to the `using-github-copilot-in-the-cli.md` file. The change modifies the PowerShell command to add aliases to the user's profile. The echo command has been updated to include double quotes around the `$GH_COPILOT_PROFILE` variable. This ensures that the variable's value is correctly interpreted, especially when it contains spaces.

Before
![image](https://github.com/github/docs/assets/17608272/0e8fbbe8-43f5-4e2b-a8a1-25028009e289)

After
![image](https://github.com/github/docs/assets/17608272/4ce3683f-819e-4f5a-b2dd-9582fc988d20)


<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
