### PR TITLE
Remove unused workflow key `jobs.<job_id>.with.<with_id>` from context availability table

### DIFF
--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs.md
@@ -123,7 +123,6 @@ The following table lists the restrictions on where each context and special fun
 | `jobs.<job_id>.steps.working-directory` | `github, needs, strategy, matrix, job, runner, env, vars, secrets, steps, inputs` | `hashFiles` |
 | `jobs.<job_id>.strategy` | `github, needs, vars, inputs` | None |
 | `jobs.<job_id>.timeout-minutes` | `github, needs, strategy, matrix, vars, inputs` | None |
-| `jobs.<job_id>.with.<with_id>` | `github, needs, strategy, matrix, inputs, vars` | None |
 | `on.workflow_call.inputs.<inputs_id>.default` | `github, inputs, vars` | None |
 | `on.workflow_call.outputs.<output_id>.value` | `github, jobs, vars, inputs` | None |
 


### PR DESCRIPTION


following the discussion here:

https://github.com/orgs/community/discussions/148153

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: #35828

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

Removed the unused workflow key `jobs.<job_id>.with.<with_id>` from the context availability table.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
