### PR TITLE
Add search syntax tip for whole word searches

### DIFF
--- a/content/search-github/github-code-search/understanding-github-code-search-syntax.md
+++ b/content/search-github/github-code-search/understanding-github-code-search-syntax.md
@@ -316,3 +316,11 @@ By default, code search is case-insensitive, and results will include both upper
 ```text
 /(?-i)True/
 ```
+
+## Whole Words
+
+If you want your search string to be matched as a whole word, you need to use a regular expression that includes the word boundary token `\b`. For example, to search for the string "True" as a whole word, you would use:
+
+```text
+/\bTrue\b/
+```


### PR DESCRIPTION
Whole word searches are very useful in situations when a normal search gives two many false positives. Let's document how to do that in Github code search, so people don't have to look that up in regext tutorials.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Because some times when receiving too many false positives matches, using whole word matching is a popular and effective way to narrow results down to your sought target.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [X] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
