### PR TITLE
Update GitHub Desktop macOS supported version

### DIFF
--- a/data/variables/desktop.yml
+++ b/data/variables/desktop.yml
@@ -1,5 +1,5 @@
 # Supported platforms
 
-mac-osx-versions: macOS 10.15 or later
+mac-osx-versions: macOS 11.0 or later
 
 windows-versions: Windows 10 64-bit or later


### PR DESCRIPTION
### Why:

xref: https://github.com/github/desktop/issues/941


### What's being changed (if available, include any code snippets, screenshots, or gifs):

Update the macOS supported os variable as we will soon ship versions that no longer support macOS 10.15.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the preview environment.
