### PR TITLE
Update configuring-dependabot-security-updates.md

### DIFF
--- a/content/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates.md
+++ b/content/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates.md
@@ -142,12 +142,12 @@ updates:
     open-pull-requests-limit: 0
     registries:
       - example
-  {%- ifversion dependabot-grouped-security-updates-config %}- package-ecosystem: "gomod"
+  {% ifversion dependabot-grouped-security-updates-config %}- package-ecosystem: "gomod"
     groups:
       golang:
         applies-to: security-updates
         patterns:
-          - "golang.org*"{%- endif %}
+          - "golang.org*"{% endif %}
 ```
 
 {% note %}


### PR DESCRIPTION
Fixes missing newline in grouped Dependabot configuration

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

In https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates

The package ecosystem for grouped Dependabot updates does not have a newline
<img width="441" alt="image" src="https://github.com/github/docs/assets/10548294/8dca1610-04ca-4189-8a04-51c3b846569a">


Closes: https://github.com/github/docs/issues/33116

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updates to no longer strip whitespace, ensuring a newline

Screenshot from preview docs: 
<img width="468" alt="image" src="https://github.com/github/docs/assets/10548294/e73c58a4-28ab-4e05-a0e2-ca65b9afa41b">

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
