### PR TITLE
docs: update misplaced word in repo terminology

### DIFF
--- a/content/repositories/creating-and-managing-repositories/about-repositories.md
+++ b/content/repositories/creating-and-managing-repositories/about-repositories.md
@@ -39,7 +39,7 @@ Fork | A new repository that shares code and visibility settings with the origin
 Merge | To take the changes from one branch and apply them to another.
 Pull request | A request to merge changes from one branch into another.
 Remote | A repository stored on {% data variables.product.product_name %}, not on your computer.
-Upstream | The branch on an original repository that has been forked or cloned. The corresponding branch on the cloned or forked branch is called the "downstream."
+Upstream | The branch on an original repository that has been forked or cloned. The corresponding branch on the cloned or forked repository is called the "downstream."
 
 {% endrowheaders %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: Fixes incorrect definition of "Upstream" in Repository Terminology'

This PR corrects the definition of "Upstream" in the Repository Terminology section. The previous definition incorrectly used the term "branch" instead of "repository" in an instance.

Closes: #35912 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require a SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing.
