### PR TITLE
Fix: Use backticks to format file name in adding-a-theme-to-your-github-pages-site-using-jekyll#adding-a-theme #35821

### DIFF
--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll.md
@@ -25,7 +25,7 @@ People with write permissions for a repository can add a theme to a {% data vari
 
 {% data reusables.pages.navigate-site-repo %}
 {% data reusables.pages.navigate-publishing-source %}
-1. Navigate to __config.yml_.
+1. Navigate to `_config.yml`.
 {% data reusables.repositories.edit-file %}
 1. Add a new line to the file for the theme name.
    * To use a supported theme, type `theme: THEME-NAME`, replacing THEME-NAME with the name of the theme as shown in the `_config.yml` of the theme's repository (most themes follow a `jekyll-theme-NAME` naming convention). For a list of supported themes, see [Supported themes](https://pages.github.com/themes/) on the {% data variables.product.prodname_pages %} site. For example, to select the Minimal theme, type `theme: jekyll-theme-minimal`.
@@ -62,11 +62,11 @@ People with write permissions for a repository can add a theme to a {% data vari
 {% data reusables.pages.theme-customization-help %}
 
 1. On {% data variables.product.prodname_dotcom %}, navigate to your theme's source repository. For example, the source repository for Minimal is https://github.com/pages-themes/minimal.
-1. In the __layouts_ folder, navigate to your theme's _default.html_ file.
+1. In the `_layouts` folder, navigate to your theme's `_default.html` file.
 1. Copy the contents of the file.
 {% data reusables.pages.navigate-site-repo %}
 {% data reusables.pages.navigate-publishing-source %}
-1. Create a file called __layouts/default.html_.
+1. Create a file called `_layouts/default.html`.
 1. Paste the default layout content you copied earlier.
 1. Customize the layout as you'd like.
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "openapi-docs": "tsx src/rest/docs.js",
     "playwright-test": "playwright test --config src/fixtures/playwright.config.ts --project=\"Google Chrome\"",
     "post-lints": "tsx src/content-linter/scripts/post-lints.js",
-    "postinstall": "cp package-lock.json .installed.package-lock.json && echo \"Updated .installed.package-lock.json\" # see husky/post-checkout and husky/post-merge",
+    "postinstall": "copy package-lock.json .installed.package-lock.json && echo \"Updated .installed.package-lock.json\" # see husky/post-checkout and husky/post-merge",
     "precompute-pageinfo": "tsx src/pageinfo/scripts/precompute-pageinfo.ts",
     "prepare": "husky src/workflows/husky",
     "prettier": "prettier -w \"**/*.{ts,tsx,js,mjs,scss,yml,yaml}\"",


### PR DESCRIPTION
Fix: Use backticks to format file name in adding-a-theme-to-your-github-pages-site-using-jekyll#adding-a-theme #35821

- Updated the article to use backticks for file names in "Adding a theme to your GitHub Pages site using Jekyll".
- Modified the `_config.yml` references to follow the GitHub Docs style guide.


### Why:

Closes: #35821

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Changed :
1. Navigate to __config.yml_.

To:
1. Navigate to `_config.yml`.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
