### PR TITLE
Adds redirect

### DIFF
--- a/content/site-policy/acceptable-use-policies/github-appeal-and-reinstatement.md
+++ b/content/site-policy/acceptable-use-policies/github-appeal-and-reinstatement.md
@@ -2,6 +2,8 @@
 title: GitHub Appeal and Reinstatement
 versions:
   fpt: '*'
+redirect_from:
+  - /articles/github-appeal-and-reinstatement
 topics:
   - Policy
   - Legal


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs-content/issues/17479

### What's being changed (if available, include any code snippets, screenshots, or gifs):

> Similar to other site [policy docs](https://github.com/github/site-policy/blob/4d03f2c5d14862cc9f582105a29ef1d19dee805a/Policies/acceptable-use-policies/github-acceptable-use-policies.md), I believe our current [GitHub Appeal and Reinstatement doc](https://github.com/github/site-policy/blob/4d03f2c5d14862cc9f582105a29ef1d19dee805a/Policies/acceptable-use-policies/github-appeal-and-reinstatement.md) is missing a redirect from /articles/github-appeal-and-reinstatement

Adds the redirect

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
