### PR TITLE
Clarify that the clone is over https

### DIFF
--- a/content/apps/creating-github-apps/writing-code-for-a-github-app/building-ci-checks-with-a-github-app.md
+++ b/content/apps/creating-github-apps/writing-code-for-a-github-app/building-ci-checks-with-a-github-app.md
@@ -861,7 +861,7 @@ To clone a repository, the code will use your {% data variables.product.prodname
 git clone https://x-access-token:TOKEN@github.com/OWNER/REPO.git
 ```
 
-The command above clones a repository over HTTP. It requires the full repository name, which includes the repository owner (user or organization) and the repository name. For example, the [octocat Hello-World](https://github.com/octocat/Hello-World) repository has a full name of `octocat/hello-world`.
+The command above clones a repository over HTTPS. It requires the full repository name, which includes the repository owner (user or organization) and the repository name. For example, the [octocat Hello-World](https://github.com/octocat/Hello-World) repository has a full name of `octocat/hello-world`.
 
 Open your `server.rb` file. In the code block that starts with `helpers do`, where it says `# ADD CLONE_REPOSITORY HELPER METHOD HERE #`, add the following code:
 


### PR DESCRIPTION
### Why:

The text incorrectly suggested that a clone was being made over `HTTP`.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

#### Before

https://docs.github.com/en/apps/creating-github-apps/writing-code-for-a-github-app/building-ci-checks-with-a-github-app#add-code-to-clone-a-repository

<img width="739" alt="image" src="https://github.com/user-attachments/assets/b1fdcb85-bfd3-4cf5-b720-ad2978245edf">

#### After

https://docs-34305-83442c.preview.ghdocs.com/en/apps/creating-github-apps/writing-code-for-a-github-app/building-ci-checks-with-a-github-app#add-code-to-clone-a-repository

<img width="744" alt="image" src="https://github.com/user-attachments/assets/122594a5-679b-4a5a-a15f-0a9423b1d944">



### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
