### PR TITLE
Update github-marketplace-developer-agreement.md

### DIFF
--- a/content/site-policy/github-terms/github-marketplace-developer-agreement.md
+++ b/content/site-policy/github-terms/github-marketplace-developer-agreement.md
@@ -85,6 +85,7 @@ Notwithstanding any of the requirements set forth in Section 2 (Purpose and Lice
 * (iv) ensuring that Developer Products are not offensive, profane, obscene, libelous or otherwise illegal;
 * (v) ensuring that its Developer Products do not contain or introduce malicious software into Marketplace, a GitHub API, any Usage Data or other data stored or transmitted using Marketplace; and
 * (vi) ensuring that its Developer Products are not designed to or utilized for the purpose of sending commercial electronic messages to any GitHub.com users, agents or End Users without their consent.
+* (vii) ensuring the name and branding of its Developer Products do not imitate existing brands or companies that the publisher is not directly affiliated with. Text like "for GitHub" may be used in the listing title if it clearly indicates integration, and not affiliation, with GitHub. Violations may result in the denial of a request to publish or a listing being removed from the marketplace.
 
 **3.7**	Developer will respect and comply with the technical and policy-implemented limitations of a GitHub API and the restrictions of this Agreement in designing and implementing Developer Products. Developer shall not violate any explicit rate limitations on calling or otherwise utilizing a GitHub API.
 


### PR DESCRIPTION
Adding copy to specify that publishers cannot publish listings with the name or branding of existing companies they are not affiliated with.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Adding copy to specify that publishers cannot publish listings with the name or branding of existing companies they are not affiliated with.

### What's being changed (if available, include any code snippets, screenshots, or gifs):


### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
