### PR TITLE
chore: update sponsorship link for supported regions

### DIFF
--- a/data/reusables/sponsors/stripe-supported-regions.md
+++ b/data/reusables/sponsors/stripe-supported-regions.md
@@ -1,1 +1,1 @@
-For a list of supported regions, see [{% data variables.product.prodname_sponsors %}](https://github.com/sponsors#regions).
+For a list of supported regions, see [AUTOTITLE](/sponsors/getting-started-with-github-sponsors/about-github-sponsors#supported-regions-for-github-sponsors).


### PR DESCRIPTION
### Why:

closes: [issue 36553](https://github.com/github/docs/issues/36553)

### What's being changed (if available, include any code snippets, screenshots, or gifs):
- Updated sponsorship link for supported regions

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing, and the changes look good in the review environment.
