### PR TITLE
Update abilities-and-restrictions-of-managed-user-accounts.md

### DIFF
--- a/content/admin/managing-iam/understanding-iam-for-enterprises/abilities-and-restrictions-of-managed-user-accounts.md
+++ b/content/admin/managing-iam/understanding-iam-for-enterprises/abilities-and-restrictions-of-managed-user-accounts.md
@@ -35,6 +35,7 @@ With {% data variables.product.prodname_emus %}, you can control the user accoun
 * Cannot install {% data variables.product.prodname_github_apps %} on their user accounts.
 * Can install {% data variables.product.prodname_github_apps %} on a repository if the app doesn't request organization permissions and if the {% data variables.enterprise.prodname_managed_user %} has admin access to the repository.
 * Can install {% data variables.product.prodname_github_apps %} on an organization if the {% data variables.enterprise.prodname_managed_user %} is an organization owner.
+* Can purchase and install paid {% data variables.product.prodname_github_apps %} only if the {% data variables.enterprise.prodname_managed_user %} is an enterprise owner.
 * Can create {% data variables.product.prodname_github_apps %} and {% data variables.product.prodname_oauth_apps %}.
 
   {% data reusables.emus.oauth-app-note %}


### PR DESCRIPTION
Adding a line to specify the EMU limitation for paid GitHub App plans.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: https://github.com/github/marketplace/issues/3659#issuecomment-2244368281

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adding a line to specify the EMU limitation for paid GitHub App plans to clarify that Enterprise Managed Users can set up paid GitHub App plans _only_ if they are enterprise owners. Enterprise members cannot.

Issue stating that this limitation is intended for EMUs: https://github.com/github/marketplace/issues/3361

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
