### PR TITLE
Added run keyword to example file triggering-a-workflow.md

### DIFF
--- a/content/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow.md
+++ b/content/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow.md
@@ -294,7 +294,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: build
-        echo 'building'
+        run: |
+          echo 'building'
 
   publish:
     needs: [build]
@@ -302,7 +303,8 @@ jobs:
     environment: production
     steps:
       - name: publish
-        echo 'publishing'
+        run: |
+          echo 'publishing'
 ```
 
 > [!NOTE]


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Run keyword is missing in the file triggering-a-workflow.md. 

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Fixed example and added missing keyword to the file content

