### PR TITLE
Fix container<->host port mapping notes

### DIFF
--- a/content/actions/use-cases-and-examples/using-containerized-services/about-service-containers.md
+++ b/content/actions/use-cases-and-examples/using-containerized-services/about-service-containers.md
@@ -84,11 +84,11 @@ You can map service containers ports to the Docker host using the `ports` keywor
 |------------------|--------------|
 | `8080:80` |	Maps TCP port 80 in the container to port 8080 on the Docker host. |
 | `8080:80/udp` |	Maps UDP port 80 in the container to port 8080 on the Docker host. |
-| `8080/udp`	| Map a randomly chosen UDP port in the container to UDP port 8080 on the Docker host. |
+| `8080/udp`	| Maps a randomly chosen port on the Docker host to UDP port 8080 in the container. |
 
 When you map ports using the `ports` keyword, {% data variables.product.prodname_dotcom %} uses the `--publish` command to publish the container’s ports to the Docker host. For more information, see "[Docker container networking](https://docs.docker.com/config/containers/container-networking/)" in the Docker documentation.
 
-When you specify the Docker host port but not the container port, the container port is randomly assigned to a free port. {% data variables.product.prodname_dotcom %} sets the assigned container port in the service container context. For example, for a `redis` service container, if you configured the Docker host port 5432, you can access the corresponding container port using the `job.services.redis.ports[5432]` context. For more information, see "[AUTOTITLE](/actions/learn-github-actions/contexts#job-context)."
+When you specify the container port but not the Docker host port, the container port is randomly assigned to a free port. {% data variables.product.prodname_dotcom %} sets the assigned container port in the service container context. For example, for a `redis` service container, if you configured the Docker host port 5432, you can access the corresponding container port using the `job.services.redis.ports[5432]` context. For more information, see "[AUTOTITLE](/actions/learn-github-actions/contexts#job-context)."
 
 ### Example mapping Redis ports
 

--- a/content/actions/writing-workflows/workflow-syntax-for-github-actions.md
+++ b/content/actions/writing-workflows/workflow-syntax-for-github-actions.md
@@ -1002,7 +1002,7 @@ For more information about the differences between networking service containers
 
 ### Example: Using localhost
 
-This example creates two services: nginx and redis. When you specify the container port but not the host port, the host port is randomly assigned to a free port on host. {% data variables.product.prodname_dotcom %} sets the assigned host port in the {% raw %}`${{job.services.<service_name>.ports}}`{% endraw %} context. In this example, you can access the service host ports using the {% raw %}`${{ job.services.nginx.ports['80'] }}`{% endraw %} and {% raw %}`${{ job.services.redis.ports['6379'] }}`{% endraw %} contexts.
+This example creates two services: nginx and redis. When you specify the container port but not the host port, the container port is randomly assigned to a free port on the host. {% data variables.product.prodname_dotcom %} sets the assigned host port in the {% raw %}`${{job.services.<service_name>.ports}}`{% endraw %} context. In this example, you can access the service host ports using the {% raw %}`${{ job.services.nginx.ports['80'] }}`{% endraw %} and {% raw %}`${{ job.services.redis.ports['6379'] }}`{% endraw %} contexts.
 
 ```yaml
 services:


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The statements are confusing and meant to be the other way around.

Closes: #34459 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Random port on the "host" vs. in the container "container" are swapped

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
