### PR TITLE
Fix: Capitalize list line in working-with-the-container-registry#authenticating-to-the-container-registry #35761

### DIFF
--- a/data/reusables/package_registry/authenticate-packages.md
+++ b/data/reusables/package_registry/authenticate-packages.md
@@ -6,4 +6,5 @@ You can use a {% data variables.product.pat_v1 %} to authenticate to {% data var
 
 To authenticate to a {% data variables.product.prodname_registry %} registry within a {% data variables.product.prodname_actions %} workflow, you can use:
 * `GITHUB_TOKEN` to publish packages associated with the workflow repository.
+
 * A {% data variables.product.pat_v1 %} with at least `read:packages` scope to install packages associated with other private repositories (which `GITHUB_TOKEN` can't access).


### PR DESCRIPTION
Capitalize the second list line to maintain consistency with our [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide#lists)

### Why:

Closes: #35761 

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
