### PR TITLE
Document the fact that Rouge only recognises lower-case language identifiers

### DIFF
--- a/content/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks.md
@@ -67,7 +67,7 @@ This will display the code block with syntax highlighting:
 ![Screenshot of three lines of Ruby code as displayed on {% data variables.product.prodname_dotcom %}. Elements of the code display in purple, blue, and red type for scannability.](/assets/images/help/writing/code-block-syntax-highlighting-rendered.png)
 
 > [!TIP]
->  When you create a fenced code block that you also want to have syntax highlighting on a GitHub Pages site, use lower-case language identifiers. For more information, see [AUTOTITLE](/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#syntax-highlighting).
+> When you create a fenced code block that you also want to have syntax highlighting on a GitHub Pages site, use lower-case language identifiers. For more information, see [AUTOTITLE](/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#syntax-highlighting).
 
 We use [Linguist](https://github.com/github-linguist/linguist) to perform language detection and to select [third-party grammars](https://github.com/github-linguist/linguist/blob/main/vendor/README.md) for syntax highlighting. You can find out which keywords are valid in [the languages YAML file](https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml).
 

--- a/content/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks.md
@@ -66,6 +66,11 @@ This will display the code block with syntax highlighting:
 
 ![Screenshot of three lines of Ruby code as displayed on {% data variables.product.prodname_dotcom %}. Elements of the code display in purple, blue, and red type for scannability.](/assets/images/help/writing/code-block-syntax-highlighting-rendered.png)
 
+> [!NOTE]
+> While both capitalized and lower-case language identifiers are allowed on GitHub, to
+> have a fenced code block highlighted on GitHub Pages sites the same way they're
+> highlighted on GitHub, you must use lower-case language identifiers.
+
 We use [Linguist](https://github.com/github-linguist/linguist) to perform language detection and to select [third-party grammars](https://github.com/github-linguist/linguist/blob/main/vendor/README.md) for syntax highlighting. You can find out which keywords are valid in [the languages YAML file](https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml).
 
 ## Creating diagrams

--- a/content/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks.md
@@ -66,10 +66,8 @@ This will display the code block with syntax highlighting:
 
 ![Screenshot of three lines of Ruby code as displayed on {% data variables.product.prodname_dotcom %}. Elements of the code display in purple, blue, and red type for scannability.](/assets/images/help/writing/code-block-syntax-highlighting-rendered.png)
 
-> [!NOTE]
-> While both capitalized and lower-case language identifiers are allowed on GitHub, to
-> have a fenced code block highlighted on GitHub Pages sites the same way they're
-> highlighted on GitHub, you must use lower-case language identifiers.
+> [!TIP]
+>  When you create a fenced code block that you also want to have syntax highlighting on a GitHub Pages site, use lower-case language identifiers. For more information, see [AUTOTITLE](/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#syntax-highlighting).
 
 We use [Linguist](https://github.com/github-linguist/linguist) to perform language detection and to select [third-party grammars](https://github.com/github-linguist/linguist/blob/main/vendor/README.md) for syntax highlighting. You can find out which keywords are valid in [the languages YAML file](https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml).
 

--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll.md
@@ -111,8 +111,7 @@ To make your site easier to read, code snippets are highlighted on {% data varia
 By default, code blocks on your site will be highlighted by Jekyll. Jekyll uses the [Rouge](https://github.com/rouge-ruby/rouge) highlighter (which is compatible with [Pygments](https://pygments.org/)). If you specify Pygments in your `_config.yml` file, Rouge will be used as the fallback instead. Jekyll cannot use any other syntax highlighter, and you'll get a page build warning if you specify another syntax highlighter in your `_config.yml` file. For more information, see [AUTOTITLE](/pages/setting-up-a-github-pages-site-with-jekyll/about-jekyll-build-errors-for-github-pages-sites).
 
 > [!NOTE]
-> Rouge will only recognize lower-case language identifiers for a fenced code
-> block.
+> Rouge only recognizes lower-case language identifiers for fenced code blocks. For a list of supported languages, see [Languages](https://rouge-ruby.github.io/docs/file.Languages.html).
 
 If you want to use another highlighter, such as [highlight.js](https://github.com/highlightjs/highlight.js), you must disable Jekyll's syntax highlighting by updating your project's `_config.yml` file.
 

--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll.md
@@ -110,6 +110,10 @@ To make your site easier to read, code snippets are highlighted on {% data varia
 
 By default, code blocks on your site will be highlighted by Jekyll. Jekyll uses the [Rouge](https://github.com/rouge-ruby/rouge) highlighter (which is compatible with [Pygments](https://pygments.org/)). If you specify Pygments in your `_config.yml` file, Rouge will be used as the fallback instead. Jekyll cannot use any other syntax highlighter, and you'll get a page build warning if you specify another syntax highlighter in your `_config.yml` file. For more information, see [AUTOTITLE](/pages/setting-up-a-github-pages-site-with-jekyll/about-jekyll-build-errors-for-github-pages-sites).
 
+> [!NOTE]
+> Rouge will only recognize lower-case language identifiers for a fenced code
+> block.
+
 If you want to use another highlighter, such as [highlight.js](https://github.com/highlightjs/highlight.js), you must disable Jekyll's syntax highlighting by updating your project's `_config.yml` file.
 
 ```yaml


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

GitHub accepts both \```Diff and \```diff for the purposes of syntax highlighting, but GitHub Pages will only highlight a ```diff code block.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Documented this caveat.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
