### PR TITLE
Fix case of `ruleId`

### DIFF
--- a/content/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning.md
+++ b/content/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning.md
@@ -35,7 +35,7 @@ If you're new to SARIF and want to learn more, see Microsoft's [`SARIF tutorials
 
 ## Providing data to track {% data variables.product.prodname_code_scanning %} alerts across runs
 
-Each time the results of a new code scan are uploaded, the results are processed and alerts are added to the repository. To prevent duplicate alerts for the same problem, {% data variables.product.prodname_code_scanning %} uses fingerprints to match results across various runs so they only appear once in the latest run for the selected branch. This makes it possible to match alerts to the correct line of code when files are edited. The `ruleID` for a result has to be the same across analysis.
+Each time the results of a new code scan are uploaded, the results are processed and alerts are added to the repository. To prevent duplicate alerts for the same problem, {% data variables.product.prodname_code_scanning %} uses fingerprints to match results across various runs so they only appear once in the latest run for the selected branch. This makes it possible to match alerts to the correct line of code when files are edited. The `ruleId` for a result has to be the same across analysis.
 
 ### Reporting consistent filepaths
 
@@ -536,7 +536,7 @@ This SARIF output file has example values to show all supported SARIF properties
         {
           "ruleId": "R01",
           "message": {
-            "text": "Specifying both [ruleIndex](1) and [ruleID](2) might lead to inconsistencies."
+            "text": "Specifying both [ruleIndex](1) and [ruleId](2) might lead to inconsistencies."
           },
           "level": "error",
           "locations": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #35709

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

#### [Before](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs)
<img width="759" alt="Screenshot 2024-12-20 at 8 25 54 AM" src="https://github.com/user-attachments/assets/0c11c204-4e83-4436-8c0c-1eef2b889e9d" />

[...](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#example-showing-all-supported-sarif-properties)
<img width="758" alt="image" src="https://github.com/user-attachments/assets/e9ae1c67-4142-4be6-9f2a-d9ba8428809f" />

#### [After](https://docs-35730-1105bf.preview.ghdocs.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs)
<img width="735" alt="image" src="https://github.com/user-attachments/assets/b28cda5b-b792-4fb3-ad45-ed35e341d48e" />

[...](https://docs-35730-1105bf.preview.ghdocs.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#example-showing-all-supported-sarif-properties)
<img width="760" alt="image" src="https://github.com/user-attachments/assets/94eb4fbc-0a69-4893-b13f-493137ae38e4" />

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing.
