### PR TITLE
Explicitly state that at least one job is required to run and that without, a workflow will fail

### DIFF
--- a/data/reusables/actions/jobs/section-using-jobs-in-a-workflow.md
+++ b/data/reusables/actions/jobs/section-using-jobs-in-a-workflow.md
@@ -1,4 +1,4 @@
-A workflow run is made up of one or more `jobs`, which run in parallel by default. To run jobs sequentially, you can define dependencies on other jobs using the `jobs.<job_id>.needs` keyword.
+A workflow run is made up of at least one or more `jobs`, which run in parallel by default. Without any jobs to run, a workflow will fail. To run jobs sequentially, you can define dependencies on other jobs using the `jobs.<job_id>.needs` keyword.
 
 Each job runs in a runner environment specified by `runs-on`.
 


### PR DESCRIPTION
### Why:

Closes: #34337

### What's being changed:

The opening paragraph of the overview to:

A workflow run is made up of at least one or more `jobs`, which run in parallel by default. Without any jobs to run, a workflow will fail. To run jobs sequentially, you can define dependencies on other jobs using the `jobs.<job_id>.needs` keyword.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
