### PR TITLE
Change git clone commands for wiki editing to not use https

### DIFF
--- a/content/communities/documenting-your-project-with-wikis/editing-wiki-content.md
+++ b/content/communities/documenting-your-project-with-wikis/editing-wiki-content.md
@@ -45,7 +45,7 @@ Wikis can display PNG, JPEG, and GIF images.
 
 You can link to an image in a repository on {% data variables.product.github %} by copying the URL in your browser and using that as the path to the image. For example, embedding an image in your wiki using Markdown might look like this:
 
-    [[https://github.com/USERNAME/REPOSITORY/blob/main/img/octocat.png|alt=octocat]]
+    [[git@github.com:USERNAME/REPOSITORY/blob/main/img/octocat.png|alt=octocat]]
 
 ## Adding mathematical expressions and diagrams
 


### PR DESCRIPTION
Since you cannot actually push changes to your wiki if you use https, the clone command should not instruct you to use https when cloning.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #36150

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

I changed https://github.com/github/docs/blob/main/content/communities/documenting-your-project-with-wikis/adding-or-editing-wiki-pages.md to suggest cloning with SSH instead of HTTPS

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the preview environment.
