### PR TITLE
Specify allowed contexts in jobs.<job_id>.services.<service_id>.image

### DIFF
--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -979,12 +979,16 @@ services:
 
 The Docker image to use as the service container to run the action. The value can be the Docker Hub image name or a registry name.
 
+> [!NOTE]
+> Usage of GitHub [contexts](https://docs.github.com/en/actions/learn-github-actions/contexts) is allowed when specyfing service image.
+> Allowed contexts are: `gitub`, `strategy`, `matrix`, `needs`, `vars` and `inputs`.
+
 If `jobs.<job_id>.services.<service_id>.image` is assigned an empty string, the service will not start. You can use this to set up conditional services, similar to the following example.
 
 ```yaml
 services:
   nginx:
-    image: {% raw %}${{ options.nginx == true && 'nginx' || '' }}{% endraw %}
+    image: {% raw %}${{ matrix.nginx_service == 'true' && 'nginx' || '' }}{% endraw %}
 ```
 
 ## `jobs.<job_id>.services.<service_id>.credentials`

--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -980,7 +980,7 @@ services:
 The Docker image to use as the service container to run the action. The value can be the Docker Hub image name or a registry name.
 
 > [!NOTE]
-> Usage of GitHub [contexts](https://docs.github.com/en/actions/learn-github-actions/contexts) is allowed when specyfing service image.
+> Usage of GitHub [AUTOTITLE](/actions/learn-github-actions/contexts) is allowed when specyfing service image.
 > Allowed contexts are: `github`, `strategy`, `matrix`, `needs`, `vars` and `inputs`.
 
 If `jobs.<job_id>.services.<service_id>.image` is assigned an empty string, the service will not start. You can use this to set up conditional services, similar to the following example.

--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -981,7 +981,7 @@ The Docker image to use as the service container to run the action. The value ca
 
 > [!NOTE]
 > Usage of GitHub [contexts](https://docs.github.com/en/actions/learn-github-actions/contexts) is allowed when specyfing service image.
-> Allowed contexts are: `gitub`, `strategy`, `matrix`, `needs`, `vars` and `inputs`.
+> Allowed contexts are: `github`, `strategy`, `matrix`, `needs`, `vars` and `inputs`.
 
 If `jobs.<job_id>.services.<service_id>.image` is assigned an empty string, the service will not start. You can use this to set up conditional services, similar to the following example.
 

--- a/content/actions/using-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/using-workflows/workflow-syntax-for-github-actions.md
@@ -980,8 +980,7 @@ services:
 The Docker image to use as the service container to run the action. The value can be the Docker Hub image name or a registry name.
 
 > [!NOTE]
-> Usage of GitHub [AUTOTITLE](/actions/learn-github-actions/contexts) is allowed when specyfing service image.
-> Allowed contexts are: `github`, `strategy`, `matrix`, `needs`, `vars` and `inputs`.
+> You can use the following [AUTOTITLE](/actions/learn-github-actions/contexts) when specifying a service image: `github`, `inputs`, `matrix`, `needs`, `strategy`, and `vars`.
 
 If `jobs.<job_id>.services.<service_id>.image` is assigned an empty string, the service will not start. You can use this to set up conditional services, similar to the following example.
 


### PR DESCRIPTION
### Why:

Documentation does not mention if and which context variable can be used in `jobs.<job_id>.services.<service_id>.image`. From my tests a subset of contexts can be used and those are: `github`, `matrix`, `strategy`, `needs`, `vars` and `inputs`. 

Unfortunately, using `env` context is not possible. Not sure why that is. Anyhow, specifying allowed contexts in docs would be helpful when writing workflows. 

I've also changed conditional service creation example because it contained invalid example that was using `options` context which does not exist.


### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added a note about allowed contexts and fixed example conditional service creation.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
