### PR TITLE
Update changing-your-github-username.md

### DIFF
--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-user-account-settings/changing-your-github-username.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-user-account-settings/changing-your-github-username.md
@@ -72,7 +72,7 @@ After you change your username, {% data variables.product.product_name %} will a
 * Web links to your existing repositories will continue to work. This can take a few minutes to complete after you make the change.
 * Command line pushes from your local repository clones to the old remote tracking URLs will continue to work.
 
-If the new owner of your old username creates a repository with the same name as your repository, that will override the redirect entry and your redirect will stop working. Because of this possibility, we recommend you update all existing remote repository URLs after changing your username. For more information, see "[AUTOTITLE](/get-started/getting-started-with-git/managing-remote-repositories)."
+We recommend you update all existing remote repository URLs after changing your username. For more information, see "[AUTOTITLE](/get-started/getting-started-with-git/managing-remote-repositories)."
 
 ## Links to your previous profile page
 


### PR DESCRIPTION
I tried using a repository name that existed on the previous username owner and got the below message which leads me to believe that this isn't possible anymore.

![image](https://github.com/user-attachments/assets/897208a0-8453-43ae-974e-d8cb58f90953)

Since the previous username owner has actually deleted the repository I wasn't able to confirm if the redirection still works.