### PR TITLE
docs: add alternative to bfg on about-large-files-on-github.md

### DIFF
--- a/content/repositories/working-with-files/managing-large-files/about-large-files-on-github.md
+++ b/content/repositories/working-with-files/managing-large-files/about-large-files-on-github.md
@@ -104,7 +104,37 @@ If the file was added with your most recent commit, and you have not pushed to {
 
 ### Removing a file that was added in an earlier commit
 
+#### BFG Repo-Cleaner
+
 If you added a file in an earlier commit, you need to remove it from the repository's history. To remove files from the repository's history, you can use the BFG Repo-Cleaner or the `git filter-repo` command. For more information see "[AUTOTITLE](/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository)."
+
+#### git rebase 
+
+Alternatively, `git rebase` may be used to alter the commit in the earlier commit. First, you need to identify the hash of the commit where the change happened. For instance, to modify `35da8436`, you may use
+
+```shell
+$ git rebase --interactive 35da8436~
+```
+
+The tilde (`~`) is strictly necessary to reapply the subsequent commits. `git rebase` will now open an editor of structure:
+
+```shell
+pick 35da8436 style: add new resources for roofs and clean up some old ones
+pick 09f6df0d feat/WIP!: major restructure and rewrite of components
+```
+
+Change `pick` to `edit` in the line of the commit to be modified. Once the file is saved, the HEAD of the repository will be at the named commit. The commit may now be modified. Repeat the steps mentioned previously:
+
+ ```shell
+   $ git rm --cached GIANT_FILE
+   # Stage our giant file for removal, but leave it on disk
+   $ git commit --amend -CHEAD
+   # Amend the previous commit with your change
+   # Simply making a new commit won't work, as you need
+   # to remove the file from the unpushed history as well
+ ```
+
+Consequently, you may return to the original HEAD using `git rebase --continue` and push the smaller commits using `git push`.
 
 ## Distributing large binaries
 


### PR DESCRIPTION
With all due respect, I found BFG really clunky to work with. Hence, I searched for an alternative. Credits to ZelluX (https://stackoverflow.com/a/1186549).

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

BFG is a mighty tool, but may have to much overhead for a simple solution concerning big files in a previous commit. 

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Just the documentation on large files and how to handle them in order to be able to push to github.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
