### PR TITLE
Update changing-a-commit-message.md | Remove quotes around external resource in changing-a-commit-message#commit-has-not-been-pushed-online #35287

### DIFF
--- a/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message.md
+++ b/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message.md
@@ -33,7 +33,7 @@ The new commit and message will appear on {% data variables.location.product_loc
 
 {% tip %}
 
-You can change the default text editor for Git by changing the `core.editor` setting. For more information, see "[Basic Client Configuration](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_basic_client_configuration)" in the Git manual.
+You can change the default text editor for Git by changing the `core.editor` setting. For more information, see [Basic Client Configuration](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_basic_client_configuration) in the Git manual.
 
 {% endtip %}
 


### PR DESCRIPTION
…ection

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #35287

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I've removed the quotation marks around the external resource link for "Basic Client Configuration" in the "Changing a Commit Message" article, as per the style guide recommendation.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ x ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ x ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
