### PR TITLE
Update link to "vulnerability" in CVE program glossary

### DIFF
--- a/content/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database.md
+++ b/content/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database.md
@@ -116,4 +116,4 @@ The {% data variables.product.prodname_advisory_database %} uses the CVSS levels
 ## Further reading
 
 * "[AUTOTITLE](/code-security/dependabot/dependabot-alerts/about-dependabot-alerts)"
-* The CVE Program's [definition of "vulnerability"](https://www.cve.org/ResourcesSupport/Glossary#vulnerability)
+* The CVE Program's [definition of "vulnerability"](https://www.cve.org/ResourcesSupport/Glossary#glossaryVulnerability)


### PR DESCRIPTION
This fixes a broken URL "#" fragment for the glossary item.

### Why:

Closes #34470

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This modifies the URL in the link to the [CVE program glossary](https://www.cve.org/ResourcesSupport/Glossary) so that instead of [having the old broken fragment](https://www.cve.org/ResourcesSupport/Glossary#vulnerability) it has [the current fragment for the specific definition](https://www.cve.org/ResourcesSupport/Glossary#glossaryVulnerability).

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
