### PR TITLE
Update code-languages.yml to include Swift

### DIFF
--- a/data/code-languages.yml
+++ b/data/code-languages.yml
@@ -61,6 +61,9 @@ shell:
 sql:
   name: SQL
   comment: hyphen
+swift:
+  name: Swift
+  comment: slash
 text:
   name: Text
   comment: number


### PR DESCRIPTION
### Why:

This is one of the languages that we need to write about and include code blocks for. So we should support syntax highlighting for it.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I've added Swift to the list of languages supported in the Docs site. It's in the list of [GitHub supported languages](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md).

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing.
