### PR TITLE
Fix update knowledge bases description

### DIFF
--- a/content/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-copilot-knowledge-bases.md
+++ b/content/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-copilot-knowledge-bases.md
@@ -63,7 +63,7 @@ Knowledge bases you create will be accessible by all organization members with a
 
 ## Updating a knowledge base
 
-Organization owners can delete a knowledge base created in their organization.
+Organization owners can update a knowledge base created in their organization.
 
 {% data reusables.profile.access_org %}
 {% data reusables.profile.org_settings %}


### PR DESCRIPTION
### Why:

It appears that the summary mentions 'delete,' whereas it should provide a description of the update to the knowledge bases.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
