### PR TITLE
Xcode extension is now generally available

### DIFF
--- a/content/copilot/using-github-copilot/copilot-chat/asking-github-copilot-questions-in-your-ide.md
+++ b/content/copilot/using-github-copilot/copilot-chat/asking-github-copilot-questions-in-your-ide.md
@@ -362,8 +362,6 @@ To share feedback about {% data variables.product.prodname_copilot_chat_short %}
 
 {% xcode %}
 
-{% data reusables.copilot.xcode-chat-public-preview-note %}
-
 ## Prerequisites
 
 To use {% data variables.product.prodname_copilot %} for Xcode, you must install the {% data variables.product.prodname_copilot %} for Xcode extension. See [AUTOTITLE](/copilot/configuring-github-copilot/installing-the-github-copilot-extension-in-your-environment).

--- a/data/reusables/copilot/xcode-chat-public-preview-note.md
+++ b/data/reusables/copilot/xcode-chat-public-preview-note.md
@@ -1,1 +1,0 @@
-> [!NOTE] {% data variables.product.prodname_copilot_chat_short %} in Xcode is in {% data variables.release-phases.public_preview %} and subject to change.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

See https://github.blog/changelog/2025-02-14-code-completion-in-github-copilot-for-xcode-is-now-generally-available/.

Also, it would be nice if you notice https://github.com/github/CopilotForXcode maintainers so they remove `Preview` labels from [README](https://github.com/github/CopilotForXcode#readme) because [they don't accept PRs](https://github.com/github/CopilotForXcode/blob/main/.github/workflows/auto-close-pr.yml).

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
