### PR TITLE
Fix typos in GitHub Audit log event descriptions

### DIFF
--- a/src/audit-logs/data/fpt/organization.json
+++ b/src/audit-logs/data/fpt/organization.json
@@ -11603,7 +11603,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "user_agent",
@@ -11625,7 +11625,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "user_agent",

--- a/src/audit-logs/data/ghec/enterprise.json
+++ b/src/audit-logs/data/ghec/enterprise.json
@@ -14385,7 +14385,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "user_agent",
@@ -14407,7 +14407,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "user_agent",

--- a/src/audit-logs/data/ghec/organization.json
+++ b/src/audit-logs/data/ghec/organization.json
@@ -11603,7 +11603,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "user_agent",
@@ -11625,7 +11625,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "user_agent",

--- a/src/audit-logs/data/ghes-3.10/enterprise.json
+++ b/src/audit-logs/data/ghes-3.10/enterprise.json
@@ -88535,7 +88535,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -88717,7 +88717,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.10/organization.json
+++ b/src/audit-logs/data/ghes-3.10/organization.json
@@ -91798,7 +91798,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -91980,7 +91980,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.11/enterprise.json
+++ b/src/audit-logs/data/ghes-3.11/enterprise.json
@@ -91788,7 +91788,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -91971,7 +91971,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.11/organization.json
+++ b/src/audit-logs/data/ghes-3.11/organization.json
@@ -98187,7 +98187,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -98370,7 +98370,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.12/enterprise.json
+++ b/src/audit-logs/data/ghes-3.12/enterprise.json
@@ -93284,7 +93284,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -93467,7 +93467,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.12/organization.json
+++ b/src/audit-logs/data/ghes-3.12/organization.json
@@ -101324,7 +101324,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -101507,7 +101507,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.13/enterprise.json
+++ b/src/audit-logs/data/ghes-3.13/enterprise.json
@@ -94893,7 +94893,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -95077,7 +95077,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.13/organization.json
+++ b/src/audit-logs/data/ghes-3.13/organization.json
@@ -103151,7 +103151,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -103335,7 +103335,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.8/enterprise.json
+++ b/src/audit-logs/data/ghes-3.8/enterprise.json
@@ -65880,7 +65880,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -66032,7 +66032,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.8/organization.json
+++ b/src/audit-logs/data/ghes-3.8/organization.json
@@ -70139,7 +70139,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -70291,7 +70291,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.9/enterprise.json
+++ b/src/audit-logs/data/ghes-3.9/enterprise.json
@@ -80642,7 +80642,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -80813,7 +80813,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",

--- a/src/audit-logs/data/ghes-3.9/organization.json
+++ b/src/audit-logs/data/ghes-3.9/organization.json
@@ -84194,7 +84194,7 @@
   },
   {
     "action": "secret_scanning_alert.reopen",
-    "description": "A seret scanning alert was reopened.",
+    "description": "A secret scanning alert was reopened.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",
@@ -84365,7 +84365,7 @@
   },
   {
     "action": "secret_scanning_alert.resolve",
-    "description": "A seret scanning alert was resolved.",
+    "description": "A secret scanning alert was resolved.",
     "docs_reference_links": "N/A",
     "fields": [
       "@timestamp",


### PR DESCRIPTION
### What's being changed:

I fixed a typo in the descriptions of the `secret_scanning_alert.reopen` and `secret_scanning_alert.resolve` GitHub Audit log events.

I also wondered if there's a typo in the name of the `org.runner_group_visiblity_updated` event. I'd be grateful if someone at GitHub Engineering could comment on this.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
