### PR TITLE
doc: modify the signing commit command

### DIFF
--- a/content/authentication/managing-commit-signature-verification/signing-commits.md
+++ b/content/authentication/managing-commit-signature-verification/signing-commits.md
@@ -33,6 +33,8 @@ You can also manually configure [gpg-agent](http://linux.die.net/man/1/gpg-agent
 
 If you have multiple keys or are attempting to sign commits or tags with a key that doesn't match your committer identity, you should [tell Git about your signing key](/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key).
 
+{% tip %}
+
 **Tips:**
 
 To sign your commit, it is necessary that the information about your account on github is the same with the one on your local machine. You can configure it by setting the `user.name` and the `user.email` through your terminal.

--- a/content/authentication/managing-commit-signature-verification/signing-commits.md
+++ b/content/authentication/managing-commit-signature-verification/signing-commits.md
@@ -33,8 +33,9 @@ You can also manually configure [gpg-agent](http://linux.die.net/man/1/gpg-agent
 
 If you have multiple keys or are attempting to sign commits or tags with a key that doesn't match your committer identity, you should [tell Git about your signing key](/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key).
 
-> ℹ️ **Configure your local information**
-> To sign your commit, it is necessary that the information about your account on github is the same with the one on your local machine. You can configure it by setting the `user.name` and the `user.email` through your terminal.
+**Tips:**
+
+To sign your commit, it is necessary that the information about your account on github is the same with the one on your local machine. You can configure it by setting the `user.name` and the `user.email` through your terminal.
 
    ```shell
    $ git config --global user.name "YOUR_FULL_NAME" 
@@ -43,7 +44,9 @@ If you have multiple keys or are attempting to sign commits or tags with a key t
    # Create or modify your existing email
    ```
 
-If you make a commit and the verification fails due to email not matching, kindly use your `github no-reply` email in the local email config. There is an article on how to get your [github no-reply](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address) email. Once it is updated, you can make the signed commit again using the command below.
+{% endtip %}
+
+If you make a commit and the verification fails due to email not matching, kindly use your `github no-reply` email in the local email config. There is an article on how to get your [github no-reply](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address) email. Once it is updated, you can make the signed commit again using the command below.
 
 1. When committing changes in your local branch, add the `-s` flag to the git commit command:
 

--- a/content/authentication/managing-commit-signature-verification/signing-commits.md
+++ b/content/authentication/managing-commit-signature-verification/signing-commits.md
@@ -33,12 +33,16 @@ You can also manually configure [gpg-agent](http://linux.die.net/man/1/gpg-agent
 
 If you have multiple keys or are attempting to sign commits or tags with a key that doesn't match your committer identity, you should [tell Git about your signing key](/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key).
 
-> ℹ️ *Configure your local information*
+> ℹ️ **Configure your local information**
 > To sign your commit, it is necessary that the information about your account on github is the same with the one on your local machine. You can configure it by setting the `user.name` and the `user.email` through your terminal.
- ```shell
-$ git config --global user.name "Leom Ayodele" 
-$ git config --global user.email "leomayodele@mail.com"
-```
+
+   ```shell
+   $ git config --global user.name "YOUR_FULL_NAME" 
+   # Create or modify your existing username
+   $ git config --global user.email "YOUR_EMAIL"
+   # Create or modify your existing email
+   ```
+
 If you make a commit and the verification fails due to email not matching, kindly use your `github no-reply` email in the local email config. There is an article on how to get your [github no-reply](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address) email. Once it is updated, you can make the signed commit again using the command below.
 
 1. When committing changes in your local branch, add the `-s` flag to the git commit command:

--- a/content/authentication/managing-commit-signature-verification/signing-commits.md
+++ b/content/authentication/managing-commit-signature-verification/signing-commits.md
@@ -33,10 +33,18 @@ You can also manually configure [gpg-agent](http://linux.die.net/man/1/gpg-agent
 
 If you have multiple keys or are attempting to sign commits or tags with a key that doesn't match your committer identity, you should [tell Git about your signing key](/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key).
 
-1. When committing changes in your local branch, add the -S flag to the git commit command:
+> ℹ️ *Configure your local information*
+> To sign your commit, it is necessary that the information about your account on github is the same with the one on your local machine. You can configure it by setting the `user.name` and the `user.email` through your terminal.
+ ```shell
+$ git config --global user.name "Leom Ayodele" 
+$ git config --global user.email "leomayodele@mail.com"
+```
+If you make a commit and the verification fails due to email not matching, kindly use your `github no-reply` email in the local email config. There is an article on how to get your [github no-reply](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address) email. Once it is updated, you can make the signed commit again using the command below.
+
+1. When committing changes in your local branch, add the `-s` flag to the git commit command:
 
    ```shell
-   $ git commit -S -m "YOUR_COMMIT_MESSAGE"
+   $ git commit -s -m "YOUR_COMMIT_MESSAGE"
    # Creates a signed commit
    ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
The existing article instruct on how to sign a commit, but the provided command was wrong. I used the command, but it was not working until I was able to figure it out. 

>The existing command: `git commit -S -m "YOUR_COMMIT_MESSAGE"`

>Correct command: `git commit -s -m "YOUR_COMMIT_MESSAGE"`

I also provided an additional context to why the signing might fail if the email on the local machine and remote (github) does not match.

Closes: 

N/A

### What's being changed (if available, include any code snippets, screenshots, or gifs):
![command](https://github.com/user-attachments/assets/8fdaa3e4-4791-4bfe-847b-a147f6fa10ff)


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
