### PR TITLE
Removed unnecessary comma in billing documentation

### DIFF
--- a/content/billing/managing-your-github-billing-settings/adding-a-sales-tax-certificate.md
+++ b/content/billing/managing-your-github-billing-settings/adding-a-sales-tax-certificate.md
@@ -18,7 +18,7 @@ If you're a {% data variables.product.company_short %} customer in the United St
 * PNG (`.png`)
 * PDF (`.pdf`)
 
-Your account is marked as tax exempt, while your certificate is reviewed. If your certificate is not approved, you will need to upload a new one.
+Your account is marked as tax exempt while your certificate is reviewed. If your certificate is not approved, you will need to upload a new one.
 
 ## Adding a sales tax exemption certificate to your organization account
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: Remove unnecessary comma in adding-a-sales-tax-certificate.md

Closes: Issue #34672

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
