### PR TITLE
Clarify blank lines requirement for Co-authored-by

### DIFF
--- a/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors.md
+++ b/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors.md
@@ -36,7 +36,7 @@ You can use {% data variables.product.prodname_desktop %} to create a commit wit
 
 {% data reusables.pull_requests.collect-co-author-commit-git-config-info %}
 
-1. Type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add two empty lines.
+1. Type your commit message and a short, meaningful description of your changes. After your commit description, instead of a closing quotation, add an empty line.
 
    ```shell
    $ git commit -m "Refactor usability tests.
@@ -45,7 +45,7 @@ You can use {% data variables.product.prodname_desktop %} to create a commit wit
    ```
 
    > [!TIP]
-   > If you're using a text editor on the command line to type your commit message, ensure there are two newlines between the end of your commit description and the `Co-authored-by:` commit trailer.
+   > If you're using a text editor on the command line to type your commit message, ensure there is a blank line (i.e., two consecutive newlines) between the end of your commit description and the `Co-authored-by:` commit trailer.
 
 1. On the next line of the commit message, type `Co-authored-by: name <name@example.com>` with specific information for each co-author. After the co-author information, add a closing quotation mark.
 
@@ -54,9 +54,8 @@ You can use {% data variables.product.prodname_desktop %} to create a commit wit
    ```shell
    $ git commit -m "Refactor usability tests.
    >
-   >
-   Co-authored-by: NAME <NAME@EXAMPLE.COM>
-   Co-authored-by: ANOTHER-NAME <ANOTHER-NAME@EXAMPLE.COM>"
+   > Co-authored-by: NAME <NAME@EXAMPLE.COM>
+   > Co-authored-by: ANOTHER-NAME <ANOTHER-NAME@EXAMPLE.COM>"
    ```
 
 The new commit and message will appear on {% data variables.location.product_location %} the next time you push. For more information, see [AUTOTITLE](/get-started/using-git/pushing-commits-to-a-remote-repository).

--- a/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors.md
+++ b/content/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors.md
@@ -45,7 +45,7 @@ You can use {% data variables.product.prodname_desktop %} to create a commit wit
    ```
 
    > [!TIP]
-   > If you're using a text editor on the command line to type your commit message, ensure there is a blank line (i.e., two consecutive newlines) between the end of your commit description and the `Co-authored-by:` commit trailer.
+   > If you're using a text editor on the command line to type your commit message, ensure there is a blank line (two consecutive newlines) between the end of your commit description and the `Co-authored-by:` commit trailer.
 
 1. On the next line of the commit message, type `Co-authored-by: name <name@example.com>` with specific information for each co-author. After the co-author information, add a closing quotation mark.
 


### PR DESCRIPTION
### Why:

At the moment, these docs suggests that two blank lines are needed before the Co-authored-by trailers for github to recognise the declared co-authors. This is (now?) incorrect, as can be seen in [this commit](https://github.com/guardian/amigo/commit/84df33440545401a4737e7584cb4e64855c693ae), which only leaves one blank line but does display the two co-authors in the UI.

Closes: https://github.com/github/docs/issues/36812

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This commit updates the docs to make it clearer that only one blank line is required.

I’ve also added the missing leading `>` symbols before the trailers when writing the message in the shell (they’re added by bash and possibly others to indicate it’s a continuation line).

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
