### PR TITLE
Remove port mapping for container jobs

### DIFF
--- a/content/actions/use-cases-and-examples/using-containerized-services/creating-postgresql-service-containers.md
+++ b/content/actions/use-cases-and-examples/using-containerized-services/creating-postgresql-service-containers.md
@@ -67,9 +67,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests
@@ -123,9 +120,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
 ```
 
 ### Configuring the steps for jobs in containers


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Verbatim from the [documentation](https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/creating-postgresql-service-containers#running-jobs-in-containers):

> Docker containers on the same user-defined bridge network expose all ports to each other, so you don't need to map any of the service container ports to the Docker host.

Closes: N/A

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Port mapping from two places where the task are running in a container, not in the host, as in where `container:` exists, is being removed:

![image](https://github.com/user-attachments/assets/569cc3ca-fd06-4eaa-94ed-92365b010f43)

I've tested it in a workflow without `ports`; it works as expected.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
