### PR TITLE
doc: include a tip on how to get your Github ID

### DIFF
--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.md
@@ -59,7 +59,6 @@ To ensure that commits are attributed to you and appear in your contributions gr
 **Tips:**
 
 If you are finding it difficult to get your `Github ID`, you can easily do that by using the Github API. Pass in your username, and you will get your information, including the ID. 
-
 You can copy the URL below and run it on your browser directly, or through any API testing client.
 
    ```text

--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.md
@@ -58,8 +58,7 @@ To ensure that commits are attributed to you and appear in your contributions gr
 
 **Tips:**
 
-If you are finding it difficult to get your `Github ID`, you can easily do that by using the Github API. Pass in your username, and you will get your information, including the ID. 
-You can copy the URL below and run it on your browser directly, or through any API testing client.
+If you are finding it difficult to get your `Github ID`, you can easily do that by using the Github API. Pass in your username, and you will get your information, including the ID. You can copy the URL below and run it on your browser directly, or through any API testing client.
 
    ```text
    https://api.github.com/users/your-username

--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.md
@@ -54,6 +54,21 @@ To ensure that commits are attributed to you and appear in your contributions gr
 
 {% endnote %}
 
+{% tip %}
+
+**Tips:**
+
+If you are finding it difficult to get your `Github ID`, you can easily do that by using the Github API. Pass in your username, and you will get your information, including the ID. 
+
+You can copy the URL below and run it on your browser directly, or through any API testing client.
+
+   ```text
+   https://api.github.com/users/your-username
+   # Returns a json response, containing your Github information, including your ID.
+   ```
+
+{% endtip %}
+
 If you use your `noreply` email address for {% data variables.product.product_name %} to make commits and then [change your username](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-user-account-settings/changing-your-github-username), those commits will not be associated with your account on {% data variables.location.product_location %}. This does not apply if you're using the ID-based `noreply` address from {% data variables.product.product_name %}. For more information, see "[AUTOTITLE](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-user-account-settings/changing-your-github-username)."{% endif %}
 
 ## Setting your commit email address on {% data variables.product.prodname_dotcom %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
The existing content tells the reader the `GitHub no-reply` email format but did not tell the readers how to get their `Github ID`. My PR added a tip on how the reader can get their `Github ID` and be able to formulate their `no-reply` email as explained in the content.

Closes: 
N/A

### What's being changed (if available, include any code snippets, screenshots, or gifs):
I included the tip, immediately after the `Note`.

![Note](https://github.com/user-attachments/assets/4b553403-319c-4cc5-ae4a-aa760db479ce)


### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
