### PR TITLE
actions/publishing(nodejs): `id-token: write` for `npm publish` with `--provenance`

### DIFF
--- a/content/actions/publishing-packages/publishing-nodejs-packages.md
+++ b/content/actions/publishing-packages/publishing-nodejs-packages.md
@@ -69,8 +69,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    {% ifversion artifact-attestations %}
-    permissions:
+    {% ifversion artifact-attestations %}permissions:
       contents: read
       id-token: write{% endif %}
     steps:

--- a/content/actions/publishing-packages/publishing-nodejs-packages.md
+++ b/content/actions/publishing-packages/publishing-nodejs-packages.md
@@ -69,6 +69,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    {% ifversion artifact-attestations %}
+    permissions:
+      contents: read
+      id-token: write{% endif %}
     steps:
       - uses: {% data reusables.actions.action-checkout %}
       # Setup .npmrc file to publish to npm


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

NPM refuses to publish with `--provenance` unless `id-token: write` permission is supplied.

```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

I used the `{% ifversion artifact-attestations %}` as it was there in L60 (where the relevant docs were written), but not sure if this would work well... :P

See also: https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Supply `id-token: write` permission as documented by NPM.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
