### PR TITLE
Clarify default org member permissions

### DIFF
--- a/content/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/setting-base-permissions-for-an-organization.md
+++ b/content/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/setting-base-permissions-for-an-organization.md
@@ -20,7 +20,7 @@ shortTitle: Set base permissions
 
 You can set base permissions that apply to all members of an organization when accessing any of the organization's repositories. Base permissions do not apply to outside collaborators.
 
-{% ifversion fpt or ghec %}By default, members of an organization will have **Read** permissions to the organization's repositories.{% endif %}
+{% ifversion fpt or ghec %}By default, members of an organization will have **Read** permissions to the organization's public repositories.{% endif %}
 
 If someone with admin access to an organization's repository grants a member a higher level of access for the repository, the higher level of access overrides the base permission.
 


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs/issues/34620

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Clarifies that organization members, by default, only have Read permissions for an organization's public repositories.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
