### PR TITLE
Unifying glossary items format

### DIFF
--- a/content/copilot/building-copilot-extensions/copilot-extensions-glossary.md
+++ b/content/copilot/building-copilot-extensions/copilot-extensions-glossary.md
@@ -37,7 +37,7 @@ Also known as {% data variables.product.prodname_vscode %} Chat extensions, {% d
 
 The foundation for a {% data variables.product.prodname_copilot_extension_short %} that provides the necessary infrastructure, permissions, and context from {% data variables.product.company_short %}, such as user, repo and organization metadata.
 
-##### {% data variables.product.prodname_marketplace %}
+#### {% data variables.product.prodname_marketplace %}
 
 The platform where {% data variables.product.company_short %} approved {% data variables.product.prodname_copilot_extensions %} can be listed publicly and discovered by users.
 
@@ -49,7 +49,7 @@ An extension that appears on the {% data variables.product.prodname_marketplace 
 
 An extension that is only visible and usable by the organization or individual user that created it.
 
-##### Public Extension
+#### Public Extension
 
 An extension that is visible and installable by any {% data variables.product.company_short %} user or organization.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The items "GitHub Marketplace" and "Public Extension" were displayed in smaller size (5 times #) than the rest (4 times #)

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
