### PR TITLE
Fix job services localhost example in workflow-syntax-for-github-actions.md

### DIFF
--- a/content/actions/writing-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/writing-workflows/workflow-syntax-for-github-actions.md
@@ -1018,8 +1018,8 @@ services:
       - 6379/tcp
 steps:
   - run: |
-      echo "Redis available on 127.0.0.1:${{ job.services.redis.ports['6379'] }}"
-      echo "Nginx available on 127.0.0.1:${{ job.services.nginx.ports['80'] }}"
+      echo "Redis available on 127.0.0.1:{% raw %}${{ job.services.redis.ports['6379'] }}{% endraw %}"
+      echo "Nginx available on 127.0.0.1:{% raw %}${{ job.services.nginx.ports['80'] }}{% endraw %}"
 ```
 
 ## `jobs.<job_id>.services.<service_id>.image`

--- a/content/actions/writing-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/writing-workflows/workflow-syntax-for-github-actions.md
@@ -1002,7 +1002,7 @@ For more information about the differences between networking service containers
 
 ### Example: Using localhost
 
-This example creates two services: nginx and redis. When you specify the Docker host port but not the container port, the container port is randomly assigned to a free port. {% data variables.product.prodname_dotcom %} sets the assigned container port in the {% raw %}`${{job.services.<service_name>.ports}}`{% endraw %} context. In this example, you can access the service container ports using the {% raw %}`${{ job.services.nginx.ports['8080'] }}`{% endraw %} and {% raw %}`${{ job.services.redis.ports['6379'] }}`{% endraw %} contexts.
+This example creates two services: nginx and redis. When you specify the container port but not the host port, the host port is randomly assigned to a free port on host. {% data variables.product.prodname_dotcom %} sets the assigned host port in the {% raw %}`${{job.services.<service_name>.ports}}`{% endraw %} context. In this example, you can access the service host ports using the {% raw %}`${{ job.services.nginx.ports['80'] }}`{% endraw %} and {% raw %}`${{ job.services.redis.ports['6379'] }}`{% endraw %} contexts.
 
 ```yaml
 services:
@@ -1016,6 +1016,10 @@ services:
     # Map TCP port 6379 on Docker host to a random free port on the Redis container
     ports:
       - 6379/tcp
+steps:
+  - run: |
+      echo "Redis available on 127.0.0.1:${{ job.services.redis.ports['6379'] }}"
+      echo "Nginx available on 127.0.0.1:${{ job.services.nginx.ports['80'] }}"
 ```
 
 ## `jobs.<job_id>.services.<service_id>.image`

--- a/content/actions/writing-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/writing-workflows/workflow-syntax-for-github-actions.md
@@ -1013,7 +1013,7 @@ services:
       - 8080:80
   redis:
     image: redis
-    # Map TCP port 6379 on Docker host to a random free port on the Redis container
+    # Map random free TCP port on Docker host to port 6379 on redis container
     ports:
       - 6379/tcp
 steps:


### PR DESCRIPTION
### Why:

Because job services localhost example is wrong and misleading.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Current example states that :
> When you specify the Docker host port but not the container port, the container port is randomly assigned to a free port. GitHub sets the assigned container port in the ${{job.services.<service_name>.ports}} context. In this example, you can access the service container ports using the ${{ job.services.nginx.ports['8080'] }} and ${{ job.services.redis.ports['6379'] }} contexts.

Which is not true because you either specify container port only and then GitHub Actions will choose random free port on **host**, or you specify both, host and container port. 

To access host port you should use container port as a key. In `nginx` example it should be  `${{ job.services.nginx.ports['80'] }}` and not `8080`.

Updated job services yaml example to show more clearly how to access those services.

I tested all this using this yaml
```yaml
jobs:
  job-a:
    runs-on: ubuntu-latest
    services:
      nginx:
        image: nginx
        # Map port 8080 on the Docker host to port 80 on the nginx container
        ports:
          - 8080:80
      redis:
        image: redis
        # Map TCP port 6379 on Docker host to a random free port on the Redis container
        ports:
          - 6379/tcp
    steps:
      - run: docker ps
      - run: echo '${{ toJSON(job.services) }}'
      - run: |
          echo "Redis available on 127.0.0.1:${{ job.services.redis.ports['6379'] }}"
          echo "Nginx available on 127.0.0.1:${{ job.services.nginx.ports['80'] }}"
      - name: Check Redis
        run: |
          echo -e '*1\r\n$4\r\nPING\r\n' | netcat -w1 127.0.0.1 ${{ job.services.redis.ports['6379'] }}
```

![image](https://github.com/github/docs/assets/503782/677f1b85-2010-44f1-8c5b-2e2cab91aed7)


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
