### PR TITLE
PR - added a new url for vs code

### DIFF
--- a/content/copilot/troubleshooting-github-copilot/troubleshooting-firewall-settings-for-github-copilot.md
+++ b/content/copilot/troubleshooting-github-copilot/troubleshooting-firewall-settings-for-github-copilot.md
@@ -27,6 +27,7 @@ Due to {% data variables.product.prodname_copilot_short %}'s interaction with a 
 | `https://copilot-proxy.githubusercontent.com/` | API service for {% data variables.product.prodname_copilot_short %} suggestions |
 | `https://origin-tracker.githubusercontent.com` | API service for {% data variables.product.prodname_copilot_short %} suggestions |
 | `https://*.githubcopilot.com` | API service for {% data variables.product.prodname_copilot_short %} suggestions |
+| `https://vscode.dev` | Used when logging in with GitHub or Microsoft for an extension or Settings Sync |
 
 Additional domains and URLs may require allowlisting, depending on your organization's security policies and the editors in use. For more information about specific editors, see "[Further reading](#further-reading)."
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
This pull request introduces a minor change to the `troubleshooting-firewall-settings-for-github-copilot.md` file. The change adds a new URL `https://vscode.dev` to the list of URLs that may require allowlisting for GitHub Copilot. This URL is used when logging in with GitHub or Microsoft for an extension or Settings Sync.

When a VS Code user is configuring the GH Copilot plugin, when authentication is completed, the user is redirected to a URL similar to the one below

https://github.com/login/oauth/authorize?client_id=XXXX&redirect_uri=https://vscode.dev/redirect&......

If the user is behind a firewall/proxy, needs to allow the vscode.dev url to complete authentication.
