### PR TITLE
Mark `converted_to_discussion` issue event type as available in timeline API

### DIFF
--- a/content/rest/using-the-rest-api/issue-event-types.md
+++ b/content/rest/using-the-rest-api/issue-event-types.md
@@ -276,7 +276,7 @@ This event is available for the following issue types.
 
 |  | REST API for issue events | REST API for timeline events |
 |---|---|---|
-|Issues| {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %}|
+|Issues| {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
 
 {% endrowheaders %}
 


### PR DESCRIPTION
### Why:

Closes: #35045

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The `converted_to_discussion` issue event type is now correctly reported as available in the timeline REST API.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
