### PR TITLE
Update automatically-redelivering-failed-deliveries-for-a-github-app-…

### DIFF
--- a/content/webhooks/using-webhooks/automatically-redelivering-failed-deliveries-for-a-github-app-webhook.md
+++ b/content/webhooks/using-webhooks/automatically-redelivering-failed-deliveries-for-a-github-app-webhook.md
@@ -102,18 +102,18 @@ jobs:
           WORKFLOW_REPO: {% raw %}${{ github.event.repository.name }}{% endraw %}
           WORKFLOW_REPO_OWNER: {% raw %}${{ github.repository_owner }}{% endraw %}
         run: |
-          node .github/workflows/scripts/redeliver-failed-deliveries.js
+          node .github/workflows/scripts/redeliver-failed-deliveries.mjs
 ```
 
 ## Adding the script
 
 This section demonstrates how you can write a script to find and redeliver failed deliveries.
 
-Copy this script into a file called `.github/workflows/scripts/redeliver-failed-deliveries.js` in the same repository where you saved the {% data variables.product.prodname_actions %} workflow file above.
+Copy this script into a file called `.github/workflows/scripts/redeliver-failed-deliveries.mjs` in the same repository where you saved the {% data variables.product.prodname_actions %} workflow file above.
 
 ```javascript copy annotate
 // This script uses {% data variables.product.company_short %}'s Octokit SDK to make API requests. For more information, see "[AUTOTITLE](/rest/guides/scripting-with-the-rest-api-and-javascript)."
-const { App, Octokit } = require("octokit");
+import { App, Octokit } from "octokit";
 
 //
 async function checkAndRedeliverWebhooks() {


### PR DESCRIPTION
…webhook.md

update docs to prevent Error [ERR_REQUIRE_ESM]: require() of ES Module

### Why:

Closes:  https://github.com/orgs/community/discussions/126156

### What's being changed (if available, include any code snippets, screenshots, or gifs):

replacing `const { App, Octokit } = require("octokit");` with `import { App, Octokit } from "octokit";` to prevent node.js error
See the discussion ticket I raised above for more details

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
