### PR TITLE
Replace misleading documentation about action inputs and outputs

### DIFF
--- a/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
+++ b/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
@@ -70,7 +70,7 @@ For example, if a workflow defined the `num-octocats` and `octocat-eye-color` in
 
 ### `inputs.<input_id>.description`
 
-**Required** A `string` description of the input parameter.
+**Optional** A `string` description of the input parameter.
 
 ### `inputs.<input_id>.required`
 

--- a/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
+++ b/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
@@ -41,7 +41,7 @@ Action metadata files use YAML syntax. If you're new to YAML, you can read "[Lea
 
 ### Example: Specifying inputs
 
-This example configures three inputs: `num-octocats` and `octocat-eye-color`. The `num-octocats` input is not required and will default to a value of `1`. `octocat-eye-color` is required and has no default value.
+This example configures two inputs: `num-octocats` and `octocat-eye-color`. The `num-octocats` input is not required and will default to a value of `1`. `octocat-eye-color` is required and has no default value.
 
 Workflow files that use this action can use the `with` keyword to set an input value for `octocat-eye-color`. For more information about the `with` syntax, see "[AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith)."
 
@@ -58,7 +58,7 @@ inputs:
 
 When you specify an input, {% data variables.product.prodname_dotcom %} creates an environment variable for the input with the name `INPUT_<VARIABLE_NAME>`. The environment variable created converts input names to uppercase letters and replaces spaces with `_` characters.
 
-If the action is written using a [composite](/actions/creating-actions/creating-a-composite-action), then it will not automatically get `INPUT_<VARIABLE_NAME>`. With composite actions youu can use `inputs` [AUTOTITLE](/actions/learn-github-actions/contexts) to access action inputs.
+If the action is written using a [composite](/actions/creating-actions/creating-a-composite-action), then it will not automatically get `INPUT_<VARIABLE_NAME>`. With composite actions you can use `inputs` [AUTOTITLE](/actions/learn-github-actions/contexts) to access action inputs.
 
 To access the environment variable in a Docker container action, you must pass the input using the `args` keyword in the action metadata file. For more information about the action metadata file for Docker container actions, see "[AUTOTITLE](/actions/creating-actions/creating-a-docker-container-action#creating-an-action-metadata-file)."
 

--- a/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
+++ b/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
@@ -37,17 +37,11 @@ Action metadata files use YAML syntax. If you're new to YAML, you can read "[Lea
 
 ## `inputs`
 
-**Optional** Input parameters allow you to specify data that the action expects to use during runtime. {% data variables.product.prodname_dotcom %} stores input parameters as environment variables. Input ids with uppercase letters are converted to lowercase during runtime. We recommend using lowercase input ids.
+**Optional** Input parameters allow you to specify data that the action expects to use during runtime. {% data variables.product.prodname_dotcom %} stores input parameters as environment variables. Input values are always converted to strings. We recommend using lowercase input ids.
 
 ### Example: Specifying inputs
 
-This example configures two inputs: `num-octocats` and `octocat-eye-color`. The `num-octocats` input is not required and will default to a value of `1`. `octocat-eye-color` is required and has no default value.
-
-{% note %}
-
-**Note:** If input is not required and default value is not specified, {% data variables.product.prodname_dotcom %} will use empty string as a default value.
-
-{% endnote %}
+This example configures three inputs: `num-octocats` and `octocat-eye-color`. The `num-octocats` input is not required and will default to a value of `1`. `octocat-eye-color` is required and has no default value.
 
 Workflow files that use this action can use the `with` keyword to set an input value for `octocat-eye-color`. For more information about the `with` syntax, see "[AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith)."
 
@@ -62,9 +56,9 @@ inputs:
     required: true
 ```
 
-When you specify an input in a workflow file or use a default input value, {% data variables.product.prodname_dotcom %} creates an environment variable for the input with the name `INPUT_<VARIABLE_NAME>`. The environment variable created converts input names to uppercase letters and replaces spaces with `_` characters.
+When you specify an input, {% data variables.product.prodname_dotcom %} creates an environment variable for the input with the name `INPUT_<VARIABLE_NAME>`. The environment variable created converts input names to uppercase letters and replaces spaces with `_` characters.
 
-If the action is written using a [composite](/actions/creating-actions/creating-a-composite-action), then it will not automatically get `INPUT_<VARIABLE_NAME>`. If the conversion doesn't occur, you can change these inputs manually.
+If the action is written using a [composite](/actions/creating-actions/creating-a-composite-action), then it will not automatically get `INPUT_<VARIABLE_NAME>`. With composite actions youu can use `inputs` [AUTOTITLE](/actions/learn-github-actions/contexts) to access action inputs.
 
 To access the environment variable in a Docker container action, you must pass the input using the `args` keyword in the action metadata file. For more information about the action metadata file for Docker container actions, see "[AUTOTITLE](/actions/creating-actions/creating-a-docker-container-action#creating-an-action-metadata-file)."
 
@@ -72,7 +66,7 @@ For example, if a workflow defined the `num-octocats` and `octocat-eye-color` in
 
 ### `inputs.<input_id>`
 
-**Required** A `string` identifier to associate with the input. The value of `<input_id>` is a map of the input's metadata. The `<input_id>` must be a unique identifier within the `inputs` object. The `<input_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.
+**Required** A `string` identifier to associate with the input. The value of `<input_id>` is a map of the input's metadata. The `<input_id>` must be a unique identifier within the `inputs` object. The `<input_id>` must start with a letter or `_` and contain only alphanumeric characters, spaces, `-`, or `_`.
 
 ### `inputs.<input_id>.description`
 
@@ -84,7 +78,7 @@ For example, if a workflow defined the `num-octocats` and `octocat-eye-color` in
 
 ### `inputs.<input_id>.default`
 
-**Optional** A `string` representing the default value. The default value is used when an input parameter isn't specified in a workflow file.
+**Optional** A `string` representing the default value. The default value is used when an input parameter isn't specified in a workflow file. If input is not required and default value is not specified, {% data variables.product.prodname_dotcom %} will use empty string as a default value.
 
 ### `inputs.<input_id>.deprecationMessage`
 

--- a/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
+++ b/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
@@ -72,11 +72,11 @@ For example, if a workflow defined the `num-octocats` and `octocat-eye-color` in
 
 ### `inputs.<input_id>`
 
-**Required** A `string` identifier to associate with the input. The value of `<input_id>` is a map of the input's metadata. The `<input_id>` must be a unique identifier within the `inputs` object. The `<input_id>` must start with a letter or `_` and contain only alphanumeric characters, spaces, `-`, or `_`.
+**Required** A `string` identifier to associate with the input. The value of `<input_id>` is a map of the input's metadata. The `<input_id>` must be a unique identifier within the `inputs` object. The `<input_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.
 
 ### `inputs.<input_id>.description`
 
-**Optional** A `string` description of the input parameter.
+**Required** A `string` description of the input parameter.
 
 ### `inputs.<input_id>.required`
 
@@ -84,7 +84,7 @@ For example, if a workflow defined the `num-octocats` and `octocat-eye-color` in
 
 ### `inputs.<input_id>.default`
 
-**Optional** A `string` representing the default value. The default value is used when an input parameter isn't specified in a workflow file. If input is not required and default value is not specified, {% data variables.product.prodname_dotcom %} will use empty string as a default value.
+**Optional** A `string` representing the default value. The default value is used when an input parameter isn't specified in a workflow file.
 
 ### `inputs.<input_id>.deprecationMessage`
 
@@ -108,11 +108,11 @@ outputs:
 
 ### `outputs.<output_id>`
 
-**Required** A `string` identifier to associate with the output. The value of `<output_id>` is a map of the output's metadata. The `<output_id>` must be a unique identifier within the `outputs` object. The `<output_id>` must start with a letter or `_` and contain only alphanumeric characters, space, `-`, or `_`.
+**Required** A `string` identifier to associate with the output. The value of `<output_id>` is a map of the output's metadata. The `<output_id>` must be a unique identifier within the `outputs` object. The `<output_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.
 
 ### `outputs.<output_id>.description`
 
-**Optional** A `string` description of the output parameter.
+**Required** A `string` description of the output parameter.
 
 ## `outputs` for composite actions
 

--- a/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
+++ b/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
@@ -102,11 +102,11 @@ outputs:
 
 ### `outputs.<output_id>`
 
-**Required** A `string` identifier to associate with the output. The value of `<output_id>` is a map of the output's metadata. The `<output_id>` must be a unique identifier within the `outputs` object. The `<output_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.
+**Required** A `string` identifier to associate with the output. The value of `<output_id>` is a map of the output's metadata. The `<output_id>` must be a unique identifier within the `outputs` object. The `<output_id>` must start with a letter or `_` and contain only alphanumeric characters, space, `-`, or `_`.
 
 ### `outputs.<output_id>.description`
 
-**Required** A `string` description of the output parameter.
+**Optional** A `string` description of the output parameter.
 
 ## `outputs` for composite actions
 

--- a/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
+++ b/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
@@ -45,7 +45,7 @@ This example configures two inputs: `num-octocats` and `octocat-eye-color`. The 
 
 {% note %}
 
-**Note:** Workflows using `required: true` will not automatically return an error if the input is not specified for events that automatically trigger workflow runs. If you set `required: true` in your workflow file and are using `workflow_dispatch` to manually run the workflow, you will be required to specify inputs on {% data variables.product.prodname_dotcom %}. For more information, see "[AUTOTITLE](/actions/using-workflows/events-that-trigger-workflows)."
+**Note:** If input is not required and default values is not defined, {% data variables.product.prodname_dotcom %} will use empty string as default value.
 
 {% endnote %}
 

--- a/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
+++ b/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
@@ -43,6 +43,12 @@ Action metadata files use YAML syntax. If you're new to YAML, you can read "[Lea
 
 This example configures two inputs: `num-octocats` and `octocat-eye-color`. The `num-octocats` input is not required and will default to a value of `1`. `octocat-eye-color` is required and has no default value.
 
+{% note %}
+
+**Note:** Actions using `required: true` will not automatically return an error if the input is not specified.
+
+{% endnote %}
+
 Workflow files that use this action can use the `with` keyword to set an input value for `octocat-eye-color`. For more information about the `with` syntax, see "[AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith)."
 
 ```yaml

--- a/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
+++ b/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
@@ -45,7 +45,7 @@ This example configures two inputs: `num-octocats` and `octocat-eye-color`. The 
 
 {% note %}
 
-**Note:** If input is not required and default values is not defined, {% data variables.product.prodname_dotcom %} will use empty string as default value.
+**Note:** If input is not required and default value is not specified, {% data variables.product.prodname_dotcom %} will use empty string as a default value.
 
 {% endnote %}
 

--- a/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
+++ b/content/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions.md
@@ -37,7 +37,7 @@ Action metadata files use YAML syntax. If you're new to YAML, you can read "[Lea
 
 ## `inputs`
 
-**Optional** Input parameters allow you to specify data that the action expects to use during runtime. {% data variables.product.prodname_dotcom %} stores input parameters as environment variables. Input values are always converted to strings. We recommend using lowercase input ids.
+**Optional** Input parameters allow you to specify data that the action expects to use during runtime. {% data variables.product.prodname_dotcom %} stores input parameters as environment variables. We recommend using lowercase input ids.
 
 ### Example: Specifying inputs
 


### PR DESCRIPTION
### Why:

Current docs for `inputs` and `outputs` in GitHub action metadata syntax contains some misleading statements

> ## `inputs`
> 
> **Optional** Input parameters allow you to specify data that the action expects to use during runtime. {% data variables.product.prodname_dotcom %} stores input parameters as environment variables. Input ids with uppercase letters are converted to lowercase during runtime. We recommend using lowercase input ids.

I've tested this `Input ids with uppercase letters are converted to lowercase during runtime.` using 
```yaml
name: Demo Composite Action
description: Demo Composite Action

inputs:
  first-input ID:
    description: First input
    required: true
  second-INPUT_id:
    description: Second input
    required: false
    default: 1
  third_input_id:
    description: Third input
    required: false
runs:
  using: composite
  steps:
    - shell: bash
      run: env | grep ^INPUT_ || true
    - shell: bash
      run: echo '${{ toJSON(inputs) }}'

```
and nothing is converted to lowercase

![image](https://github.com/github/docs/assets/503782/e4103c1f-e66d-4449-a065-bf0d6c94a25e)


> Note: Workflows using required: true will not automatically return an error if the input is not specified for events that automatically trigger workflow runs. If you set required: true in your workflow file and are using workflow_dispatch to manually run the workflow, you will be required to specify inputs on GitHub. For more information, see "[Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)."
> 
> Workflow files that use this action can use the with keyword to set an input value for octocat-eye-color. For more information about the with syntax, see "[Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith)."

This is misleading because documentation is about action metadata syntax and note is describing inputs in workflow metadata syntax. This has nothing to do with action inputs, I think.

> When you specify an input in a workflow file or use a default input value, {% data variables.product.prodname_dotcom %} creates an environment variable for the input with the name `INPUT_<VARIABLE_NAME>`. The environment variable created converts input names to uppercase letters and replaces spaces with `_` characters.

Again, this paragraph seems to be mixing workflow inputs with action inputs.

> If the action is written using a [composite](/actions/creating-actions/creating-a-composite-action), then it will not automatically get `INPUT_<VARIABLE_NAME>`. If the conversion doesn't occur, you can change these inputs manually.

Last sentence does not make much sense and I tested it. There is no `INPUT_*` variables present at all with composite actions. I don't even know what `you can change these inputs manually` part actually means. Inputs are read-only afaik, right?

> ### `inputs.<input_id>`
> 
> **Required** A `string` identifier to associate with the input. The value of `<input_id>` is a map of the input's metadata. The `<input_id>` must be a unique identifier within the `inputs` object. The `<input_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.

As far as my tests got me, `space` characters are also valid to use in input ids.

> ### `inputs.<input_id>.description`
>
> **Required** A `string` description of the input parameter.

I tested this with composite and docker action:

```yaml
name: Demo Docker Action
description: Demo Docker Action

inputs:
  first-input ID:
    required: true
  second-INPUT_id:
    required: false
    default: 1
  third_input_id:
    required: false

runs:
  using: 'docker'
  image: 'Dockerfile'
  args:
    - ${{ inputs['first-input ID'] }}
    - ${{ inputs.second-INPUT_id }}
    - ${{ inputs.third_input_id }}
```
and 
```yaml
name: Demo Composite Action
description: Demo Composite Action

inputs:
  first-input ID:
    required: true
  second-INPUT_id:
    required: false
    default: 1
  third_input_id:
    required: false
runs:
  using: composite
  steps:
    - shell: bash
      run: echo '${{ toJSON(inputs) }}'
```
And inputs in those action did not require any description and actions were run without problem
```yaml
jobs:
  actions-examples:
    name: Actions Reuse
    runs-on: ubuntu-latest
    steps:
      - name: Use organization composite action
        uses: pkroczynski/action-demo-composite@inputs
        with:
          first-input ID: hello
      - name: Use organization docker action
        uses: pkroczynski/action-demo-docker@main
        with:
          first-input ID: hello
```

![image](https://github.com/user-attachments/assets/291547e5-a9f6-4285-8516-2f43c9dc0481)

> ### `outputs.<output_id>`
>
> **Required** A `string` identifier to associate with the output. The value of `<output_id>` is a map of the output's metadata. The `<output_id>` must be a unique identifier within the `outputs` object. The `<output_id>` must start with a letter or `_` and contain only alphanumeric characters, `-`, or `_`.

There seems to be also space allowed in output id. Tested with js action using `core.setOutput('output 1', "test")` and it was returned as action output.

> ### `outputs.<output_id>.description`
>
> **Required** A `string` description of the output parameter.

Tried and description can be omitted like below without any problems so it seems that it is optional.

```yaml
outputs:
  output 1: {}
```

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updated docs a bit to reflect what is actually happening with inputs and outputs in actions.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
