### PR TITLE
fix: invalid syntax for docker commit prefix

### DIFF
--- a/content/code-security/dependabot/dependabot-version-updates/customizing-dependabot-prs.md
+++ b/content/code-security/dependabot/dependabot-version-updates/customizing-dependabot-prs.md
@@ -128,7 +128,7 @@ updates:
       interval: "weekly"
     commit-message:
       # Prefix all commit messages with [docker] " (no colon, but a trailing whitespace)
-      prefix: [docker] "
+      prefix: "[docker] "
 
   - package-ecosystem: "composer"
     directory: "/"


### PR DESCRIPTION
### Why:

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fixes incorrect syntax for the docker commit prefix. 

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the preview environment.
