### PR TITLE
(Fixed) Add period in quotation marks in Apps page

### DIFF
--- a/content/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation.md
+++ b/content/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation.md
@@ -26,7 +26,7 @@ You can also use an installation access token to authenticate for HTTP-based Git
 
 Requests made with an installation access token are sometimes called "server-to-server" requests.
 
-For more information about authenticating as an app on behalf of a user instead of as an app installation, see "[AUTOTITLE](/apps/creating-github-apps/authenticating-with-a-github-app/identifying-and-authorizing-users-for-github-apps)".
+For more information about authenticating as an app on behalf of a user instead of as an app installation, see "[AUTOTITLE](/apps/creating-github-apps/authenticating-with-a-github-app/identifying-and-authorizing-users-for-github-apps)."
 
 ## Using an installation access token to authenticate as an app installation
 


### PR DESCRIPTION
Fixes #34039

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #34039 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Moved the period from outside the quotation marks to inside the quotation marks.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
