### PR TITLE
Add note about tokens when working with maven registries

### DIFF
--- a/content/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry.md
@@ -132,6 +132,9 @@ If your instance has subdomain isolation disabled:
 
 If you would like to publish multiple packages to the same repository, you can include the URL of the repository in the `<distributionManagement>` element of the _pom.xml_ file. {% data variables.product.prodname_dotcom %} will match the repository based on that field. Since the repository name is also part of the `distributionManagement` element, there are no additional steps to publish multiple packages to the same repository.
 
+> [!NOTE]
+> As mentioned in {% data reusables.package_registry.authenticate-step %}, `GITHUB_TOKEN` will not be able to access target repository if it's private, and a personal access token should be used in this case.
+
 For more information on creating a package, see the [maven.apache.org documentation](https://maven.apache.org/guides/getting-started/maven-in-five-minutes.html).
 
 1. Edit the `distributionManagement` element of the _pom.xml_ file located in your package directory, replacing {% ifversion ghes %}HOSTNAME with the host name of {% data variables.location.product_location %}, {% endif %}`OWNER` with the name of the personal account or organization that owns the repository and `REPOSITORY` with the name of the repository containing your project.{% ifversion ghes %}

--- a/content/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry.md
@@ -133,8 +133,8 @@ If your instance has subdomain isolation disabled:
 If you would like to publish multiple packages to the same repository, you can include the URL of the repository in the `<distributionManagement>` element of the _pom.xml_ file. {% data variables.product.prodname_dotcom %} will match the repository based on that field. Since the repository name is also part of the `distributionManagement` element, there are no additional steps to publish multiple packages to the same repository.
 
 > [!NOTE]
-> {% data variables.product.pat_generic %} must be used if the target repository is private.
-> {% data reusables.package_registry.authenticate-step %}.
+> `GITHUB_TOKEN` can't be used to publish to other _private_ repositories and {% data variables.product.pat_generic %} must be used instead.
+> For more information, see "[Authenticating to {% data variables.product.prodname_registry %}](#authenticating-to-github-packages)."
 
 For more information on creating a package, see the [maven.apache.org documentation](https://maven.apache.org/guides/getting-started/maven-in-five-minutes.html).
 

--- a/content/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry.md
@@ -133,7 +133,8 @@ If your instance has subdomain isolation disabled:
 If you would like to publish multiple packages to the same repository, you can include the URL of the repository in the `<distributionManagement>` element of the _pom.xml_ file. {% data variables.product.prodname_dotcom %} will match the repository based on that field. Since the repository name is also part of the `distributionManagement` element, there are no additional steps to publish multiple packages to the same repository.
 
 > [!NOTE]
-> As mentioned in {% data reusables.package_registry.authenticate-step %}, `GITHUB_TOKEN` will not be able to access target repository if it's private, and a personal access token should be used in this case.
+> {% data variables.product.pat_generic %} must be used if the target repository is private.
+> {% data reusables.package_registry.authenticate-step %}.
 
 For more information on creating a package, see the [maven.apache.org documentation](https://maven.apache.org/guides/getting-started/maven-in-five-minutes.html).
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

From the issue in setup-java action ( https://github.com/actions/setup-java/issues/620#issuecomment-2094266608 ), I think this part of documentation could be improved.

It can be a bit confusing when the docs say "you can publish to other repos and no extra steps are needed" w/o re-iterating that `GITHUB_TOKEN` can't access private repositories and hence can't be used to publish to them.

This improves the documentation a bit by following the ["format for scannability"](https://docs.github.com/en/contributing/writing-for-github-docs/best-practices-for-github-docs#format-for-scannability) principle for github docs.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
