### PR TITLE
Fix NuGet typo

### DIFF
--- a/content/admin/monitoring-activity-in-your-enterprise/analyzing-how-your-team-works-with-server-statistics/about-server-statistics.md
+++ b/content/admin/monitoring-activity-in-your-enterprise/analyzing-how-your-team-works-with-server-statistics/about-server-statistics.md
@@ -141,7 +141,7 @@ The following aggregate metrics will be collected and transmitted on a daily bas
 | CF | `packages_stats.ecosystems.nuget.internal_packages_count` | Number of internal NuGet packages |
 | CG | `packages_stats.ecosystems.nuget.user_packages_count` | Number of NuGet packages owned by user accounts |
 | CH | `packages_stats.ecosystems.nuget.organization_packages_count` | Number of NuGet packages owned by organizations |
-| CI | `packages_stats.ecosystems.nuget.daily_download_count` | Number of downloads of Nuget packages |
+| CI | `packages_stats.ecosystems.nuget.daily_download_count` | Number of downloads of NuGet packages |
 | CJ | `packages_stats.ecosystems.nuget.daily_update_count` | Number of NuGet packages updated |
 | CK | `packages_stats.ecosystems.nuget.daily_delete_count` | Number of NuGet packages deleted |
 | CL | `packages_stats.ecosystems.nuget.daily_create_count` | Number of NuGet packages created |

--- a/content/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages.md
+++ b/content/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages.md
@@ -334,8 +334,8 @@ Creating a {% data variables.product.prodname_codeql %} database without buildin
 
 You can ensure a more accurate analysis by taking the following steps:
 
-* Provide access to the public internet or ensure that access to a private Nuget feed is available.
-* Check whether the repository requires multiple versions of the same Nuget dependency. {% data variables.product.prodname_codeql %} can use only one version and usually chooses the newer version where there are multiple versions. This approach may not work for all repositories.
+* Provide access to the public internet or ensure that access to a private NuGet feed is available.
+* Check whether the repository requires multiple versions of the same NuGet dependency. {% data variables.product.prodname_codeql %} can use only one version and usually chooses the newer version where there are multiple versions. This approach may not work for all repositories.
 * Check whether multiple versions of .NET are referenced, for example, `net48`, `net5.0`, and `netstandard1.6`. {% data variables.product.prodname_codeql %} can use only one version and this may affect accuracy.
 * Avoid colliding class names, otherwise this may cause missing method call targets, which has an impact on dataflow analysis.
 
@@ -379,13 +379,13 @@ If `autobuild` detects multiple solution or project files at the same (shortest)
 
 For .NET Core application development on self-hosted runners, the .NET SDK is required (for `dotnet`).
 
-For .NET Framework application development, you will need Microsoft Build Tools (for `msbuild`) and Nuget CLI (for `nuget`).
+For .NET Framework application development, you will need Microsoft Build Tools (for `msbuild`) and NuGet CLI (for `nuget`).
 
 Windows runners require `powershell.exe` to be on the `PATH`.
 
 {% ifversion codeql-no-build-csharp %}
 
-If you plan to create {% data variables.product.prodname_codeql %} databases using `build-mode: none`, you also need to provide access to the public internet, or you must ensure that access to a private Nuget feed is available.
+If you plan to create {% data variables.product.prodname_codeql %} databases using `build-mode: none`, you also need to provide access to the public internet, or you must ensure that access to a private NuGet feed is available.
 
 {% endif %}
 
@@ -404,7 +404,7 @@ For .NET Framework application development, you will require Mono Runtime (to ru
 
 {% ifversion codeql-no-build-csharp %}
 
-If you plan to create {% data variables.product.prodname_codeql %} databases using `build-mode: none`, you also need to provide access to the public internet, or you must ensure that access to a private Nuget feed is available.
+If you plan to create {% data variables.product.prodname_codeql %} databases using `build-mode: none`, you also need to provide access to the public internet, or you must ensure that access to a private NuGet feed is available.
 
 {% endif %}
 

--- a/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
+++ b/content/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file.md
@@ -1027,7 +1027,7 @@ You can give {% data variables.product.prodname_dependabot %} access to private 
 > * Gradle
 > * Maven
 > * Npm
-> * Nuget{% ifversion dependabot-updates-pub-private-registry %}
+> * NuGet{% ifversion dependabot-updates-pub-private-registry %}
 > * Pub{% endif %}
 > * Python
 > * Yarn

--- a/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
@@ -34,7 +34,7 @@ You'll find detailed guidance for the setup of the following package managers:
 * [Gradle](#gradle)
 * [Maven](#maven)
 * [npm](#npm)
-* [Nuget](#nuget){% ifversion dependabot-updates-pub-private-registry %}
+* [NuGet](#nuget){% ifversion dependabot-updates-pub-private-registry %}
 * [pub](#pub){% endif %}
 * [Python](#python)
 * [Yarn](#yarn)
@@ -323,7 +323,7 @@ For scoped dependencies (`@my-org/my-dep`), {% data variables.product.prodname_d
 
 Registries should be configured using the `https` protocol.
 
-### Nuget
+### NuGet
 
 Supported by Artifactory, Artifacts, Cloudsmith, {% data variables.product.prodname_registry %} registry, Nexus, and ProGet.
 

--- a/content/code-security/dependabot/working-with-dependabot/removing-dependabot-access-to-public-registries.md
+++ b/content/code-security/dependabot/working-with-dependabot/removing-dependabot-access-to-public-registries.md
@@ -226,11 +226,11 @@ If the `yarn.lock` file doesn't list the private registry as the dependency sour
 > [!NOTE]
 > For scoped dependencies (`@my-org/my-dep`), {% data variables.product.prodname_dependabot %} requires that the private registry is defined in the project's `.yarnrc` file. To define private registries for individual scopes, use `"@myscope:registry" "https://private_registry_url"`.
 
-## Nuget
+## NuGet
 
-To allow the Nuget ecosystem to only access private registries, you can configure the `dependabot.yml` file. For more information, see "[AUTOTITLE](/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#nuget-feed)."
+To allow the NuGet ecosystem to only access private registries, you can configure the `dependabot.yml` file. For more information, see "[AUTOTITLE](/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#nuget-feed)."
 
-The Nuget ecosystem additionally requires a `nuget.config` file to be checked into the repository, with either a `< clear />` tag in `<packageSources>` section or a key `nuget.org` as true in the `disabledPackageSources` section of the `nuget.config` file.
+The NuGet ecosystem additionally requires a `nuget.config` file to be checked into the repository, with either a `< clear />` tag in `<packageSources>` section or a key `nuget.org` as true in the `disabledPackageSources` section of the `nuget.config` file.
 
 This is an example of a `< clear />` tag in the `packageSources` section of the `nuget.config`.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The are some occurrences where **NuGet** is written as **Nuget**.

Closes: none

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This PR fixes the typo **Nuget** to **NuGet**.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
