### PR TITLE
Remove .git from directory name

### DIFF
--- a/content/repositories/creating-and-managing-repositories/duplicating-a-repository.md
+++ b/content/repositories/creating-and-managing-repositories/duplicating-a-repository.md
@@ -37,7 +37,7 @@ Before you can push the original repository to your new copy, or _mirror_, of th
 1. Mirror-push to the new repository.
 
    ```shell
-   cd OLD-REPOSITORY.git
+   cd OLD-REPOSITORY
    git push --mirror https://{% data variables.product.product_url %}/EXAMPLE-USER/NEW-REPOSITORY.git
    ```
 
@@ -45,7 +45,7 @@ Before you can push the original repository to your new copy, or _mirror_, of th
 
    ```shell
    cd ..
-   rm -rf OLD-REPOSITORY.git
+   rm -rf OLD-REPOSITORY
    ```
 
 ## Mirroring a repository that contains {% data variables.large_files.product_name_long %} objects
@@ -60,7 +60,7 @@ Before you can push the original repository to your new copy, or _mirror_, of th
 1. Navigate to the repository you just cloned.
 
    ```shell
-   cd OLD-REPOSITORY.git
+   cd OLD-REPOSITORY
    ```
 
 1. Pull in the repository's {% data variables.large_files.product_name_long %} objects.
@@ -85,7 +85,7 @@ Before you can push the original repository to your new copy, or _mirror_, of th
 
    ```shell
    cd ..
-   rm -rf OLD-REPOSITORY.git
+   rm -rf OLD-REPOSITORY
    ```
 
 ## Mirroring a repository in another location


### PR DESCRIPTION
By default, `git clone` creates a directory with the same name as the repository, but it does not append `.git` to the directory name.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
By default, `git clone` creates a directory with the same name as the repository, but it does not append `.git` to the directory name.
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
