### PR TITLE
Remove reference to case-sensitive repositories

### DIFF
--- a/content/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors.md
+++ b/content/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors.md
@@ -98,7 +98,7 @@ If you've previously set up SSH keys, you can use the SSH clone URL instead of H
 
 ### Check your spelling
 
-Typos happen, and repository names are case-sensitive.  If you try to clone `git@{% data variables.product.product_url %}:user/repo.git`, but the repository is really named `User/Repo` you will receive this error.
+Typos happen.  If you try to clone `git@{% data variables.product.product_url %}:owner/repotile.git`, but the repository is really named `owner/repoti1e` you will receive this error.
 
 To avoid this error, when cloning, always copy and paste the clone URL from the repository's page. For more information, see "[AUTOTITLE](/repositories/creating-and-managing-repositories/cloning-a-repository)."
 


### PR DESCRIPTION
### Why:

Closes: #32838


### What's being changed (if available, include any code snippets, screenshots, or gifs):

Provided an example of a homoglyph repository because those can happen whereas GitHub does not treat owners/repository names case-sensitively.

[Before](https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#check-your-spelling)
<img width="722" alt="image" src="https://github.com/github/docs/assets/2119212/c31d9889-fda5-4944-8e09-35ca40b2d7f0">

[After](https://docs-32962-d5aa0e.preview.ghdocs.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#check-your-spelling)
<img width="750" alt="image" src="https://github.com/github/docs/assets/2119212/d651570e-fa12-4944-84d4-22ff64862c4a">


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
