### PR TITLE
Add Eclipse Update Site for the GitHub Copilot Eclipse plug-in

### DIFF
--- a/content/copilot/managing-copilot/configure-personal-settings/installing-the-github-copilot-extension-in-your-environment.md
+++ b/content/copilot/managing-copilot/configure-personal-settings/installing-the-github-copilot-extension-in-your-environment.md
@@ -246,7 +246,7 @@ To see instructions for other popular coding environments, use the tool switcher
 
 ## Installing {% data variables.product.prodname_copilot %} in Eclipse
 
-1. Download and install the latest version of {% data variables.product.prodname_copilot %} from the [Eclipse Marketplace](https://aka.ms/copiloteclipse) or directly via the [Eclipse Update Site](https://azuredownloads-g3ahgwb5b8bkbxhd.b01.azurefd.net/github-copilot/) by following the [Eclipse documentation](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.user%2Ftasks%2Ftasks-124.htm&cp%3D0_3_19).
+1. Download and install the latest version of {% data variables.product.prodname_copilot %} from the [Eclipse Marketplace](https://aka.ms/copiloteclipse) or directly via the [Eclipse Update Site](https://azuredownloads-g3ahgwb5b8bkbxhd.b01.azurefd.net/github-copilot/). For more information, see [Installing New Software](https://help.eclipse.org/latest/topic/org.eclipse.platform.doc.user/tasks/tasks-124.htm) in the Eclipse documentation.
 
 1. After the extension is installed, restart Eclipse to apply the changes.
 

--- a/content/copilot/managing-copilot/configure-personal-settings/installing-the-github-copilot-extension-in-your-environment.md
+++ b/content/copilot/managing-copilot/configure-personal-settings/installing-the-github-copilot-extension-in-your-environment.md
@@ -246,7 +246,7 @@ To see instructions for other popular coding environments, use the tool switcher
 
 ## Installing {% data variables.product.prodname_copilot %} in Eclipse
 
-1. Download and install the latest version of {% data variables.product.prodname_copilot %} in the [Eclipse Marketplace](https://aka.ms/copiloteclipse).
+1. Download and install the latest version of {% data variables.product.prodname_copilot %} from the [Eclipse Marketplace](https://aka.ms/copiloteclipse) or directly via the [Eclipse Update Site](https://azuredownloads-g3ahgwb5b8bkbxhd.b01.azurefd.net/github-copilot/) by following the [Eclipse documentation](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.user%2Ftasks%2Ftasks-124.htm&cp%3D0_3_19).
 
 1. After the extension is installed, restart Eclipse to apply the changes.
 


### PR DESCRIPTION
Closes: [36411
](https://github.com/github/docs/issues/36411)

Installing from the Eclipse Update Site is an alternative to the Eclipse Marketplace (that might not be available). Link to the official (and always latest) Eclipse documentation on how to do so.
