### PR TITLE
Update evaluate-expressions-in-workflows-and-actions.md

### DIFF
--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions.md
@@ -132,6 +132,17 @@ env:
 In this example, we're using a ternary operator to set the value of the `MY_ENV_VAR` environment variable based on whether the {% data variables.product.prodname_dotcom %} reference is set to `refs/heads/main` or not. If it is, the variable is set to `value_for_main_branch`. Otherwise, it is set to `value_for_other_branches`.
 It is important to note that the first value after the `&&` must be truthy. Otherwise, the value after the `||` will always be returned.
 
+An other example where a path is set depending on `runner.os`:
+
+{% raw %}
+
+```yaml
+env:
+  MY_ENV_VAR: ${{ runner.os == 'Windows' && format('{0}{1}', env.HOME, '\AppData\Local\ms-playwright') || runner.os == 'Linux' && '~/.cache/ms-playwright' || '~/Library/Caches/ms-playwright' }}
+```
+
+{% endraw %}
+
 ## Functions
 
 {% data variables.product.prodname_dotcom %} offers a set of built-in functions that you can use in expressions. Some functions cast values to a string to perform comparisons. {% data variables.product.prodname_dotcom %} casts data types to a string using these conversions:


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

I want to have a dynamic path depending on `runner.os` in a GitHub workflow. See https://github.com/microsoft/playwright/issues/7249 for the context.

The documentation at https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions helped me. However even with all that documentation it took me a long time to make it work. I would like to add an example to help others that would face a similar use case.

Closes: Nothing

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This pull request add an example where a value is a path dynamic per OS.

This example uses `format` and `env.HOME` to build the path on windows, something as follow:

```yml
path: format('{0}{1}', env.HOME, '\AppData\Local\ms-playwright')
```

This means something before have to set `env.HOME` which can be achieved like this:

```yml
- name: Put $HOME in env
  if: runner.os == 'windows'
  run: echo "HOME=$HOME" | Out-File -FilePath $env:GITHUB_ENV -Append
```

I don't know if this should be added to the documentation but if we don't add it people will have trouble to make it work.

I hope you'll find this useful, thank you.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
