### PR TITLE
Fix alert header

### DIFF
--- a/content/code-security/dependabot/dependabot-alerts/viewing-and-updating-dependabot-alerts.md
+++ b/content/code-security/dependabot/dependabot-alerts/viewing-and-updating-dependabot-alerts.md
@@ -146,7 +146,7 @@ With a {% data variables.product.prodname_copilot_enterprise %} license, you can
 
 ## Dismissing {% data variables.product.prodname_dependabot_alerts %}
 
-> [!TIP]
+> [!NOTE]
 > You can only dismiss open alerts.
 
 If you schedule extensive work to upgrade a dependency, or decide that an alert does not need to be fixed, you can dismiss the alert. Dismissing alerts that you have already assessed makes it easier to triage new alerts as they appear.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The alert header does not match with the description.

Closes: #35413

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The alert header has been changed from tip to note.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
