### PR TITLE
Update about-security-overview.md for customer feedback

### DIFF
--- a/content/code-security/security-overview/about-security-overview.md
+++ b/content/code-security/security-overview/about-security-overview.md
@@ -150,7 +150,7 @@ If you are an organization or team member, you can view security overview for th
 | `admin` access for one or more repositories | View data for those repositories |  View data for those repositories, and enable and disable security features |
 | `write` access for one or more repositories | View {% data variables.product.prodname_code_scanning %} and {% data variables.product.prodname_dependabot %} data for those repositories | No access |
 | `read` or `triage` access for one or more repositories | No access | No access |
-| Security alert access for one or more repositories | View all security alert data for those repositories | No access 
+| Security alert access for one or more repositories | View all security alert data for those repositories | No access |
 | Custom organization role with permission to view one or more types of security alert |  View allowed alert data for all repositories in all views  | No access |
 
 {% endrowheaders %}

--- a/content/code-security/security-overview/about-security-overview.md
+++ b/content/code-security/security-overview/about-security-overview.md
@@ -128,27 +128,29 @@ For information about permissions, see "[Permission to view data in security ove
 
 If you are an owner or security manager for an organization, you can see data for all the repositories in the organization in all views.
 
-If you are an organization member, you can view security overview for the organization and see data for repositories where you have access.
+If you are an organization or team member, you can view security overview for the organization and see data for repositories where you have an appropriate level of access.
 
 {% ifversion security-overview-dashboard %}
 {% rowheaders %}
 
-| Organization member with | Overview dashboard (beta) view | Risk and alerts views | Coverage view |
+| Organization or team member with | Overview dashboard (beta) view | Risk and alerts views | Coverage view |
 |--------------------|-------------|---------------------|---------|
 | `admin` access for one or more repositories | View data for those repositories | View data for those repositories |  View data for those repositories{% ifversion security-configurations-beta-and-pre-beta %}, and enable and disable security features{% endif %} |
-| `write` access for one or more repositories | View {% data variables.product.prodname_code_scanning %} and {% data variables.product.prodname_dependabot %} data for those repositories | View {% data variables.product.prodname_code_scanning %} and {% data variables.product.prodname_dependabot %} data for those repositories | No access for those repositories |
-| Security alert access for one or more repositories | View all security alert data for those repositories | View all security alert data for those repositories | No access for those repositories
+| `write` access for one or more repositories | View {% data variables.product.prodname_code_scanning %} and {% data variables.product.prodname_dependabot %} data for those repositories | View {% data variables.product.prodname_code_scanning %} and {% data variables.product.prodname_dependabot %} data for those repositories | No access |
+| `read` or `triage` access for one or more repositories | No access | No access | No access |
+| Security alert access for one or more repositories | View all security alert data for those repositories | View all security alert data for those repositories | No access |
 | Custom organization role with permission to view one or more types of security alert | View allowed alert data for all repositories |  View allowed alert data for all repositories in all views  | No access |
 
 {% endrowheaders %}
 {% else %}
 {% rowheaders %}
 
-| Organization member with | Risk and alerts views | Coverage view |
+| Organization or team member with | Risk and alerts views | Coverage view |
 |--------------------|-------------|---------------------|
 | `admin` access for one or more repositories | View data for those repositories |  View data for those repositories, and enable and disable security features |
-| `write` access for one or more repositories | View {% data variables.product.prodname_code_scanning %} and {% data variables.product.prodname_dependabot %} data for those repositories | No access for those repositories |
-| Security alert access for one or more repositories | View all security alert data for those repositories | No access for those repositories
+| `write` access for one or more repositories | View {% data variables.product.prodname_code_scanning %} and {% data variables.product.prodname_dependabot %} data for those repositories | No access |
+| `read` or `triage` access for one or more repositories | No access | No access |
+| Security alert access for one or more repositories | View all security alert data for those repositories | No access 
 | Custom organization role with permission to view one or more types of security alert |  View allowed alert data for all repositories in all views  | No access |
 
 {% endrowheaders %}


### PR DESCRIPTION
### What's being changed (if available, include any code snippets, screenshots, or gifs):

1. Updates the permissions information to explicitly mention team members (previously we assumed that organization members was enough since it contains team members).
2. Explicitly tells people that anyone with `read` or `triage` access only cannot view a repository at all.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
