### PR TITLE
Update outdated note on downloading actions

### DIFF
--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow.md
@@ -156,7 +156,7 @@ After a workflow run has been completed, you can download or delete artifacts on
 The [`actions/download-artifact`](https://github.com/actions/download-artifact) action can be used to download previously uploaded artifacts during a workflow run.
 
 > [!NOTE]
-> {% ifversion fpt or ghec %}If you want to download artifacts from a different workflow or workflow run, you need to supply a token and run identifier. See [Download Artifacts from other Workflow Runs or Repositories](https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories) in the documentation for the download-artifact action.
+> {% ifversion fpt or ghec %}If you want to download artifacts from a different workflow or workflow run, you need to supply a token and run identifier. See [Download Artifacts from other Workflow Runs or Repositories](https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories) in the documentation for the `download-artifact` action.
 {% elsif ghes %}You can only download artifacts in a workflow that were uploaded during the same workflow run.{% endif %}
 
 Specify an artifact's name to download an individual artifact. If you uploaded an artifact without specifying a name, the default name is `artifact`.

--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow.md
@@ -156,7 +156,8 @@ After a workflow run has been completed, you can download or delete artifacts on
 The [`actions/download-artifact`](https://github.com/actions/download-artifact) action can be used to download previously uploaded artifacts during a workflow run.
 
 > [!NOTE]
-> You can only download artifacts in a workflow that were uploaded during the same workflow run.
+> {% ifversion fpt or ghec %}If you want to download artifacts from a different workflow or workflow run, you need to supply a token and run identifier. See [Download Artifacts from other Workflow Runs or Repositories](https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories) in the documentation for the download-artifact action.
+{% elsif ghes %}You can only download artifacts in a workflow that were uploaded during the same workflow run.{% endif %}
 
 Specify an artifact's name to download an individual artifact. If you uploaded an artifact without specifying a name, the default name is `artifact`.
 


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs/issues/36343

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The existing note is still correct for users of GitHub Enterprise Server, but wrong for users of Github cloud. This PR updates the note to cover the options for GitHub cloud users. See more detailed information in: https://github.com/github/docs/issues/36343#issuecomment-2668309339.

New note for Free, Pro, Team, and GitHub Enterprise Cloud versions of the docs:

<img width="749" alt="Screenshot showing a preview of the note content for users of Github Cloud." src="https://github.com/user-attachments/assets/304b6065-c247-423e-854f-684b16668044" />

The original note is still shown for GitHub Enterprise Server versions of the docs.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the preview environment.
