### PR TITLE
Fix HTTP header typo

### DIFF
--- a/content/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/configuring-your-copilot-agent-to-communicate-with-github.md
+++ b/content/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/configuring-your-copilot-agent-to-communicate-with-github.md
@@ -23,9 +23,9 @@ For more details and examples of signature verification in specific languages, s
 
 ## Fetching resources from the {% data variables.product.github %} API
 
-Requests to your {% data variables.product.prodname_copilot_agent_short %} will receive an `X-Github-Token` header. This header contains an API token that can be used to fetch resources from the {% data variables.product.github %} API on behalf of the user interacting with your agent. The permissions of this token are the overlap of the user's own permissions and the permissions granted to your {% data variables.product.prodname_github_app %} installation.
+Requests to your {% data variables.product.prodname_copilot_agent_short %} will receive an `X-GitHub-Token` header. This header contains an API token that can be used to fetch resources from the {% data variables.product.github %} API on behalf of the user interacting with your agent. The permissions of this token are the overlap of the user's own permissions and the permissions granted to your {% data variables.product.prodname_github_app %} installation.
 
-For an example of how you might use `X-Github-Token`, see the following code sample:
+For an example of how you might use `X-GitHub-Token`, see the following code sample:
 
 ```typescript
 async function whoami(req) {

--- a/content/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/using-copilots-llm-for-your-agent.md
+++ b/content/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/using-copilots-llm-for-your-agent.md
@@ -24,7 +24,7 @@ You have the option to use {% data variables.product.prodname_copilot_short %}'s
 
 You can call {% data variables.product.prodname_copilot_short %}'s LLM deployment at `{% data variables.copilot.chat_completions_api %}` with a POST request. The request and responses should be in the same format as the OpenAI API.
 
-To authenticate, use the same `X-Github-Token` header sent to your agent. For more information, see "[AUTOTITLE](/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/configuring-your-copilot-agent-to-communicate-with-github#fetching-resources-from-the-github-api)."
+To authenticate, use the same `X-GitHub-Token` header sent to your agent. For more information, see "[AUTOTITLE](/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/configuring-your-copilot-agent-to-communicate-with-github#fetching-resources-from-the-github-api)."
 
 Here is an example of how {% data variables.product.prodname_copilot_short %}'s LLM deployment is used by the Blackbeard extension to generate completions for a user message:
 

--- a/content/copilot/building-copilot-extensions/building-a-copilot-skillset-for-your-copilot-extension/building-copilot-skillsets.md
+++ b/content/copilot/building-copilot-extensions/building-a-copilot-skillset-for-your-copilot-extension/building-copilot-skillsets.md
@@ -25,7 +25,7 @@ Before you begin, make sure you have the following:
     * Be able to verify the signature of requests from {% data variables.product.github %} to authenticate their origin and prevent unauthorized access
     * Be publicly accessible via HTTPS
 
-For more information about signature verification, see "[Verifying that payloads are coming from Github](/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/configuring-your-copilot-agent-to-communicate-with-github#verifying-that-payloads-are-coming-from-github)".
+For more information about signature verification, see "[Verifying that payloads are coming from GitHub](/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/configuring-your-copilot-agent-to-communicate-with-github#verifying-that-payloads-are-coming-from-github)".
 
 ## Configuration requirements
 

--- a/content/graphql/guides/migrating-graphql-global-node-ids.md
+++ b/content/graphql/guides/migrating-graphql-global-node-ids.md
@@ -25,14 +25,14 @@ Additionally, if you currently decode the legacy IDs to extract type information
 
 ## Migrating to the new global IDs
 
-To facilitate migration to the new ID format, you can use the `X-Github-Next-Global-ID` header in your GraphQL API requests. The value of the `X-Github-Next-Global-ID` header can be `1` or `0`. Setting the value to `1` will force the response payload to always use the new ID format for any object that you requested the `id` field for. Setting the value to `0` will revert to default behavior, which is to show the legacy ID or new ID depending on the object creation date.
+To facilitate migration to the new ID format, you can use the `X-GitHub-Next-Global-ID` header in your GraphQL API requests. The value of the `X-GitHub-Next-Global-ID` header can be `1` or `0`. Setting the value to `1` will force the response payload to always use the new ID format for any object that you requested the `id` field for. Setting the value to `0` will revert to default behavior, which is to show the legacy ID or new ID depending on the object creation date.
 
 Here is an example request using a `curl` command:
 
 ```shell
 $ curl \
   -H "Authorization: Bearer $GITHUB_TOKEN" \
-  -H "X-Github-Next-Global-ID: 1" \
+  -H "X-GitHub-Next-Global-ID: 1" \
   https://api.github.com/graphql \
   -d '{ "query": "{ node(id: \"MDQ6VXNlcjM0MDczMDM=\") { id } }" }'
 ```
@@ -43,7 +43,7 @@ Even though the legacy ID `MDQ6VXNlcjM0MDczMDM=` was used in the query, the resp
 {"data":{"node":{"id":"U_kgDOADP9xw"}}}
 ```
 
-With the `X-Github-Next-Global-ID` header, you can find the new ID format for legacy IDs that you reference in your application. You can then update those references with the ID received in the response. You should update all references to legacy IDs and use the new ID format for any subsequent requests to the API.
+With the `X-GitHub-Next-Global-ID` header, you can find the new ID format for legacy IDs that you reference in your application. You can then update those references with the ID received in the response. You should update all references to legacy IDs and use the new ID format for any subsequent requests to the API.
 To perform bulk operations, you can use aliases to submit multiple node queries in one API call. For more information, see "[the GraphQL docs](https://graphql.org/learn/queries/#aliases)."
 
 You can also get the new ID for a collection of items. For example, if you wanted to get the new ID for the last 10 repositories in your organization, you could use a query like this:
@@ -64,7 +64,7 @@ You can also get the new ID for a collection of items. For example, if you wante
 }
 ```
 
-Note that setting `X-Github-Next-Global-ID` to `1` will affect the return value of every `id` field in your query. This means that even when you submit a non-`node` query, you will get back the new format ID if you requested the `id` field.
+Note that setting `X-GitHub-Next-Global-ID` to `1` will affect the return value of every `id` field in your query. This means that even when you submit a non-`node` query, you will get back the new format ID if you requested the `id` field.
 
 ## Sharing feedback
 

--- a/content/rest/using-the-rest-api/getting-started-with-the-rest-api.md
+++ b/content/rest/using-the-rest-api/getting-started-with-the-rest-api.md
@@ -482,9 +482,9 @@ Vary: Accept, Authorization, Cookie, Accept-Encoding, Accept, X-Requested-With
 X-Accepted-Oauth-Scopes: repo
 X-Content-Type-Options: nosniff
 X-Frame-Options: deny
-X-Github-Api-Version-Selected: 2022-08-09
-X-Github-Media-Type: github.v3; format=json
-X-Github-Request-Id: 1C73:26D4:E2E500:1EF78F4:62EC2479
+X-GitHub-Api-Version-Selected: 2022-08-09
+X-GitHub-Media-Type: github.v3; format=json
+X-GitHub-Request-Id: 1C73:26D4:E2E500:1EF78F4:62EC2479
 X-Oauth-Client-Id: 178c6fc778ccc68e1d6a
 X-Oauth-Scopes: gist, read:org, repo, workflow
 X-Ratelimit-Limit: 15000

--- a/data/reusables/codespaces/using-tools-to-access-ports-2.md
+++ b/data/reusables/codespaces/using-tools-to-access-ports-2.md
@@ -3,7 +3,7 @@
 In a terminal on your local computer, enter:
 
 ```shell
-curl ADDRESS -H "X-Github-Token: TOKEN"
+curl ADDRESS -H "X-GitHub-Token: TOKEN"
 ```
 
 Replace `ADDRESS` and `TOKEN` with the values you copied previously.
@@ -16,7 +16,7 @@ Replace `ADDRESS` and `TOKEN` with the values you copied previously.
 
    ![Screenshot of the URL for the forwarded port, pasted into Postman as the GET request URL. The URL is highlighted.](/assets/images/help/codespaces/postman-screenshot-url.png)
 
-1. In the **Headers** tab, create a new entry where the key is "X-Github-Token" and the value is the `GITHUB_TOKEN` you copied previously.
+1. In the **Headers** tab, create a new entry where the key is "X-GitHub-Token" and the value is the `GITHUB_TOKEN` you copied previously.
 
    ![Screenshot of a dummy GITHUB_TOKEN, pasted into Postman as the value of the X-GitHub-Token key. The key and value are highlighted.](/assets/images/help/codespaces/postman-screenshot-key-token.png)
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

There are occurrences where HTTP headers `X-GitHub-` are written as `X-Github-`.

Closes: #35429

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The HTTP headers `X-Github-` has been changed to `X-GitHub-`.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
