### PR TITLE
Added needed call of google-github-actions/auth with credentials and changed version of google-github-actions calls

### DIFF
--- a/content/actions/deployment/deploying-to-your-cloud-provider/deploying-to-google-kubernetes-engine.md
+++ b/content/actions/deployment/deploying-to-your-cloud-provider/deploying-to-google-kubernetes-engine.md
@@ -160,8 +160,13 @@ jobs:
     - name: Checkout
       uses: {% data reusables.actions.action-checkout %}
 
+    - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1 # or specify different version if available
+        with:
+          credentials_json: ${{ secrets.GKE_SA_KEY }}
+
     # Setup gcloud CLI
-    - uses: google-github-actions/setup-gcloud@1bee7de035d65ec5da40a31f8589e240eba8fde5
+    - uses: google-github-actions/setup-gcloud@v2 # or specify different version if available
       with:
         service_account_key: {% raw %}${{ secrets.GKE_SA_KEY }}{% endraw %}
         project_id: {% raw %}${{ secrets.GKE_PROJECT }}{% endraw %}
@@ -172,7 +177,7 @@ jobs:
         gcloud --quiet auth configure-docker
 
     # Get the GKE credentials so we can deploy to the cluster
-    - uses: google-github-actions/get-gke-credentials@db150f2cc60d1716e61922b832eae71d2a45938f
+    - uses: google-github-actions/get-gke-credentials@v2 # or specify different version
       with:
         cluster_name: {% raw %}${{ env.GKE_CLUSTER }}{% endraw %}
         location: {% raw %}${{ env.GKE_ZONE }}{% endraw %}


### PR DESCRIPTION
### Why:

Based on my own following the tutorial and usage of .github/workflows/main.yml, I found out, that there is needed to call the auth from google-github-actions for the workflow to work properly. Also the noted versions of google-github-actions were not readable, resp. their meaning was not explained and was not obvious.

When I was solving my problem, I started a discussion at community forum here: [could not load the default credentials error in deploy action to GKE](https://github.com/orgs/community/discussions/135236), where can be seen and explained the problematic part, that leads me to this little modification.
