### PR TITLE
Update link for renewing GitHub Education account

### DIFF
--- a/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/github-education-for-students/apply-to-github-education-as-a-student.md
+++ b/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/github-education-for-students/apply-to-github-education-as-a-student.md
@@ -42,11 +42,10 @@ For information about renewing your {% data variables.product.prodname_global_ca
 
 ## Expiration and renewals
 
-Once your {% data variables.product.prodname_global_campus %} access expires, you may reapply if you're still eligible, although some of our partner offers for {% data variables.product.prodname_student_pack %} cannot renew. Most of the timed offers from our partners start once you set them up. To reapply, first make sure that you are signed in to your GitHub Education account. Then navigate to to https://education.github.com/learner/learn, click your profile picture, then click **Your benefits application**.
+Once your {% data variables.product.prodname_global_campus %} access expires, you may reapply if you're still eligible, although some of our partner offers for {% data variables.product.prodname_student_pack %} cannot renew. Most of the timed offers from our partners start once you set them up. To reapply, first make sure that you are signed in to your {% data variables.product.prodname_education %} account. Then, navigate to https://education.github.com/learner/learn, click your profile picture, then click **Your benefits application**.
 
 ![Screenshot of a profile menu on the GitHub Education website. The "Your benefits application" menu option is outlined in red.](/assets/images/help/education/your-benefits-application.png)
 
-Once on the "Benefits application" page, you will find further instructions on how to renew your account.
 
 For more information, see the [{% data variables.product.prodname_student_pack %}](https://education.github.com/pack) page.
 

--- a/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/github-education-for-students/apply-to-github-education-as-a-student.md
+++ b/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/github-education-for-students/apply-to-github-education-as-a-student.md
@@ -46,7 +46,6 @@ Once your {% data variables.product.prodname_global_campus %} access expires, yo
 
 ![Screenshot of a profile menu on the GitHub Education website. The "Your benefits application" menu option is outlined in red.](/assets/images/help/education/your-benefits-application.png)
 
-
 For more information, see the [{% data variables.product.prodname_student_pack %}](https://education.github.com/pack) page.
 
 To see when your free access to the {% data variables.product.prodname_student_pack %} expires, visit your account's [billing settings](https://github.com/settings/billing).

--- a/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/github-education-for-students/apply-to-github-education-as-a-student.md
+++ b/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/github-education-for-students/apply-to-github-education-as-a-student.md
@@ -42,7 +42,7 @@ For information about renewing your {% data variables.product.prodname_global_ca
 
 ## Expiration and renewals
 
-Once your {% data variables.product.prodname_global_campus %} access expires, you may reapply if you're still eligible, although some of our partner offers for {% data variables.product.prodname_student_pack %} cannot renew. Most of the timed offers from our partners start once you set them up. To reapply, simply return to https://education.github.com, click your profile picture, then click **Your benefits application**.
+Once your {% data variables.product.prodname_global_campus %} access expires, you may reapply if you're still eligible, although some of our partner offers for {% data variables.product.prodname_student_pack %} cannot renew. Most of the timed offers from our partners start once you set them up. To reapply, simply return to https://education.github.com/learner/learn, click your profile picture, then click **Your benefits application**.
 
 ![Screenshot of a profile menu on the GitHub Education website. The "Your benefits application" menu option is outlined in red.](/assets/images/help/education/your-benefits-application.png)
 

--- a/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/github-education-for-students/apply-to-github-education-as-a-student.md
+++ b/content/education/explore-the-benefits-of-teaching-and-learning-with-github-education/github-education-for-students/apply-to-github-education-as-a-student.md
@@ -42,9 +42,11 @@ For information about renewing your {% data variables.product.prodname_global_ca
 
 ## Expiration and renewals
 
-Once your {% data variables.product.prodname_global_campus %} access expires, you may reapply if you're still eligible, although some of our partner offers for {% data variables.product.prodname_student_pack %} cannot renew. Most of the timed offers from our partners start once you set them up. To reapply, simply return to https://education.github.com/learner/learn, click your profile picture, then click **Your benefits application**.
+Once your {% data variables.product.prodname_global_campus %} access expires, you may reapply if you're still eligible, although some of our partner offers for {% data variables.product.prodname_student_pack %} cannot renew. Most of the timed offers from our partners start once you set them up. To reapply, first make sure that you are signed in to your GitHub Education account. Then navigate to to https://education.github.com/learner/learn, click your profile picture, then click **Your benefits application**.
 
 ![Screenshot of a profile menu on the GitHub Education website. The "Your benefits application" menu option is outlined in red.](/assets/images/help/education/your-benefits-application.png)
+
+Once on the "Benefits application" page, you will find further instructions on how to renew your account.
 
 For more information, see the [{% data variables.product.prodname_student_pack %}](https://education.github.com/pack) page.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #36625 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

This PR updates the link for renewing a GitHub Education to avoid incorrectly redirecting to https://github.com/education. Instead, the user will always end up at the desired https://education.github.com/learner/learn. 

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
