### PR TITLE
Fix alerts to match the markdown notation

### DIFF
--- a/content/admin/managing-iam/using-ldap-for-enterprise-iam/using-ldap.md
+++ b/content/admin/managing-iam/using-ldap-for-enterprise-iam/using-ldap.md
@@ -158,20 +158,15 @@ A synchronization job will also run at the specified time interval to perform th
 
 {% data reusables.enterprise_user_management.ldap-sync-nested-teams %}
 
-{% warning %}
-
-**Security Warning:**
-
-When LDAP Sync is enabled, site admins and organization owners can search the LDAP directory for groups to map the team to.
-
-This has the potential to disclose sensitive organizational information to contractors or other unprivileged users, including:
-
-* The existence of specific LDAP Groups visible to the _Domain search user_.
-* Members of the LDAP group who have {% data variables.product.prodname_ghe_server %} user accounts, which is disclosed when creating a team synced with that LDAP group.
-
-If disclosing such information is not desired, your company or organization should restrict the permissions of the configured _Domain search user_ in the admin console. If such restriction isn't possible, contact us by visiting {% data variables.contact.contact_ent_support %}.
-
-{% endwarning %}
+> [!WARNING]
+> When LDAP Sync is enabled, site admins and organization owners can search the LDAP directory for groups to map the team to.
+>
+> This has the potential to disclose sensitive organizational information to contractors or other unprivileged users, including:
+>
+> * The existence of specific LDAP Groups visible to the _Domain search user_.
+> * Members of the LDAP group who have {% data variables.product.prodname_ghe_server %} user accounts, which is disclosed when creating a team synced with that LDAP group.
+>
+> If disclosing such information is not desired, your company or organization should restrict the permissions of the configured _Domain search user_ in the admin console. If such restriction isn't possible, contact us by visiting {% data variables.contact.contact_ent_support %}.
 
 ## Supported LDAP group object classes
 

--- a/content/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning.md
+++ b/content/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning.md
@@ -314,11 +314,8 @@ This SARIF output file has example values to show the minimum required propertie
 
 This SARIF output file has example of values for the field `originalUriBaseIds`, showing the minimum required properties a SARIF producer should include when using relative URI references.
 
-{% note %}
-
-**Note:** While this property is not required by {% data variables.product.prodname_dotcom %} for the {% data variables.product.prodname_code_scanning %} results to be displayed correctly, it is required to produce a valid SARIF output when using relative URI references.
-
-{% endnote %}
+> [!NOTE]
+> While this property is not required by {% data variables.product.prodname_dotcom %} for the {% data variables.product.prodname_code_scanning %} results to be displayed correctly, it is required to produce a valid SARIF output when using relative URI references.
 
 ```json
 {

--- a/content/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud.md
+++ b/content/migrations/using-github-enterprise-importer/migrating-between-github-products/migrating-repositories-from-github-enterprise-server-to-github-enterprise-cloud.md
@@ -73,13 +73,10 @@ Because many {% data variables.product.prodname_ghe_server %} instances sit behi
 
 You must first set up blob storage with a supported cloud provider, then configure your settings in the {% data variables.enterprise.management_console %} of {% data variables.location.product_location_enterprise %}.
 
-{% note %}
-
-**Note**: You only need to configure blob storage if you use {% data variables.product.prodname_ghe_server %} versions 3.8 or higher. If you use {% data variables.product.prodname_ghe_server %} versions 3.7 or lower, skip to "[Step 4: Set up a migration source in {% data variables.product.prodname_ghe_cloud %}](#step-4-set-up-a-migration-source-in-github-enterprise-cloud)."
-
-Blob storage is required to migrate repositories with large Git source or metadata. If you use {% data variables.product.prodname_ghe_server %} versions 3.7 or lower, you will not be able to perform migrations where your Git source or metadata exports exceed 2GB. To perform these migrations, update to {% data variables.product.prodname_ghe_server %} versions 3.8 or higher.
-
-{% endnote %}
+> [!NOTE]
+> You only need to configure blob storage if you use {% data variables.product.prodname_ghe_server %} versions 3.8 or higher. If you use {% data variables.product.prodname_ghe_server %} versions 3.7 or lower, skip to "[Step 4: Set up a migration source in {% data variables.product.prodname_ghe_cloud %}](#step-4-set-up-a-migration-source-in-github-enterprise-cloud)."
+>
+> Blob storage is required to migrate repositories with large Git source or metadata. If you use {% data variables.product.prodname_ghe_server %} versions 3.7 or lower, you will not be able to perform migrations where your Git source or metadata exports exceed 2GB. To perform these migrations, update to {% data variables.product.prodname_ghe_server %} versions 3.8 or higher.
 
 ### Setting up blob storage with a supported cloud provider
 

--- a/content/organizations/managing-organization-settings/deleting-an-organization-account.md
+++ b/content/organizations/managing-organization-settings/deleting-an-organization-account.md
@@ -25,11 +25,8 @@ shortTitle: Delete organization
 {% endif %}
 Deleting your organization account removes all repositories, forks of private repositories, wikis, issues, pull requests, and project or organization pages. {% ifversion fpt or ghec %}Your billing will end and, after 90 days, the organization name becomes available for use on a new user or organization account.
 
-{% tip %}
-
-**Tip**: If you rename an organization, you can create a new organization with the same name immediately. For more information, see "[AUTOTITLE](/organizations/managing-organization-settings/renaming-an-organization)."
-
-{% endtip %}
+> [!TIP]
+> If you rename an organization, you can create a new organization with the same name immediately. For more information, see "[AUTOTITLE](/organizations/managing-organization-settings/renaming-an-organization)."
 
 {% endif %}
 

--- a/data/reusables/secret-scanning/beta-prs-discussions-wikis-scanned.md
+++ b/data/reusables/secret-scanning/beta-prs-discussions-wikis-scanned.md
@@ -1,11 +1,8 @@
 {% ifversion ghes < 3.15 %}
 {% ifversion secret-scanning-enhancements-prs-discussions %}
 
-{% note %}
-
-**Note:** The scanning of content in pull requests and {% data variables.product.prodname_discussions %} is currently in {% data variables.release-phases.public_preview %} and subject to change.
-
-{% endnote %}
+> [!NOTE]
+> The scanning of content in pull requests and {% data variables.product.prodname_discussions %} is currently in {% data variables.release-phases.public_preview %} and subject to change.
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

There were still some occurrences of alerts that don't matched the markdown notation.

Closes: none

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The alerts has been changed to match the markdown notation.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.