### PR TITLE
Fix supported values for Dependabot update types

### DIFF
--- a/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
+++ b/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
@@ -267,7 +267,7 @@ When `ignore` is used {% data variables.product.prodname_dependabot %} uses the 
 |------------|---------|
 | `dependency-name` | Ignore updates for dependencies with matching names, optionally using `*` to match zero or more characters. |
 | `versions` | Ignore specific versions or ranges of versions. |
-| `update-types` | Ignore updates to one or more semantic versioning levels. Supported values: `sem-ver:minor`, `sem-ver:patch`, and `sem-ver:major`. |
+| `update-types` | Ignore updates to one or more semantic versioning levels. Supported values: `version-update:semver-patch`, `version-update:semver-minor` and `version-update:semver-major`. |
 
 ### `dependency-name` (`ignore`)
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: https://github.com/github/docs/issues/35862

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

The documentation for the `dependabot.yml` file specified the wrong values for the `ignore -> > update-types` field.
I replaced them by the ones actually accepted.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
