### PR TITLE
docs: add required title parameter to message command

### DIFF
--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
@@ -159,7 +159,7 @@ echo "::notice file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
 {% powershell %}
 
 ```powershell copy
-Write-Output "::notice file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
+Write-Output "::notice file=app.js,line=1,col=5,endColumn=7,title=YOUR-TITLE::Missing semicolon"
 ```
 
 {% endpowershell %}
@@ -179,7 +179,7 @@ Creates a warning message and prints the message to the log. {% data reusables.a
 {% bash %}
 
 ```bash copy
-echo "::warning file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
+echo "::warning file=app.js,line=1,col=5,endColumn=7,title=YOUR-TITLE::Missing semicolon"
 ```
 
 {% endbash %}
@@ -187,7 +187,7 @@ echo "::warning file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semic
 {% powershell %}
 
 ```powershell copy
-Write-Output "::warning file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
+Write-Output "::warning file=app.js,line=1,col=5,endColumn=7,title=YOUR-TITLE::Missing semicolon"
 ```
 
 {% endpowershell %}
@@ -207,7 +207,7 @@ Creates an error message and prints the message to the log. {% data reusables.ac
 {% bash %}
 
 ```bash copy
-echo "::error file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
+echo "::error file=app.js,line=1,col=5,endColumn=7,title=YOUR-TITLE::Missing semicolon"
 ```
 
 {% endbash %}
@@ -215,7 +215,7 @@ echo "::error file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicol
 {% powershell %}
 
 ```powershell copy
-Write-Output "::error file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
+Write-Output "::error file=app.js,line=1,col=5,endColumn=7,title=YOUR-TITLE::Missing semicolon"
 ```
 
 {% endpowershell %}

--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
@@ -159,7 +159,7 @@ echo "::notice file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
 {% powershell %}
 
 ```powershell copy
-Write-Output "::notice file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
+Write-Output "::notice file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
 ```
 
 {% endpowershell %}
@@ -179,7 +179,7 @@ Creates a warning message and prints the message to the log. {% data reusables.a
 {% bash %}
 
 ```bash copy
-echo "::warning file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
+echo "::warning file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
 ```
 
 {% endbash %}
@@ -187,7 +187,7 @@ echo "::warning file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
 {% powershell %}
 
 ```powershell copy
-Write-Output "::warning file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
+Write-Output "::warning file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
 ```
 
 {% endpowershell %}
@@ -207,7 +207,7 @@ Creates an error message and prints the message to the log. {% data reusables.ac
 {% bash %}
 
 ```bash copy
-echo "::error file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
+echo "::error file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
 ```
 
 {% endbash %}
@@ -215,7 +215,7 @@ echo "::error file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
 {% powershell %}
 
 ```powershell copy
-Write-Output "::error file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
+Write-Output "::error file=app.js,line=1,col=5,endColumn=7,title=Syntax::Missing semicolon"
 ```
 
 {% endpowershell %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Message command example does not comply with the required parameters table.

Closes: 
https://github.com/github/docs/issues/34450

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Add the required `title` parameter to message command examples

### Check off the following:

- [X] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
