### PR TITLE
(Fixed) Move period inside ending quotations in hanging-your-two-fact…

### DIFF
--- a/data/reusables/two_fa/enable-totp-app-method.md
+++ b/data/reusables/two_fa/enable-totp-app-method.md
@@ -5,4 +5,4 @@
 
    ![Screenshot of the "Setup authenticator app" section of the 2FA settings. A link, labeled "setup key", is highlighted in orange.](/assets/images/help/2fa/ghes-3.8-and-higher-2fa-wizard-app-click-code.png)
 
-1. The TOTP application saves your account on {% data variables.location.product_location %} and generates a new authentication code every few seconds. On {% data variables.product.product_name %}, type the code into the field under "Verify the code from the app".
+1. The TOTP application saves your account on {% data variables.location.product_location %} and generates a new authentication code every few seconds. On {% data variables.product.product_name %}, type the code into the field under "Verify the code from the app."


### PR DESCRIPTION
…or-authentication-method#adding-a-totp-app

Fixes #34225


### Why:
To maintain consistency with [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide)

Closes: 
34225

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Moved the period inside the ending quotations at 

> On GitHub, type the code into the field under "Verify the code from the app".

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
