### PR TITLE
Add context information for `jobs.<job_id>.uses`

### DIFF
--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs.md
@@ -88,7 +88,7 @@ Different contexts are available throughout a workflow run. For example, the `se
 
 In addition, some functions may only be used in certain places. For example, the `hashFiles` function is not available everywhere.
 
-The following table indicates where each context and special function can be used within a workflow. Unless listed below, a function can be used anywhere.
+The following table lists the restrictions on where each context and special function can be used within a workflow. The listed contexts are only available for the given workflow key, and may not be used anywhere else. Unless listed below, a function can be used anywhere.
 
 | Workflow key | Context | Special functions |
 | ---- | ------- | ----------------- |

--- a/data/reusables/actions/reusable-workflow-calling-syntax.md
+++ b/data/reusables/actions/reusable-workflow-calling-syntax.md
@@ -3,4 +3,4 @@
 
 In the first option, `{ref}` can be a SHA, a release tag, or a branch name. If a release tag and a branch have the same name, the release tag takes precedence over the branch name. Using the commit SHA is the safest option for stability and security. For more information, see "[AUTOTITLE](/actions/security-guides/security-hardening-for-github-actions#reusing-third-party-workflows)."
 
-If you use the second syntax option (without `{owner}/{repo}` and `@{ref}`) the called workflow is from the same commit as the caller workflow. Ref prefixes such as `refs/heads` and `refs/tags` are not allowed.
+If you use the second syntax option (without `{owner}/{repo}` and `@{ref}`) the called workflow is from the same commit as the caller workflow. Ref prefixes such as `refs/heads` and `refs/tags` are not allowed. You cannot use contexts or expressions in this keyword.


### PR DESCRIPTION
### Why:

As far as I can tell, this property does not have access to any context and needs to be a statically defined string. If this is incorrect, it'd be great to have some clarification here.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Add row for `jobs.<job_id>.uses` into context availability table. Alternatively, a note at the top of this section could be used instead saying indicating that if the key is not listed in the table, it does not/may not support expression evaluation from context data.

As a third option, a note about this behavior could be added to the [relevant section on the workflow syntax page](https://docs-34833-5eac20.preview.ghdocs.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_iduses).

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).
  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
