### PR TITLE
Make client_secret optional since it's not always required

### DIFF
--- a/content/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens.md
+++ b/content/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens.md
@@ -50,7 +50,7 @@ If you opt into user access tokens that expire after you have already generated 
    Query parameter | Type | Description
    -----|------|------------
    `client_id` | `string` | **Required.** The client ID for your {% data variables.product.prodname_github_app %}. The client ID is different from the app ID. You can find the client ID on the settings page for your app.
-   `client_secret` | `string` | **Required.** The client secret for your {% data variables.product.prodname_github_app %}. You can generate a client secret on the settings page for your app.
+   `client_secret` | `string` | **Optional.** The client secret for your {% data variables.product.prodname_github_app %}. You can generate a client secret on the settings page for your app. Omit this when the user access token was generated using the device flow.
    `grant_type` | `string` | **Required.** The value must be "refresh_token".
    `refresh_token` | `string` | **Required.** The refresh token that you received when you generated a user access token.
 

--- a/content/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens.md
+++ b/content/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens.md
@@ -50,7 +50,7 @@ If you opt into user access tokens that expire after you have already generated 
    Query parameter | Type | Description
    -----|------|------------
    `client_id` | `string` | **Required.** The client ID for your {% data variables.product.prodname_github_app %}. The client ID is different from the app ID. You can find the client ID on the settings page for your app.
-   `client_secret` | `string` | **Optional.** The client secret for your {% data variables.product.prodname_github_app %}. You can generate a client secret on the settings page for your app. Omit this when the user access token was generated using the device flow.
+   `client_secret` | `string` | **Required** unless the user access token was generated using the device flow. The client secret for your {% data variables.product.prodname_github_app %}.
    `grant_type` | `string` | **Required.** The value must be "refresh_token".
    `refresh_token` | `string` | **Required.** The refresh token that you received when you generated a user access token.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Apps using the device flow does not have a client secret and can generate new access tokens using the refresh_token grant without this parameter in the request.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Example request:

```python
requests.post(
    "https://github.com/login/oauth/access_token",
    data={
        "client_id": "<YOUR CLIENT ID>",
        "refresh_token": refresh_token,
        "grant_type": "refresh_token",
    },
)
```

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
