### PR TITLE
Update Node.js 14, 16 versions to 20 in building-and-testing-nodejs.m…

### DIFF
--- a/content/actions/automating-builds-and-tests/building-and-testing-nodejs.md
+++ b/content/actions/automating-builds-and-tests/building-and-testing-nodejs.md
@@ -64,7 +64,7 @@ We recommend that you have a basic understanding of Node.js, YAML, workflow conf
 
        strategy:
          matrix:
-           node-version: [14.x, 16.x, 18.x]
+           node-version: [18.x, 20.x]
            # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
        steps:
@@ -101,7 +101,7 @@ Each job can access the value defined in the matrix `node-version` array using t
 ```yaml copy
 strategy:
   matrix:
-    node-version: ['14.x', '16.x', '18.x']
+    node-version: ['18.x', '20.x']
 
 steps:
 - uses: {% data reusables.actions.action-checkout %}
@@ -254,7 +254,7 @@ steps:
 - uses: {% data reusables.actions.action-checkout %}
 - uses: {% data reusables.actions.action-setup-node %}
   with:
-    node-version: {% ifversion actions-node20-support %}'20'{% else %}'14'{% endif %}
+    node-version: {% ifversion actions-node20-support %}'20'{% else %}'18'{% endif %}
     cache: 'npm'
 - run: npm install
 - run: npm test
@@ -267,7 +267,7 @@ steps:
 - uses: {% data reusables.actions.action-checkout %}
 - uses: {% data reusables.actions.action-setup-node %}
   with:
-    node-version: {% ifversion actions-node20-support %}'20'{% else %}'14'{% endif %}
+    node-version: {% ifversion actions-node20-support %}'20'{% else %}'18'{% endif %}
     cache: 'yarn'
 - run: yarn
 - run: yarn test
@@ -287,7 +287,7 @@ steps:
     version: 6.10.0
 - uses: {% data reusables.actions.action-setup-node %}
   with:
-    node-version: {% ifversion actions-node20-support %}'20'{% else %}'14'{% endif %}
+    node-version: {% ifversion actions-node20-support %}'20'{% else %}'18'{% endif %}
     cache: 'pnpm'
 - run: pnpm install
 - run: pnpm test


### PR DESCRIPTION
…d building-and-testing-nodejs.md

Removed Node.js versions 14.x and 16.x. Added version 20.x. Updated Node.js 14.x with 18.x, as 18 is still supported.
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
GitHub Actions show warnings with Node.js 14.x version when running nodejs.yaml workflow file, which refers to the documentation https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Removed `14.x` and `16.x`, added `20.x`.
Replaced `14` to `18`.
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
