### PR TITLE
Use --no-restore and --no-build when possible

### DIFF
--- a/content/actions/use-cases-and-examples/building-and-testing/building-and-testing-net.md
+++ b/content/actions/use-cases-and-examples/building-and-testing/building-and-testing-net.md
@@ -171,9 +171,9 @@ steps:
 - name: Install dependencies
   run: dotnet restore
 - name: Build
-  run: dotnet build
+  run: dotnet build --no-restore
 - name: Test with the dotnet CLI
-  run: dotnet test
+  run: dotnet test --no-build
 ```
 
 ## Packaging workflow data as artifacts
@@ -204,7 +204,7 @@ jobs:
         - name: Install dependencies
           run: dotnet restore
         - name: Test with dotnet
-          run: dotnet test --logger trx --results-directory {% raw %}"TestResults-${{ matrix.dotnet-version }}"{% endraw %}
+          run: dotnet test --no-restore --logger trx --results-directory {% raw %}"TestResults-${{ matrix.dotnet-version }}"{% endraw %}
         - name: Upload dotnet test results
           uses: {% data reusables.actions.action-upload-artifact %}
           with:


### PR DESCRIPTION
### Why:

In dotnet, when manually calling `dotnet restore`, the following `dotnet build` can skip the restoring step with the flag `--no-restore`.
Also, when manually calling `dotnet build`, the following `dotnet test` can skip the building step with the flag `--no-build`, which also implicitly sets the `--no-restore` flag (https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?tabs=dotnet-test-with-vstest).

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Change the yaml examples to use the `--no-restore` and `--no-build` flags when possible, just like the GHES example.

https://github.com/github/docs/blob/a29d6739245e9906c5cd1f815d0f3d27e5e64765/content/actions/use-cases-and-examples/building-and-testing/building-and-testing-net.md?plain=1#L63-L68

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
