### PR TITLE
Fix attest build provenance steps in publishing docker image examples

### DIFF
--- a/content/actions/use-cases-and-examples/publishing-packages/publishing-docker-images.md
+++ b/content/actions/use-cases-and-examples/publishing-packages/publishing-docker-images.md
@@ -116,7 +116,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: {% raw %}${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}{% endraw %}
+          subject-name: index.docker.io/my-docker-hub-namespace/my-docker-hub-repository
           subject-digest: {% raw %}${{ steps.push.outputs.digest }}{% endraw %}
           push-to-registry: true
 {% endif -%}
@@ -226,10 +226,16 @@ jobs:
           labels: {% raw %}${{ steps.meta.outputs.labels }}{% endraw %}
 
 {% ifversion artifact-attestations %}
-      - name: Generate artifact attestation
+      - name: Generate artifact attestation for Docker Hub
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: {% raw %}${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}{% endraw %}
+          subject-name: index.docker.io/my-docker-hub-namespace/my-docker-hub-repository
+          subject-digest: {% raw %}${{ steps.push.outputs.digest }}{% endraw %}
+          push-to-registry: true
+      - name: Generate artifact attestation for the Container registry
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: {% data reusables.package_registry.container-registry-hostname %}/{% raw %}${{ github.repository }}{% endraw %}
           subject-digest: {% raw %}${{ steps.push.outputs.digest }}{% endraw %}
           push-to-registry: true
 {% endif -%}

--- a/content/actions/use-cases-and-examples/publishing-packages/publishing-docker-images.md
+++ b/content/actions/use-cases-and-examples/publishing-packages/publishing-docker-images.md
@@ -226,13 +226,7 @@ jobs:
           labels: {% raw %}${{ steps.meta.outputs.labels }}{% endraw %}
 
 {% ifversion artifact-attestations %}
-      - name: Generate artifact attestation for Docker Hub
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: index.docker.io/my-docker-hub-namespace/my-docker-hub-repository
-          subject-digest: {% raw %}${{ steps.push.outputs.digest }}{% endraw %}
-          push-to-registry: true
-      - name: Generate artifact attestation for the Container registry
+      - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: {% data reusables.package_registry.container-registry-hostname %}/{% raw %}${{ github.repository }}{% endraw %}


### PR DESCRIPTION
Instead of using env.REGISTRY and env.IMAGE_NAME, which are not set, use the images in the metadata-action step.

Fixes #36243

### Why:

Closes: #36243

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The image publishing example workflows use `env.REGISTRY` and `env.IMAGE_NAME` which I found confusing because they are not set. I changed them to use the image names that are already used elsewhere in the same workflows.

In the example that pushes an image to both Docker Hub and GitHub I added an attestation step for Docker Hub to show how to create attestations in multiple registries.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the preview environment.
