### PR TITLE
GitHub Pages: Adding note to remove default DNS records

### DIFF
--- a/content/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site.md
+++ b/content/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site.md
@@ -66,7 +66,7 @@ To set up an apex domain, such as `example.com`, you must configure a custom dom
       ```
 
 > [!NOTE]
-> If your DNS provider automatically set a default record for your domain, be sure to remove it before continuing.
+> If your DNS provider automatically sets a default record, be sure to remove it before continuing.
 
 {% indented_data_reference reusables.pages.wildcard-dns-warning spaces=3 %}
 {% data reusables.command_line.open_the_multi_os_terminal %}

--- a/content/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site.md
+++ b/content/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site.md
@@ -65,6 +65,9 @@ To set up an apex domain, such as `example.com`, you must configure a custom dom
       2606:50c0:8003::153
       ```
 
+> [!NOTE]
+> If your DNS provider automatically set a default record for your domain, be sure to remove it before continuing.
+
 {% indented_data_reference reusables.pages.wildcard-dns-warning spaces=3 %}
 {% data reusables.command_line.open_the_multi_os_terminal %}
 1. To confirm that your DNS record configured correctly, use the `dig` command, replacing _EXAMPLE.COM_ with your apex domain. Confirm that the results match the IP addresses for {% data variables.product.prodname_pages %} above.
@@ -88,7 +91,6 @@ To set up an apex domain, such as `example.com`, you must configure a custom dom
      > EXAMPLE.COM     3600    IN AAAA     2606:50c0:8003::153
      ```
 
-      Remember to also check your `A` record.
 {% data reusables.pages.build-locally-download-cname %}
 {% data reusables.pages.enforce-https-custom-domain %}
 

--- a/content/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site.md
+++ b/content/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site.md
@@ -66,7 +66,7 @@ To set up an apex domain, such as `example.com`, you must configure a custom dom
       ```
 
 > [!NOTE]
-> If your DNS provider automatically sets a default record, be sure to remove it before continuing.
+> If your DNS provider automatically sets a default record, remove it before continuing.
 
 {% indented_data_reference reusables.pages.wildcard-dns-warning spaces=3 %}
 {% data reusables.command_line.open_the_multi_os_terminal %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #36158 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

I set up GitHub pages for the first time and ran into issues because my DNS provider (Squarespace) automatically adds an `A` record and apex domain for newly created domains. After doing some research it appears this is common for many DNS providers (i.e. Wix, GoDaddy, etc.) so I figured it was worth notating to help other readers.

Feel free to move it to a different part of the page, or even incorporate it into an existing paragraph instead of my note alert--whatever you think is best!

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the preview environment.
