### PR TITLE
Fix liquid-syntax error parsing

### DIFF
--- a/src/content-linter/lib/linting-rules/liquid-syntax.js
+++ b/src/content-linter/lib/linting-rules/liquid-syntax.js
@@ -91,7 +91,9 @@ export const liquidSyntax = {
 }
 
 function getErrorMessageInfo(message) {
-  const [errorDescription, lineString, columnString] = message.split(',')
+  const [errorDescription, lineString, columnString] = message
+    .match(/(.*?),\s*(line:\d+),\s*(col:\d+)/)
+    .slice(1, 4)
   // There has to be a line number so we'll default to line 1 if the message
   // doesn't contain a line number.
   if (!columnString || !lineString)


### PR DESCRIPTION
### Why:

https://github.com/github/docs/actions/runs/9506483722/job/26203752861#step:5:14
```
> lint-content
> node src/content-linter/scripts/lint-content.js --print-annotations --paths data/reusables/actions/jobs/matrix-used-twice.md content/actions/using-jobs/using-a-matrix-for-your-jobs.md

- Running content linter


file:///home/runner/work/docs/docs/src/content-linter/lib/linting-rules/liquid-syntax.js:[8](https://github.com/github/docs/actions/runs/9506483722/job/26203752861#step:5:9)0
      const range = [columnNumber, line.slice(columnNumber - 1).length]
                                        ^

TypeError: Cannot read properties of undefined (reading 'slice')
    at Object.GHD018 [as function] (file:///home/runner/work/docs/docs/src/content-linter/lib/linting-rules/liquid-syntax.js:80:41)
    at invokeRuleFunction (/home/runner/work/docs/docs/node_modules/markdownlint/lib/markdownlint.js:735:51)
    at forRule (/home/runner/work/docs/docs/node_modules/markdownlint/lib/markdownlint.js:746:7)
    at Array.map (<anonymous>)
    at lintContent (/home/runner/work/docs/docs/node_modules/markdownlint/lib/markdownlint.js:813:44)
    at lintContentWrapper (/home/runner/work/docs/docs/node_modules/markdownlint/lib/markdownlint.js:866:[12](https://github.com/github/docs/actions/runs/9506483722/job/26203752861#step:5:13))
    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read/context:68:3)
```

The error message had:
```
unexpected token "", value expected, line:29, col:65'
```

And splitting on `,` does not result in a happy world


<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fix the pattern to have a better chance of extracting `line` and `col`.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
