### PR TITLE
Update evaluate-expressions-in-workflows-and-actions.md

### DIFF
--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions.md
@@ -292,17 +292,29 @@ Returns a single hash for the set of files that matches the `path` pattern. You 
 
 You can use pattern matching characters to match file names. Pattern matching for `hashFiles` follows glob pattern matching and is case-insensitive on Windows. For more information about supported pattern matching characters, see the [Patterns](https://www.npmjs.com/package/@actions/glob#patterns) section in the `@actions/glob` documentation.
 
-#### Example with a single pattern
+#### Examples with a single pattern
 
 Matches any `package-lock.json` file in the repository.
 
 `hashFiles('**/package-lock.json')`
 
-#### Example with multiple patterns
+Matches all `.js` files in the `src` directory at root level, but ignores any subdirectories of `src`.
+
+`hashFiles('/src/*.js')`
+
+Matches all `.rb` files in the `lib` directory at root level, including any subdirectories of `lib`.
+
+`hashFiles('/lib/**/*.rb')`
+
+#### Examples with multiple patterns
 
 Creates a hash for any `package-lock.json` and `Gemfile.lock` files in the repository.
 
 `hashFiles('**/package-lock.json', '**/Gemfile.lock')`
+
+Creates a hash for all `.rb` files in the `lib` directory at root level, including any subdirectories of `lib`, but excluding `.rb` files in the `foo` subdirectory.
+
+`hashFiles('/lib/**/*.rb', '!/lib/foo/*.rb')`
 
 ## Status check functions
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes:  #32305

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

As agreed upon in the linked issue, additional `hashFiles` examples were added, showcasing more advanced pattern matching options. In keeping with the tech referenced in the article's current examples (JavaScript/Ruby), the following file extensions were used: `.js` and `.rb`. The single-pattern examples provide use-cases for patterns involving fixed-level directory search and recursive subdirectory search. The multi-pattern example makes use of a fixed-level exclude `!` pattern in a recursive subdirectory search.
 
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [X] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [X] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [X] All CI checks are passing and the changes look good in the preview environment.
