### PR TITLE
Update about-self-hosted-runners.md

### DIFF
--- a/content/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners.md
+++ b/content/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners.md
@@ -181,7 +181,26 @@ codeload.github.com
 
 ```shell copy
 results-receiver.actions.githubusercontent.com
-*.blob.core.windows.net
+productionresultssa0.blob.core.windows.net
+productionresultssa1.blob.core.windows.net
+productionresultssa2.blob.core.windows.net
+productionresultssa3.blob.core.windows.net
+productionresultssa4.blob.core.windows.net
+productionresultssa5.blob.core.windows.net
+productionresultssa6.blob.core.windows.net
+productionresultssa7.blob.core.windows.net
+productionresultssa8.blob.core.windows.net
+productionresultssa9.blob.core.windows.net
+productionresultssa10.blob.core.windows.net
+productionresultssa11.blob.core.windows.net
+productionresultssa12.blob.core.windows.net
+productionresultssa13.blob.core.windows.net
+productionresultssa14.blob.core.windows.net
+productionresultssa15.blob.core.windows.net
+productionresultssa16.blob.core.windows.net
+productionresultssa17.blob.core.windows.net
+productionresultssa18.blob.core.windows.net
+productionresultssa19.blob.core.windows.net
 ```
 
 **Needed for runner version updates:**


### PR DESCRIPTION
Don't advise allowing access to *.blob.core.windows.net as it allows access to all azure blobs in the world, for any action.  Better to allow access to only specific blob stores.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Relates to: https://github.com/actions/actions-runner-controller/issues/3406

Previously, the docs said to only allow specific azure blob stores, but now they say to allow `*.blob.core.windows.net` which is much less secure. Any-bucket controlled by anyone, for any operation in the whole of Azure, worldwide, isn't exactly controlled. Surely it's enterprises paying for github enterprise that want selfhosted runners, and don't want to give unfettered access to build agents that this exists for?


### What's being changed (if available, include any code snippets, screenshots, or gifs):

Just a list of hostnames

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
