### PR TITLE
Clarify Codespaces VSCode extension requirements

### DIFF
--- a/content/codespaces/developing-in-a-codespace/using-github-codespaces-in-visual-studio-code.md
+++ b/content/codespaces/developing-in-a-codespace/using-github-codespaces-in-visual-studio-code.md
@@ -28,7 +28,7 @@ If you prefer to work in the browser, but want to continue using your existing {
 
 ## Prerequisites
 
-To develop in a codespace directly in {% data variables.product.prodname_vscode_shortname %}, you must install and sign into the {% data variables.product.prodname_github_codespaces %} extension with your {% data variables.product.product_name %} credentials. The {% data variables.product.prodname_github_codespaces %} extension requires {% data variables.product.prodname_vscode_shortname %} October 2020 Release 1.51 or later.
+To develop in a codespace directly in {% data variables.product.prodname_vscode_shortname %}, you must install and sign into the {% data variables.product.prodname_github_codespaces %} extension with your {% data variables.product.product_name %} credentials. The {% data variables.product.prodname_github_codespaces %} extension requires a 64-bit edition of {% data variables.product.prodname_vscode_shortname %} October 2020 Release 1.51 or later.
 
 Use the {% data variables.product.prodname_vscode_marketplace %} to install the [{% data variables.product.prodname_github_codespaces %}](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) extension. For more information, see [Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery) in the {% data variables.product.prodname_vscode_shortname %} documentation.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Github Codespaces does not support 32-bit versions of local VSCode.
This change clarifies the requirements for the GitHub Codespaces extension for VSCode. Users of 32-bit VSCode, like myself, have encountered an error stating, "Failed to start VS Code Remote server." The issue arises due to the GitHub Codespaces extension lacking support for 32-bit VSCode. This change will specify the need for a 64-bit version of VSCode, thereby saving users time.

<!-- ### What's being changed (if available, include any code snippets, screenshots, or gifs): -->

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
