### PR TITLE
Blank lines causing the quote lines to not be joined to the "tip" formatted block.

### DIFF
--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-personal-account/merging-multiple-personal-accounts.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-personal-account/merging-multiple-personal-accounts.md
@@ -19,13 +19,9 @@ shortTitle: Merge multiple accounts
 
 > [!TIP]
 {% ifversion ghec %}
-
 > {% data variables.product.prodname_emus %} allow an enterprise to provision unique personal accounts for its members through an identity provider (IdP). For more information, see "[AUTOTITLE](/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users)." For other use cases, we recommend using only one personal account to manage both personal and professional repositories.
-
 {% else %}
-
 > We recommend using only one personal account to manage both personal and professional repositories.
-
 {% endif %}
 
 > [!WARNING]

--- a/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-personal-account/merging-multiple-personal-accounts.md
+++ b/content/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-personal-account/merging-multiple-personal-accounts.md
@@ -17,11 +17,16 @@ topics:
 shortTitle: Merge multiple accounts
 ---
 
-> [!TIP]
 {% ifversion ghec %}
+
+> [!TIP]
 > {% data variables.product.prodname_emus %} allow an enterprise to provision unique personal accounts for its members through an identity provider (IdP). For more information, see "[AUTOTITLE](/admin/identity-and-access-management/using-enterprise-managed-users-for-iam/about-enterprise-managed-users)." For other use cases, we recommend using only one personal account to manage both personal and professional repositories.
+
 {% else %}
+
+> [!TIP]
 > We recommend using only one personal account to manage both personal and professional repositories.
+
 {% endif %}
 
 > [!WARNING]


### PR DESCRIPTION
### Why:
The resulting markdown currently renders as an empty TIP block and a subsequent quote block. The goal of this is to join the disconnected quote block to the empty TIP block above it.

Closes: 
https://github.com/github/docs/issues/35364

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Duplicate the TIP block start into both branches of the conditional entry.
#### Old
![image](https://github.com/user-attachments/assets/8e2ddc6b-4c74-46a4-a8ef-7a06c5b3f465)
#### New
![image](https://github.com/user-attachments/assets/1e4e58b1-b9df-4b38-9314-1d067c5dddc6)

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
