### PR TITLE
Add building-and-testing-rust.md

### DIFF
--- a/content/actions/use-cases-and-examples/building-and-testing/building-and-testing-go.md
+++ b/content/actions/use-cases-and-examples/building-and-testing/building-and-testing-go.md
@@ -1,6 +1,6 @@
----
-title: Building and testing Go
-intro: You can create a continuous integration (CI) workflow to build and test your Go project.
+[---
+title: Building and testing Rust
+intro: You can create a continuous integration (CI) workflow to build and test your Rust project.
 versions:
   fpt: '*'
   ghes: '*'
@@ -8,16 +8,16 @@ versions:
 type: tutorial
 topics:
   - CI
-shortTitle: Build & test Go
+shortTitle: Build & test Rust
 redirect_from:
-  - /actions/automating-builds-and-tests/building-and-testing-go
+  - /actions/automating-builds-and-tests/building-and-testing-rust
 ---
 
-{% data reusables.actions.enterprise-github-hosted-runners %}
+~~{% data reusables.actions.enterprise-github-hosted-runners %}~~
 
 ## Introduction
 
-This guide shows you how to build, test, and publish a Go package.
+This guide shows you how to build, test, and publish a Rust package.
 
 {% data variables.product.prodname_dotcom %}-hosted runners have a tools cache with preinstalled software, which includes the dependencies for Go. For a full list of up-to-date software and the preinstalled versions of Go, see [AUTOTITLE](/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software).
 
@@ -25,72 +25,40 @@ This guide shows you how to build, test, and publish a Go package.
 
 You should already be familiar with YAML syntax and how it's used with {% data variables.product.prodname_actions %}. For more information, see [AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions).
 
-We recommend that you have a basic understanding of the Go language. For more information, see [Getting started with Go](https://golang.org/doc/tutorial/getting-started).
+We recommend that you have a basic understanding of the Rust language. For more information, see [Getting started with Rust](https://www.rust-lang.org/learn).
 
-## Using a Go workflow template
+## Using a Rust workflow template
 
 {% data reusables.actions.workflow-templates-get-started %}
 
-{% data variables.product.prodname_dotcom %} provides a Go workflow template that should work for most Go projects. The subsequent sections of this guide give examples of how you can customize this workflow template.
+{% data variables.product.prodname_dotcom %} provides a Rust workflow template that should work for most basic Rust projects. The subsequent sections of this guide give examples of how you can customize this workflow template.
 
 {% data reusables.repositories.navigate-to-repo %}
 {% data reusables.repositories.actions-tab %}
 {% data reusables.actions.new-starter-workflow %}
-1. The "Choose a workflow" page shows a selection of recommended workflow templates. Search for "go".
+1. The "Choose a workflow" page shows a selection of recommended workflow templates. Search for "Rust".
 1. Filter the selection of workflows by clicking **Continuous integration**.
-1. On the "Go - by {% data variables.product.prodname_actions %}" workflow, click **Configure**.
+1. On the "Rust - by {% data variables.product.prodname_actions %}" workflow, click **Configure**.
 
    ![Screenshot of the "Choose a workflow" page. The "Configure" button on the "Go" workflow is highlighted with an orange outline.](/assets/images/help/actions/starter-workflow-go.png)
 
-{%- ifversion ghes %}
-   If you don't find the "Go - by {% data variables.product.prodname_actions %}" workflow template, copy the following workflow code to a new file called `go.yml` in the `.github/workflows` directory of your repository.
 
-   ```yaml copy
-   name: Go
-
-   on:
-     push:
-       branches: [ "main" ]
-     pull_request:
-       branches: [ "main" ]
-
-   jobs:
-     build:
-
-       runs-on: self-hosted
-       steps:
-         - uses: {% data reusables.actions.action-checkout %}
-
-         - name: Set up Go
-           uses: {% data reusables.actions.action-setup-go %}
-           with:
-             go-version: '1.20'
-
-         - name: Build
-           run: go build -v ./...
-
-         - name: Test
-           run: go test -v ./...
-   ```
-
-{%- endif %}
-
-1. Edit the workflow as required. For example, change the version of Go.
+1. Edit the workflow as required. For example, change the version of Rust.
 1. Click **Commit changes**.
 
 {% ifversion fpt or ghec %}
-   The `go.yml` workflow file is added to the `.github/workflows` directory of your repository.
+   The `rust.yml` workflow file is added to the `.github/workflows` directory of your repository.
 {% endif %}
 
-## Specifying a Go version
+## Specifying a Rust version
 
-The easiest way to specify a Go version is by using the `setup-go` action provided by {% data variables.product.prodname_dotcom %}. For more information see, the [`setup-go` action](https://github.com/actions/setup-go/).
+~~The easiest way to specify a Rust version is by using the `rustup` action provided by {% data variables.product.prodname_dotcom %}. For more information see, the [`setup-rust` action](https://github.com/actions/setup-rust/).~~
 
-To use a preinstalled version of Go on a {% data variables.product.prodname_dotcom %}-hosted runner, pass the relevant version to the `go-version` property of the `setup-go` action. This action finds a specific version of Go from the tools cache on each runner, and adds the necessary binaries to `PATH`. These changes will persist for the remainder of the job.
+To use a preinstalled version of Rust on a {% data variables.product.prodname_dotcom %}-hosted runner, pass the relevant version to the `rust-version` property of the `setup-rust` action. This action finds a specific version of Rust from the tools cache on each runner, and adds the necessary binaries to `PATH`. These changes will persist for the remainder of the job.
 
-The `setup-go` action is the recommended way of using Go with {% data variables.product.prodname_actions %}, because it helps ensure consistent behavior across different runners and different versions of Go. If you are using a self-hosted runner, you must install Go and add it to `PATH`.
+The `setup-rust` action is the recommended way of using rust with {% data variables.product.prodname_actions %}, because it helps ensure consistent behavior across different runners and different versions of Rust. If you are using a self-hosted runner, you must install rust and add it to your self-hosted runner's `PATH`.
 
-### Using multiple versions of Go
+### Using multiple versions of rust
 
 ```yaml copy
 name: Go
@@ -103,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.19', '1.20', '1.21.x' ]
+        rust-version: [ '1.8', '1.20', '1.21.x' ]
 
     steps:
       - uses: {% data reusables.actions.action-checkout %}
@@ -191,7 +159,7 @@ If you have a custom requirement or need finer controls for caching, you can use
 
 ## Building and testing your code
 
-You can use the same commands that you use locally to build and test your code. This example workflow demonstrates how to use `go build` and `go test` in a job:
+You can use the same commands that you use locally to build and test your code. This example workflow demonstrates how to use `cargo build` and `cargo test` in a job:
 
 ```yaml copy
 name: Go
@@ -204,49 +172,13 @@ jobs:
     steps:
       - uses: {% data reusables.actions.action-checkout %}
       - name: Setup Go
-        uses: {% data reusables.actions.action-setup-go %}
+        uses: {% data reusables.actions.action-setup-rust %}
         with:
-          go-version: '1.21.x'
+          rust-version: '1.8.x'
       - name: Install dependencies
         run: go get .
       - name: Build
         run: go build -v ./...
       - name: Test with the Go CLI
         run: go test
-```
-
-## Packaging workflow data as artifacts
-
-After a workflow completes, you can upload the resulting artifacts for analysis. For example, you may need to save log files, core dumps, test results, or screenshots. The following example demonstrates how you can use the `upload-artifact` action to upload test results.
-
-For more information, see [AUTOTITLE](/actions/using-workflows/storing-workflow-data-as-artifacts).
-
-```yaml copy
-name: Upload Go test results
-
-on: [push]
-
-jobs:
-  build:
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [ '1.19', '1.20', '1.21.x' ]
-
-    steps:
-      - uses: {% data reusables.actions.action-checkout %}
-      - name: Setup Go
-        uses: {% data reusables.actions.action-setup-go %}
-        with:
-          go-version: {% raw %}${{ matrix.go-version }}{% endraw %}
-      - name: Install dependencies
-        run: go get .
-      - name: Test with Go
-        run: go test -json > TestResults-{% raw %}${{ matrix.go-version }}{% endraw %}.json
-      - name: Upload Go test results
-        uses: {% data reusables.actions.action-upload-artifact %}
-        with:
-          name: Go-results-{% raw %}${{ matrix.go-version }}{% endraw %}
-          path: TestResults-{% raw %}${{ matrix.go-version }}{% endraw %}.json
 ```

--- a/content/actions/use-cases-and-examples/building-and-testing/index.md
+++ b/content/actions/use-cases-and-examples/building-and-testing/index.md
@@ -27,6 +27,7 @@ children:
   - /building-and-testing-powershell
   - /building-and-testing-python
   - /building-and-testing-ruby
+  - /building-and-testing-rust
   - /building-and-testing-swift
   - /building-and-testing-xamarin-applications
 ---


### PR DESCRIPTION
Right now, it's a manual search and replace, I would like to build the docs as I find myself the answers to enable my own rust workflows beyond what https://github.com/foursixnine/cndk8/blob/main/.github/workflows/rust.yml is already doing.

PoC: Add documentation for rust workflows

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Because there's no documentation on how to properly handle rust stuff on github

would take a look later at [github/docs/issues/23181](https://github.com/github/docs/issues/23181) and see what else fails

### What's being changed (if available, include any code snippets, screenshots, or gifs):

So far adding documentation based off the Golang one, and my own journey through https://github.com/foursixnine/cndk8/ and [isototest-ng](https://github.com/os-autoinst/isotest-ng/

Commits, PR's will be listed 

### Check off the following:

Still WIP:

- [ ] Update filename
- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing.
