### PR TITLE
HTTPS repositories: user/pass only required for private repos

### DIFF
--- a/content/get-started/getting-started-with-git/about-remote-repositories.md
+++ b/content/get-started/getting-started-with-git/about-remote-repositories.md
@@ -52,7 +52,7 @@ For information on setting or changing your remote URL, see [AUTOTITLE](/get-sta
 
 The `https://` clone URLs are available on all repositories, regardless of visibility. `https://` clone URLs work even if you are behind a firewall or proxy.
 
-When you `git clone`, `git fetch`, `git pull`, or `git push` to a remote repository using HTTPS URLs on the command line, Git will ask for your {% data variables.product.product_name %} username and password. {% data reusables.user-settings.password-authentication-deprecation %}
+When you `git clone`, `git fetch`, `git pull`, or `git push` to a private remote repository using HTTPS URLs on the command line, Git will ask for your {% data variables.product.product_name %} username and password. {% data reusables.user-settings.password-authentication-deprecation %}
 
 {% data reusables.command_line.provide-an-access-token %}
 


### PR DESCRIPTION
Add 'private' to indicate that user/password are only necessary for HTTPS access if the repo is private.

Fixes: https://github.com/github/docs/issues/35846

Closes: https://github.com/github/docs/issues/35846

Changes: content/get-started/getting-started-with-git/about-remote-repositories.md

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
