### PR TITLE
Update 'Building and testing Python' for Python 3.13

### DIFF
--- a/content/actions/use-cases-and-examples/building-and-testing/building-and-testing-python.md
+++ b/content/actions/use-cases-and-examples/building-and-testing/building-and-testing-python.md
@@ -70,21 +70,21 @@ We recommend that you have a basic understanding of Python, and pip. For more in
 
        steps:
        - uses: {% data reusables.actions.action-checkout %}
-       - name: Set up Python 3.10
+       - name: Set up Python 3.13
          uses: {% data reusables.actions.action-setup-python %}
          with:
-           python-version: "3.10"
+           python-version: "3.13"
        - name: Install dependencies
          run: |
            python -m pip install --upgrade pip
-           pip install flake8 pytest
+           pip install ruff pytest
            if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-       - name: Lint with flake8
+       - name: Lint and format Python code with ruff
          run: |
-           # stop the build if there are Python syntax errors or undefined names
-           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Lint with the default set of ruff rules with GitHub Annotations
+          ruff check --format=github --target-version=py39
+          # Verify the code is properly formatted
+          ruff format --diff --target-version=py39
        - name: Test with pytest
          run: |
            pytest
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["pypy3.9", "pypy3.10", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: {% data reusables.actions.action-checkout %}
@@ -151,7 +151,7 @@ jobs:
 
 ### Using a specific Python version
 
-You can configure a specific version of Python. For example, 3.10. Alternatively, you can use semantic version syntax to get the latest minor release. This example uses the latest minor release of Python 3.
+You can configure a specific version of Python. For example, 3.12. Alternatively, you can use semantic version syntax to get the latest minor release. This example uses the latest minor release of Python 3.
 
 ```yaml copy
 name: Python package
@@ -180,7 +180,7 @@ jobs:
 
 ### Excluding a version
 
-If you specify a version of Python that is not available, `setup-python` fails with an error such as: `##[error]Version 3.6 with arch x64 not found`. The error message includes the available versions.
+If you specify a version of Python that is not available, `setup-python` fails with an error such as: `##[error]Version 3.7 with arch x64 not found`. The error message includes the available versions.
 
 You can also use the `exclude` keyword in your workflow if there is a configuration of Python that you do not wish to run. For more information, see "[AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategy)."
 
@@ -196,12 +196,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "pypy3.9", "pypy3.10"]
+        python-version: ["3.9", "3.11", "3.13", "pypy3.10"]
         exclude:
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.11"
           - os: windows-latest
-            python-version: "3.9"
+            python-version: "3.11"
 ```
 
 ### Using the default Python version
@@ -259,7 +259,7 @@ steps:
 - uses: {% data reusables.actions.action-checkout %}
 - uses: {% data reusables.actions.action-setup-python %}
   with:
-    python-version: '3.11'
+    python-version: '3.12'
     cache: 'pip'
 - run: pip install -r requirements.txt
 - run: pip test
@@ -294,9 +294,9 @@ steps:
     pytest tests.py --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
 ```
 
-### Using Ruff to lint code
+### Using Ruff to lint and/or format code
 
-The following example installs or upgrades `ruff` and uses it to lint all files. For more information, see [Ruff](https://beta.ruff.rs/docs).
+The following example installs or upgrades `ruff` and uses it to lint all files. For more information, see [Ruff](https://docs.astral.sh/ruff).
 
 ```yaml copy
 steps:
@@ -305,18 +305,16 @@ steps:
   uses: {% data reusables.actions.action-setup-python %}
   with:
     python-version: '3.x'
-- name: Install dependencies
-  run: |
-    python -m pip install --upgrade pip
-    pip install -r requirements.txt
-- name: Lint with Ruff
-  run: |
-    pip install ruff
-    ruff check --output-format=github .
+- name: Install the code linting and formatting tool Ruff
+  run: pipx install ruff
+- name: Lint code with Ruff
+  run: ruff check --output-format=github --target-version=py39
+- name: Check code formatting with Ruff
+  run: ruff format --diff --target-version=py39
   continue-on-error: true
 ```
 
-The linting step has `continue-on-error: true` set. This will keep the workflow from failing if the linting step doesn't succeed. Once you've addressed all of the linting errors, you can remove this option so the workflow will catch new issues.
+The formatting step has `continue-on-error: true` set. This will keep the workflow from failing if the formatting step doesn't succeed. Once you've addressed all of the formatting errors, you can remove this option so the workflow will catch new issues.
 
 ### Running tests with tox
 
@@ -333,7 +331,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.11", "3.13"]
 
     steps:
       - uses: {% data reusables.actions.action-checkout %}
@@ -365,7 +363,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: {% data reusables.actions.action-checkout %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
* Python 3.9 thru 3.13 are the currently supported versions of CPython and they are now all available on GitHub Actions.
    * https://devguide.python.org/versions/#supported-versions
* PyPy 3.9 is no longer downloadable from the PyPy Downloads site.
    * https://pypy.org/download.html
* Upgrade from flake8 to ruff for code linting and formatting because ruff is far faster and more capable.  Flake8 is not compatible with Python modernization via `pyproject.toml`.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
