### PR TITLE
Add hint for Enforcement Status for Rulesets

### DIFF
--- a/data/reusables/repositories/repo-new-ruleset.md
+++ b/data/reusables/repositories/repo-new-ruleset.md
@@ -1,4 +1,4 @@
 1. Click **New ruleset**.
 1. Click **New branch ruleset**.
 1. Under "Ruleset name," type a name for the ruleset.
-1. Set "Enforcement Status" to `Active` to ensure that the ruleset is taken into account.
+1. To activate the ruleset, under "Enforcement Status", select **Active**.

--- a/data/reusables/repositories/repo-new-ruleset.md
+++ b/data/reusables/repositories/repo-new-ruleset.md
@@ -1,3 +1,4 @@
 1. Click **New ruleset**.
 1. Click **New branch ruleset**.
 1. Under "Ruleset name," type a name for the ruleset.
+1. Set "Enforcement Status" to `Active` to ensure that the ruleset is taken into account.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: [36801](https://github.com/github/docs/issues/36801)

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
This change will extend the description how to setup a Ruleset for Copilot for the following 2 paragraphs:
[Configuring automatic code review for a single repository](https://docs.github.com/en/copilot/using-github-copilot/code-review/configuring-automatic-code-review-by-copilot#configuring-automatic-code-review-for-a-single-repository)
[Configuring automatic code review for repositories in an organization](https://docs.github.com/en/copilot/using-github-copilot/code-review/configuring-automatic-code-review-by-copilot#configuring-automatic-code-review-for-repositories-in-an-organization)

Point 5 will be replaced by this change with the hint that the "Enforcement Status" should be set to `Active` to ensure that the ruleset is taken into account.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
