### PR TITLE
Fixing subheading level sudo-mode.md

### DIFF
--- a/content/authentication/keeping-your-account-and-data-secure/sudo-mode.md
+++ b/content/authentication/keeping-your-account-and-data-secure/sudo-mode.md
@@ -56,7 +56,7 @@ To confirm access for sudo mode, you can authenticate with your password. Option
 
 {% ifversion passkeys %}
 
-## Confirming access using a passkey
+### Confirming access using a passkey
 
 You must have a passkey registered to your account to confirm access to your account for sudo mode using a passkey. See [AUTOTITLE](/authentication/authenticating-with-a-passkey/about-passkeys).
 {% endif %}

--- a/content/authentication/keeping-your-account-and-data-secure/sudo-mode.md
+++ b/content/authentication/keeping-your-account-and-data-secure/sudo-mode.md
@@ -45,7 +45,7 @@ After you authenticate to perform a sensitive action, your session is temporaril
 To confirm access for sudo mode, you can authenticate with your password. Optionally, you can use a different authentication method, like {% ifversion passkeys %}a passkey, {% endif %}{% ifversion fpt or ghec %}a security key, {% data variables.product.prodname_mobile %}, or a 2FA code{% elsif ghes %}a security key or a 2FA code{% endif %}.
 
 {%- ifversion passkeys %}
-* [Confirming access using a passkey key](#confirming-access-using-a-passkey)
+* [Confirming access using a passkey](#confirming-access-using-a-passkey)
 {%- endif %}
 * [Confirming access using a security key](#confirming-access-using-a-security-key)
 {%- ifversion fpt or ghec %}


### PR DESCRIPTION
Was working on some docs for WordPress VIP about a similar feature and saw that one of the subheading on this page wasn't at the correct level in the hierarchy. This should fix that.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: No issue - just a subheading change

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

![image](https://github.com/user-attachments/assets/2913abfb-0d1e-4397-99d8-03384590cdda)

As you can see, the top two headings are H2s whereas the second heading should be an H3 to match the others.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
