### PR TITLE
Fix typo in prompt-engineering-for-github-copilot.md

### DIFF
--- a/content/copilot/using-github-copilot/prompt-engineering-for-github-copilot.md
+++ b/content/copilot/using-github-copilot/prompt-engineering-for-github-copilot.md
@@ -57,7 +57,7 @@ For example, instead of asking {% data variables.product.prodname_copilot_short 
 
 * Write a function to generate a 10 by 10 grid of letters.
 * Write a function to find all words in a grid of letters, given a list of valid words.
-* Write a function to that uses the previous functions to generate a 10 by 10 grid of letters that contains at least 10 words.
+* Write a function that uses the previous functions to generate a 10 by 10 grid of letters that contains at least 10 words.
 * Update the previous function to print the grid of letters and 10 random words from the grid.
 
 ## Avoid ambiguity


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Fixing typo.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The sentence:

> ...a function **to that uses** the....

Should read:

> ...a function **that uses** the....

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
