### PR TITLE
typo in searching-users.md

### DIFF
--- a/content/search-github/searching-on-github/searching-users.md
+++ b/content/search-github/searching-on-github/searching-users.md
@@ -34,7 +34,7 @@ With the `in` qualifier you can restrict your search to the username (`login`), 
 | Qualifier        | Example
 | ------------- | -------------
 | `user:name` | [**user:octocat**](https://github.com/search?q=user%3Aoctocat&type=Users) matches the user with the username "octocat".
-| `org:name` | [**org:electron type:users**](https://github.com/search?q=org%3Aelectron+type%3Ausers&type=Users) matches the Electron organization's account name.
+| `org:name` | [**org:electron type:user**](https://github.com/search?q=org%3Aelectron+type%3Ausers&type=Users) matches the Electron organization's account name.
 | `in:login` | [**kenya in:login**](https://github.com/search?q=kenya+in%3Alogin&type=Users) matches users with the word "kenya" in their username.
 | `in:name` | [**bolton in:name**](https://github.com/search?q=bolton+in%3Afullname&type=Users) matches users whose real name contains the word "bolton."
 | `fullname:firstname lastname` | [**fullname:nat friedman**](https://github.com/search?q=fullname%3Anat+friedman&type=Users) matches a user with the full name "Nat Friedman." Note: This search qualifier is sensitive to spacing.

--- a/content/search-github/searching-on-github/searching-users.md
+++ b/content/search-github/searching-on-github/searching-users.md
@@ -34,7 +34,7 @@ With the `in` qualifier you can restrict your search to the username (`login`), 
 | Qualifier        | Example
 | ------------- | -------------
 | `user:name` | [**user:octocat**](https://github.com/search?q=user%3Aoctocat&type=Users) matches the user with the username "octocat".
-| `org:name` | [**org:electron type:user**](https://github.com/search?q=org%3Aelectron+type%3Ausers&type=Users) matches the Electron organization's account name.
+| `org:name` | [**org:electron type:user**](https://github.com/search?q=org%3Aelectron+type%3Ausers&type=User) matches the Electron organization's account name.
 | `in:login` | [**kenya in:login**](https://github.com/search?q=kenya+in%3Alogin&type=Users) matches users with the word "kenya" in their username.
 | `in:name` | [**bolton in:name**](https://github.com/search?q=bolton+in%3Afullname&type=Users) matches users whose real name contains the word "bolton."
 | `fullname:firstname lastname` | [**fullname:nat friedman**](https://github.com/search?q=fullname%3Anat+friedman&type=Users) matches a user with the full name "Nat Friedman." Note: This search qualifier is sensitive to spacing.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Fixes #35589
> Corrected `type:users` to `type:user` in the example

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The org:name example, it’s saying type:users instead of type:user:

Qualifier | Example
-- | --
user:name | user:octocat matches the user with the username "octocat".
**org:name** | org:electron **type:users** matches the Electron organization's account name.
in:login | kenya in:login matches users with the word "kenya" in their username.
in:name | bolton in:name matches users whose real name contains the word "bolton."
fullname:firstname lastname | fullname:nat friedman matches a user with the full name "Nat Friedman." Note: This search qualifier is sensitive to spacing.
in:email | data in:email matches users with the word "data" in their email.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing.
