### PR TITLE
Fix typo: 'practise' to 'practice'

### DIFF
--- a/content/get-started/start-your-journey/hello-world.md
+++ b/content/get-started/start-your-journey/hello-world.md
@@ -110,7 +110,7 @@ Pull requests are the heart of collaboration on {% data variables.product.produc
 
 As soon as you make a commit, you can open a pull request and start a discussion, even before the code is finished.
 
-In this step, you'll open a pull request in your own repository and then merge it yourself. It's a great way to practise the {% data variables.product.product_name %} flow before working on larger projects.
+In this step, you'll open a pull request in your own repository and then merge it yourself. It's a great way to practice the {% data variables.product.product_name %} flow before working on larger projects.
 
 1. Click the **Pull requests** tab of your `hello-world` repository.
 1. Click **New pull request**.


### PR DESCRIPTION
Corrected a small typo. Sorry, I had to do it for pull request practice!

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: Typo fix

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
