### PR TITLE
Fix formatting issues in documentation: Removed periods and added backticks

### DIFF
--- a/content/discussions/guides/best-practices-for-community-conversations-on-github.md
+++ b/content/discussions/guides/best-practices-for-community-conversations-on-github.md
@@ -22,10 +22,10 @@ For more information about opening an issue and cross-referencing a discussion, 
 You can create and participate in discussions, issues, and pull requests, depending on the type of conversation you'd like to have.
 
 You can use {% data variables.product.prodname_discussions %} to discuss big picture ideas, brainstorm, and develop a project's specific details before committing it to an issue, which can then be scoped. {% data variables.product.prodname_discussions %} is useful for teams in a number of scenarios.
-* You are in the discovery phase of a project and are still learning which direction your team wants to go in
-* You want to collect feedback from a wider community about a project
-* You want to keep bug fixes, feature requests, and general conversations separate
-* You want to measure interest in new ideas and gauge community opinion using polls
+* You are in the discovery phase of a project and are still learning which direction your team wants to go in.
+* You want to collect feedback from a wider community about a project.
+* You want to keep bug fixes, feature requests, and general conversations separate.
+* You want to measure interest in new ideas and gauge community opinion using polls.
 
 You might use repository discussions to discuss topics that are specific to the repository. If your project spans multiple repositories, you might use organization discussions to discuss topics that aren't specific to a single repository in your organization.
 

--- a/content/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line.md
+++ b/content/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line.md
@@ -85,7 +85,7 @@ You can now merge the branches on the command line or [push your changes to your
 
 To resolve a merge conflict caused by competing changes to a file, where a person deletes a file in one branch and another person edits the same file, you must choose whether to delete or keep the removed file in a new commit.
 
-For example, if you edited a file, such as (`README.md`), and another person removed the same file in another branch in the same Git repository, you'll get a merge conflict error when you try to merge these branches. You must resolve this merge conflict with a new commit before you can merge these branches.
+For example, if you edited a file, such as `README.md`, and another person removed the same file in another branch in the same Git repository, you'll get a merge conflict error when you try to merge these branches. You must resolve this merge conflict with a new commit before you can merge these branches.
 
 {% data reusables.command_line.open_the_multi_os_terminal %}
 1. Navigate into the local Git repository that has the merge conflict.
@@ -94,7 +94,7 @@ For example, if you edited a file, such as (`README.md`), and another person rem
    cd REPOSITORY-NAME
    ```
 
-1. Generate a list of the files affected by the merge conflict. In this example, the file (`README.md`) has a merge conflict.
+1. Generate a list of the files affected by the merge conflict. In this example, the file `README.md` has a merge conflict.
 
    ```shell
    $ git status

--- a/content/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line.md
+++ b/content/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line.md
@@ -85,7 +85,7 @@ You can now merge the branches on the command line or [push your changes to your
 
 To resolve a merge conflict caused by competing changes to a file, where a person deletes a file in one branch and another person edits the same file, you must choose whether to delete or keep the removed file in a new commit.
 
-For example, if you edited a file, such as _README.md_, and another person removed the same file in another branch in the same Git repository, you'll get a merge conflict error when you try to merge these branches. You must resolve this merge conflict with a new commit before you can merge these branches.
+For example, if you edited a file, such as (`README.md`), and another person removed the same file in another branch in the same Git repository, you'll get a merge conflict error when you try to merge these branches. You must resolve this merge conflict with a new commit before you can merge these branches.
 
 {% data reusables.command_line.open_the_multi_os_terminal %}
 1. Navigate into the local Git repository that has the merge conflict.
@@ -94,7 +94,7 @@ For example, if you edited a file, such as _README.md_, and another person remov
    cd REPOSITORY-NAME
    ```
 
-1. Generate a list of the files affected by the merge conflict. In this example, the file _README.md_ has a merge conflict.
+1. Generate a list of the files affected by the merge conflict. In this example, the file (`README.md`) has a merge conflict.
 
    ```shell
    $ git status

--- a/data/reusables/actions/about-workflows-long.md
+++ b/data/reusables/actions/about-workflows-long.md
@@ -1,6 +1,6 @@
 A **workflow** is a configurable automated process that will run one or more jobs. Workflows are defined by a YAML file checked in to your repository and will run when triggered by an event in your repository, or they can be triggered manually, or at a defined schedule.
 
 Workflows are defined in the `.github/workflows` directory in a repository. A repository can have multiple workflows, each of which can perform a different set of tasks such as:
-* Building and testing pull requests.
-* Deploying your application every time a release is created.
-* Adding a label whenever a new issue is opened.
+* Building and testing pull requests
+* Deploying your application every time a release is created
+* Adding a label whenever a new issue is opened

--- a/data/reusables/dependency-review/feature-overview.md
+++ b/data/reusables/dependency-review/feature-overview.md
@@ -1,4 +1,4 @@
 {% data reusables.dependency-review.short-summary %} It provides an easily understandable visualization of dependency changes with a rich diff on the "Files Changed" tab of a pull request. Dependency review informs you of:
-* Which dependencies were added, removed, or updated, along with the release dates.
-* How many projects use these components.
-* Vulnerability data for these dependencies.
+* Which dependencies were added, removed, or updated, along with the release dates
+* How many projects use these components
+* Vulnerability data for these dependencies


### PR DESCRIPTION
Removed periods, Use backticks to format references to the file names (instead of italics).

### Why:
The bullet points were not complete sentences, and according to the style guide, lists with incomplete sentences should not end with periods. This change ensures the article follows the documentation style guide.

Closes: #35661 
Closes: #35660 
Closes: #35658 
Closes: #35657 


### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
