### PR TITLE
Add GitHub no-reply email to example of adding co-authors

### DIFF
--- a/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors.md
+++ b/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors.md
@@ -56,7 +56,7 @@ You can use {% data variables.product.prodname_desktop %} to create a commit wit
    >
    >
    Co-authored-by: NAME <NAME@EXAMPLE.COM>
-   Co-authored-by: ANOTHER-NAME <ANOTHER-NAME@EXAMPLE.COM>"
+   Co-authored-by: ANOTHER-NAME <username@users.noreply.github.com>"
    ```
 
 The new commit and message will appear on {% data variables.location.product_location %} the next time you push. For more information, see [AUTOTITLE](/get-started/using-git/pushing-commits-to-a-remote-repository).


### PR DESCRIPTION
### Why:

Every few weeks I google how to do this and in addition to needing to google this, I also need to google what the no-reply email address is. Combining these two sets of information in the same docs would be helpful.

Closes: None

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the preview environment.
