### PR TITLE
Update squash_and_merge_summary.md

### DIFF
--- a/data/reusables/pull_requests/squash_and_merge_summary.md
+++ b/data/reusables/pull_requests/squash_and_merge_summary.md
@@ -4,4 +4,4 @@ To squash and merge pull requests, you must have [write permissions](/organizati
 
 ![Diagram of commit squashing, where multiple commits from a feature branch are combined into only one commit that is added to `main`.](/assets/images/help/pull_requests/commit-squashing-diagram.png)
 
-You can use squash and merge to create a more streamlined Git history in your repository. Work-in-progress commits are helpful when working on a feature branch, but they aren’t necessarily important to retain in the Git history. If you squash these commits into one commit when merging to the default branch, you retain only the consolidated changes, leading to a clear Git history.
+You can use squash and merge to create a more streamlined Git history in your repository. Work-in-progress commits are helpful when working on a feature branch, but they aren’t necessarily important to retain in the Git history. If you squash these commits into one commit when merging to the default branch, the changes are consolidated, leading to a clear Git history.

--- a/data/reusables/pull_requests/squash_and_merge_summary.md
+++ b/data/reusables/pull_requests/squash_and_merge_summary.md
@@ -4,4 +4,4 @@ To squash and merge pull requests, you must have [write permissions](/organizati
 
 ![Diagram of commit squashing, where multiple commits from a feature branch are combined into only one commit that is added to `main`.](/assets/images/help/pull_requests/commit-squashing-diagram.png)
 
-You can use squash and merge to create a more streamlined Git history in your repository. Work-in-progress commits are helpful when working on a feature branch, but they aren’t necessarily important to retain in the Git history. If you squash these commits into one commit while merging to the default branch, you can retain the original changes with a clear Git history.
+You can use squash and merge to create a more streamlined Git history in your repository. Work-in-progress commits are helpful when working on a feature branch, but they aren’t necessarily important to retain in the Git history. If you squash these commits into one commit when merging to the default branch, you retain only the consolidated changes, leading to a clear Git history.


### PR DESCRIPTION
Revise terminology from "original" change to "consolidated" changes to better describe what gets committed when squashing commits.

### Why:
The final sentence of the squash and merge summary confusingly describes squashing commits as retaining "original" changes. That isn't accurate. Consolidated changes are kept from squashing commits.

Closes: #36456

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Only the final sentence of the reusable squash-and-merge-summary snippet is updated.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
