### PR TITLE
Provide redirect for broken UI link as temporary fix

### DIFF
--- a/content/actions/writing-workflows/quickstart.md
+++ b/content/actions/writing-workflows/quickstart.md
@@ -5,6 +5,7 @@ allowTitleToDifferFromFilename: true
 redirect_from:
   - /actions/getting-started-with-github-actions/starting-with-preconfigured-workflow-templates
   - /actions/quickstart
+  - /actions/getting-started-with-github-actions
 versions:
   fpt: '*'
   ghes: '*'


### PR DESCRIPTION
### Why:

This is a partial fix for https://github.com/github/docs/issues/35843. It adds a redirect from the broken URL to the correct article.

The full fix will require an update to the UI which will take a little longer to arrange and publish.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The URL used in the UI: `https://docs.github.com/actions/getting-started-with-github-actions` will automatically redirect to the article https://docs.github.com/en/actions/writing-workflows/quickstart once this change is deployed to production.

This redirect will be useful to users of GitHub Enterprise Server longer term, but GitHub cloud users will stop using the redirect once the UI is updated.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing.
