### PR TITLE
Corrected broken URL's in the automation-for-release-forms-with-query…

### DIFF
--- a/content/repositories/releasing-projects-on-github/automation-for-release-forms-with-query-parameters.md
+++ b/content/repositories/releasing-projects-on-github/automation-for-release-forms-with-query-parameters.md
@@ -31,5 +31,5 @@ Query parameter | Example
 
 ## Further reading
 
-* [AUTOTITLE](/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-url-query)
-* [AUTOTITLE](/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request)
+* [AUTOTITLE](/content/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-url-query)
+* [AUTOTITLE](/content/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request)


### PR DESCRIPTION
…-parameters.md file

I found out that the 2 URL's at the bottom of the page were broken and weren't updated whenever the content structure of the repo was done. So I updated them accordingly.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes:
https://github.com/github/docs/issues/35867

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I am just fixing the links at the bottom of the file so that they properly resolve and aren't broken links.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
