### PR TITLE
Fixed a typo in setting-up-github-copilot-in-the-cli.md

### DIFF
--- a/content/copilot/github-copilot-in-the-cli/setting-up-github-copilot-in-the-cli.md
+++ b/content/copilot/github-copilot-in-the-cli/setting-up-github-copilot-in-the-cli.md
@@ -38,7 +38,7 @@ An enterprise owner can choose whether to enable a feature for all organizations
 
 To install {% data variables.product.prodname_copilot_cli_short %}, you must have {% data variables.product.prodname_cli %} installed. {% data reusables.cli.cli-installation %}
 
-1. If you are have not already authenticated with your {% data variables.product.prodname_dotcom %} account, run the following command in your terminal.
+1. If you have not already authenticated with your {% data variables.product.prodname_dotcom %} account, run the following command in your terminal.
 
     ```shell copy
     gh auth login


### PR DESCRIPTION
Removed the unnecessary word "are" on line number 41 of setting-up-github-copilot-in-the-cli.md

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
To fix a typo.
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
![image](https://github.com/github/docs/assets/143330633/b85cda09-71f1-4489-a9a9-69a7894769ef)

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
