### PR TITLE
Add note on quirk in editing preview regarding links

### DIFF
--- a/content/communities/documenting-your-project-with-wikis/editing-wiki-content.md
+++ b/content/communities/documenting-your-project-with-wikis/editing-wiki-content.md
@@ -27,6 +27,9 @@ You can create links in wikis using the standard markup supported by your page, 
 - If your pages are rendered with Markdown, the link syntax is `[Link Text](full-URL-of-wiki-page)`.
 - With MediaWiki syntax, the link syntax is `[[Link Text|nameofwikipage]]`.
 
+> [!NOTE]
+> Links do not work in the editing preview.
+
 ## Adding images
 
 Wikis can display PNG, JPEG, and GIF images.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

It confuses people why links don't work in the preview but work when the page is saved. Note this behavior here, so people will know that they didn't make a mistake when editing pages.

Closes: No reported documentation issue. 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Just the documentation of the "Editing wiki content" page on "Adding links".

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).
  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
