### PR TITLE
Update changing-a-commit-message.md | Remove quotes around external resource in changing-a-commit-message#amending-older-or-multiple-commit-messages #35288

### DIFF
--- a/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message.md
+++ b/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message.md
@@ -43,7 +43,7 @@ If you have already pushed the commit to {% data variables.location.product_loca
 
 {% warning %}
 
-We strongly discourage force pushing, since this changes the history of your repository. If you force push, people who have already cloned your repository will have to manually fix their local history. For more information, see "[Recovering from upstream rebase](https://git-scm.com/docs/git-rebase#_recovering_from_upstream_rebase)" in the Git manual.
+We strongly discourage force pushing, since this changes the history of your repository. If you force push, people who have already cloned your repository will have to manually fix their local history. For more information, see [Recovering from upstream rebase](https://git-scm.com/docs/git-rebase#_recovering_from_upstream_rebase) in the Git manual.
 
 {% endwarning %}
 


### PR DESCRIPTION
…ng-a-commit-message.md

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #35288

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Removed the quotation marks around the external link "Recovering from upstream rebase" in the "Changing a commit message" article to align with the GitHub Docs style guide.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
