### PR TITLE
Update configuring-notifications.md to add link for Custom Routing

### DIFF
--- a/content/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications.md
+++ b/content/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications.md
@@ -201,7 +201,7 @@ If you are a member of more than one organization, you can configure each one to
 {% data reusables.notifications.access_notifications %}
 {% data reusables.notifications-v2.manage-notifications %}
 {% ifversion update-notification-settings-22 %}
-1. Under "Default notifications email", click **Custom routing**.
+1. Under "Default notifications email", click **[Custom routing](https://github.com/settings/notifications/custom_routing)**.
 
    ![Screenshot of the "Default notifications email" section. A button, titled "Custom routing", is highlighted with an orange outline.](/assets/images/help/notifications/custom-router-emphasized.png)
 


### PR DESCRIPTION
Add link to the Custom Routing URL.


### Why:

Shorten the path to reaching the page needed.

Closes: 

N/A

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
