### PR TITLE
Update `about-code-owners.md`

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -135,7 +135,12 @@ apps/ @octocat
 
 # In this example, @octocat owns any file in the `/apps`
 # directory in the root of your repository except for the `/apps/github`
-# subdirectory, as its owners are left empty.
+# subdirectory, as its owners are left empty. Be careful, ownership of
+# `/apps/github` will not revert back to some other owner previously
+# defined. Leaving `/apps/github` without an owner means that no one
+# owns it. Changes to this directory and its files can be introduced
+# with the approval of any user with at least write access to the
+# repository. 
 /apps/ @octocat
 /apps/github
 

--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md
@@ -135,12 +135,9 @@ apps/ @octocat
 
 # In this example, @octocat owns any file in the `/apps`
 # directory in the root of your repository except for the `/apps/github`
-# subdirectory, as its owners are left empty. Be careful, ownership of
-# `/apps/github` will not revert back to some other owner previously
-# defined. Leaving `/apps/github` without an owner means that no one
-# owns it. Changes to this directory and its files can be introduced
-# with the approval of any user with at least write access to the
-# repository. 
+# subdirectory, as its owners are left empty. Without an owner, changes
+# to `apps/github` can be made with the approval of any user who has
+# write access to the repository.
 /apps/ @octocat
 /apps/github
 


### PR DESCRIPTION
Adds some more clarification on the use of statements like:

```txt
/apps/github
```

Users might be confused thinking that this means that the ownership reverts back to some previously defined owner, but that is not the case.

---

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #34699

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Adds additional/more explicit information on how these statements in the CODEOWNERS file work.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
