### PR TITLE
Fix incorrect summary of how an SSH agent works

### DIFF
--- a/content/authentication/connecting-to-github-with-ssh/working-with-ssh-key-passphrases.md
+++ b/content/authentication/connecting-to-github-with-ssh/working-with-ssh-key-passphrases.md
@@ -18,7 +18,7 @@ shortTitle: SSH key passphrases
 
 ## About passphrases for SSH keys
 
-With SSH keys, if someone gains access to your computer, the attacker can gain access to every system that uses that key. To add an extra layer of security, you can add a passphrase to your SSH key. To avoid entering the passphrase every time you connect, you can securely save your passphrase in the SSH agent.
+With SSH keys, if someone gains access to your computer, the attacker can gain access to every system that uses that key. To add an extra layer of security, you can add a passphrase to your SSH key. To avoid entering the passphrase every time you connect, you can securely cache the key in the SSH agent.
 
 ## Adding or changing a passphrase
 


### PR DESCRIPTION
### Why:

<!-- Paste the issue link or number here -->
Closes: [36303](https://github.com/github/docs/issues/36303)

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This PR fixes an incorrect statement in the Authentication / Connect with SSH article: When summarizing the role of an SSH agent, the article claims that the agent stores the passphrase. In reality, it caches keys and lets the client request signatures calculated with those keys. The agent only uses the passphrase to decrypt the key.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the preview environment.
