### PR TITLE
Update setting-your-commit-email-address.md

### DIFF
--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.md
@@ -112,3 +112,15 @@ You can change the email address associated with commits you make in a single re
    ```
 
 1. {% data reusables.user-settings.link_email_with_your_account %}
+
+### Resetting commits that violate your email privacy settings
+
+If you have accidentally committed to the repository with a public e-mail that should be private you will need to reset the author in your local commit by following these steps: 
+
+```shell
+git config --global user.email "ID+USERNAME@users.noreply.github.com"
+git rebase -i
+git commit --amend --reset-author
+git rebase --continue
+git push
+```


### PR DESCRIPTION
If you have your public email accidentally in a new git config, you must reset commits that have this e-mail address.  This is an attempt to include this in the docs near email settings.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: This documentation didn't cover an experience I ran into

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):  Just some added documentation to the email preferences.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
