### PR TITLE
Add missing space for command in migrating-from-bitbucket-pipelines-with-github-actions-importer.md

### DIFF
--- a/content/actions/migrating-to-github-actions/automated-migrations/migrating-from-bitbucket-pipelines-with-github-actions-importer.md
+++ b/content/actions/migrating-to-github-actions/automated-migrations/migrating-from-bitbucket-pipelines-with-github-actions-importer.md
@@ -125,7 +125,7 @@ The audit command performs the following steps.
 To perform an audit run the following command in your terminal, replacing `:workspace` with the name of the Bitbucket workspace to audit.
 
 ```bash
-gh actions-importer audit bitbucket --workspace :workspace--output-dir tmp/audit
+gh actions-importer audit bitbucket --workspace :workspace --output-dir tmp/audit
 ```
 
 Optionally, a `--project-key` option can be provided to the audit command to limit the results to only pipelines associated with a project.


### PR DESCRIPTION
### Why:

I was following this guide and I found a space is missing on a command (to space arguments)

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I just add an extra space on a command to separate arguments correctly

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
