### PR TITLE
Fix link to supported packages in 'Code Security > Explore dependencies'

### DIFF
--- a/content/code-security/supply-chain-security/understanding-your-software-supply-chain/exploring-the-dependencies-of-a-repository.md
+++ b/content/code-security/supply-chain-security/understanding-your-software-supply-chain/exploring-the-dependencies-of-a-repository.md
@@ -85,7 +85,7 @@ For public repositories, the dependents view shows how the repository is used by
 
 You may notice some repositories have a "Used by" section in the sidebar of the **Code** tab. Your repository will have a "Used by" section if:
 * The dependency graph is enabled for the repository (see the above section for more details).
-* Your repository contains a package that is published on a [supported package ecosystem](/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#supported-package-ecosystems).
+* Your repository contains a package that is published on a [supported package ecosystem](/code-security/supply-chain-security/understanding-your-software-supply-chain/dependency-graph-supported-package-ecosystems#supported-package-ecosystems).
 * Within the ecosystem, your package has a link to a _public_ repository where the source is stored.
 * More than 100 repositories depend on your package.
 


### PR DESCRIPTION
### Why:

Closes: #35360 

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The "supported package ecosystem" link has been changed to the right target.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
