### PR TITLE
Correct thanks.dev instructions

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository.md
@@ -31,7 +31,7 @@ Platform | Syntax
 [Tidelift](https://tidelift.com/) | `tidelift: PLATFORM-NAME/PACKAGE-NAME`
 [Polar](https://www.polar.sh/) | `polar: USERNAME`
 [Buy Me a Coffee](https://www.buymeacoffee.com/) | `buy_me_a_coffee: USERNAME`
-[thanks.dev](https://thanks.dev/) | `thanks_dev: USERNAME`
+[thanks.dev](https://thanks.dev/) | `thanks_dev: u/gh/USERNAME`
 Custom URL | `custom: LINK1` or `custom: [LINK1, LINK2, LINK3, LINK4]`
 
 For Tidelift, use the `platform-name/package-name` syntax with the following platform names.


### PR DESCRIPTION
### Why:

The current thanks.dev instructions are wrong. This is the correct URL.

For example, this goes nowhere: https://thanks.dev/vladh

This goes somewhere: https://thanks.dev/u/gh/vladh

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I've only changed the thanks.dev FUNDING file example.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
