### PR TITLE
fix lists in communicating-on-github.md (#33100)

### DIFF
--- a/content/get-started/using-github/communicating-on-github.md
+++ b/content/get-started/using-github/communicating-on-github.md
@@ -34,25 +34,25 @@ You can create and participate in issues, pull requests and team discussions, de
 
 ### {% data variables.product.prodname_github_issues %}
 
-- are useful for discussing specific details of a project such as bug reports, planned improvements and feedback.
-- are specific to a repository, and usually have a clear owner.
-- are often referred to as {% data variables.product.prodname_dotcom %}'s bug-tracking system.
+- Are useful for discussing specific details of a project such as bug reports, planned improvements and feedback
+- Are specific to a repository, and usually have a clear owner
+- Are often referred to as {% data variables.product.prodname_dotcom %}'s bug-tracking system
 
 ### Pull requests
 
-- allow you to propose specific changes.
-- allow you to comment directly on proposed changes suggested by others.
-- are specific to a repository.
+- Allow you to propose specific changes
+- Allow you to comment directly on proposed changes suggested by others
+- Are specific to a repository
 
 {% ifversion fpt or ghec %}
 
 ### {% data variables.product.prodname_discussions %}
 
-- are like a forum, and are best used for open-form ideas and discussions where collaboration is important.
-- may span many repositories.
-- provide a collaborative experience outside the codebase, allowing the brainstorming of ideas, and the creation of a community knowledge base.
-- often don’t have a clear owner.
-- often do not result in an actionable task.
+- Are like a forum, and are best used for open-form ideas and discussions where collaboration is important
+- May span many repositories
+- Provide a collaborative experience outside the codebase, allowing the brainstorming of ideas, and the creation of a community knowledge base
+- Often don’t have a clear owner
+- Often do not result in an actionable task
 {% endif %}
 
 {% ifversion team-discussions %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
- Capitalize the first letters 
- Remove ending period from the sentences
![Screenshot 2024-05-25 at 3 21 58 AM](https://github.com/github/docs/assets/52472550/42537ee4-7cd3-4054-be67-3ab3e037a3ca)

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
