### PR TITLE
Remove unnecessary regex lookarounds in pagination docs

### DIFF
--- a/content/rest/using-the-rest-api/using-pagination-in-the-rest-api.md
+++ b/content/rest/using-the-rest-api/using-pagination-in-the-rest-api.md
@@ -127,7 +127,7 @@ const octokit = new Octokit({ {% ifversion ghes %}
 {% endif %}});
 
 async function getPaginatedData(url) {
-  const nextPattern = /(?<=<)([\S]*)(?=>; rel="Next")/i;
+  const nextPattern = /<([\S]*); rel="next"/i;
   let pagesRemaining = true;
   let data = [];
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: N/A

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Lookarounds aren't available in all regex parsers. And in this case they're unnecessary. Remove them to make it easier for folks to work with pagination in their own projects.

### Check off the following:

- [X] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [X] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing.
