### PR TITLE
Fix a typo

### DIFF
--- a/.github/workflows/no-response.yaml
+++ b/.github/workflows/no-response.yaml
@@ -46,7 +46,7 @@ jobs:
             This PR has been automatically closed because there has been no response to
             to our request for more information from the original author. Please reach out
             if you have the information we requested, or open a [new issue](https://github.com/github/docs/issues/new/choose)
-            to describing your changes. Then we can begin the review process.
+            to describe your changes. Then we can begin the review process.
 
       - name: Check out repo
         if: ${{ failure() }}


### PR DESCRIPTION
### Why:

Closes: N/A: it is a problem with the `.github` folder, not with the website (and also there's not a template for it)

### What's being changed:

Fix a typo in the no response workflow. I don't have screenshots because I haven't seen the comment.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing.
