### PR TITLE
Fix reference link of `user_email.mark_as_unclaimed` GitHub Audit log event

### DIFF
--- a/src/audit-logs/data/fpt/user.json
+++ b/src/audit-logs/data/fpt/user.json
@@ -1726,8 +1726,8 @@
   },
   {
     "action": "user_email.mark_as_unclaimed",
-    "description": "N/A",
-    "docs_reference_links": "An enterprise managed user unclaimed an email address."
+    "description": "An enterprise managed user unclaimed an email address",
+    "docs_reference_links": "N/A"
   },
   {
     "action": "user.enable_collaborators_only",

--- a/src/audit-logs/data/ghec/enterprise.json
+++ b/src/audit-logs/data/ghec/enterprise.json
@@ -4126,8 +4126,8 @@
   },
   {
     "action": "user_email.mark_as_unclaimed",
-    "description": "N/A",
-    "docs_reference_links": "An enterprise managed user unclaimed an email address."
+    "description": "An enterprise managed user unclaimed an email address",
+    "docs_reference_links": "N/A"
   },
   {
     "action": "user_license.create",

--- a/src/audit-logs/data/ghec/user.json
+++ b/src/audit-logs/data/ghec/user.json
@@ -1726,8 +1726,8 @@
   },
   {
     "action": "user_email.mark_as_unclaimed",
-    "description": "N/A",
-    "docs_reference_links": "An enterprise managed user unclaimed an email address."
+    "description": "An enterprise managed user unclaimed an email address",
+    "docs_reference_links": "N/A"
   },
   {
     "action": "user.enable_collaborators_only",

--- a/src/audit-logs/data/ghes-3.14/enterprise.json
+++ b/src/audit-logs/data/ghes-3.14/enterprise.json
@@ -3391,8 +3391,8 @@
   },
   {
     "action": "user_email.mark_as_unclaimed",
-    "description": "N/A",
-    "docs_reference_links": "An enterprise managed user unclaimed an email address."
+    "description": "An enterprise managed user unclaimed an email address",
+    "docs_reference_links": "N/A"
   },
   {
     "action": "user.enable_collaborators_only",

--- a/src/audit-logs/data/ghes-3.14/user.json
+++ b/src/audit-logs/data/ghes-3.14/user.json
@@ -1661,8 +1661,8 @@
   },
   {
     "action": "user_email.mark_as_unclaimed",
-    "description": "N/A",
-    "docs_reference_links": "An enterprise managed user unclaimed an email address."
+    "description": "An enterprise managed user unclaimed an email address",
+    "docs_reference_links": "N/A"
   },
   {
     "action": "user.enable_collaborators_only",

--- a/src/audit-logs/data/ghes-3.15/enterprise.json
+++ b/src/audit-logs/data/ghes-3.15/enterprise.json
@@ -3431,8 +3431,8 @@
   },
   {
     "action": "user_email.mark_as_unclaimed",
-    "description": "N/A",
-    "docs_reference_links": "An enterprise managed user unclaimed an email address."
+    "description": "An enterprise managed user unclaimed an email address",
+    "docs_reference_links": "N/A"
   },
   {
     "action": "user.enable_collaborators_only",

--- a/src/audit-logs/data/ghes-3.15/user.json
+++ b/src/audit-logs/data/ghes-3.15/user.json
@@ -1701,8 +1701,8 @@
   },
   {
     "action": "user_email.mark_as_unclaimed",
-    "description": "N/A",
-    "docs_reference_links": "An enterprise managed user unclaimed an email address."
+    "description": "An enterprise managed user unclaimed an email address",
+    "docs_reference_links": "N/A"
   },
   {
     "action": "user.enable_collaborators_only",


### PR DESCRIPTION
### Why:

Discovered **invalid** contents in `docs_reference_links` attribute value of `user_email.mark_as_unclaimed` GitHub Audit log event.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Please see above.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
