### PR TITLE
docs: Update code block formatting

### DIFF
--- a/content/authentication/troubleshooting-ssh/using-ssh-over-the-https-port.md
+++ b/content/authentication/troubleshooting-ssh/using-ssh-over-the-https-port.md
@@ -20,10 +20,10 @@ shortTitle: Use SSH over HTTPS port
 
 To test if SSH over the HTTPS port is possible, run this SSH command:
 
-```shell
+```bash
 $ ssh -T -p 443 git@ssh.github.com
-> Hi USERNAME! You've successfully authenticated, but GitHub does not
-> provide shell access.
+# Hi USERNAME! You've successfully authenticated, but GitHub does not
+# provide shell access.
 ```
 
 {% note %}
@@ -55,10 +55,10 @@ Host {% data variables.product.product_url %}
 
 You can test that this works by connecting once more to {% data variables.location.product_location %}:
 
-```shell
+```bash
 $ ssh -T git@{% data variables.product.product_url %}
-> Hi USERNAME! You've successfully authenticated, but GitHub does not
-> provide shell access.
+# Hi USERNAME! You've successfully authenticated, but GitHub does not
+# provide shell access.
 ```
 
 ## Updating known hosts
@@ -66,12 +66,12 @@ $ ssh -T git@{% data variables.product.product_url %}
 The first time you interact with {% data variables.product.prodname_dotcom %} after switching to port 443, you may get a warning message
 that the host wasn't found in `known_hosts`, or that it was found by another name.
 
-```shell
-> The authenticity of host '[ssh.github.com]:443 ([140.82.112.36]:443)' can't be established.
-> ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
-> This host key is known by the following other names/addresses:
->     ~/.ssh/known_hosts:32: github.com
-> Are you sure you want to continue connecting (yes/no/[fingerprint])?
+```bash
+# The authenticity of host '[ssh.github.com]:443 ([140.82.112.36]:443)' can't be established.
+# ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
+# This host key is known by the following other names/addresses:
+#     ~/.ssh/known_hosts:32: github.com
+# Are you sure you want to continue connecting (yes/no/[fingerprint])?
 ```
 
 It is safe to answer "yes" to this question, assuming that the SSH fingerprint matches


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #34621 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Changes the language identifier of code blocks (which contain command output) from `shell` to `bash` and replaces `>` characters with `#`  as suggested in the issue mentioned above.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
