### PR TITLE
fix: omit incorrect slash commands

### DIFF
--- a/content/copilot/using-github-copilot/copilot-chat/github-copilot-chat-cheat-sheet.md
+++ b/content/copilot/using-github-copilot/copilot-chat/github-copilot-chat-cheat-sheet.md
@@ -28,11 +28,8 @@ Available slash commands may vary, depending on your environment and the context
 | --- | --- |
 | `/clear` | Clear conversation. |
 | `/delete` | Delete a conversation. |
-| `/file` | Retrieves a specific file from the repository by its path. |
-| `/help` | Quick reference and basics of using {% data variables.product.prodname_copilot %}. |
 | `/new` | Start a new conversation |
 | `/rename` | Rename a conversation. |
-| `/search` | Performs a search within the repository, including issues, pull requests, and code. |
 
 {% endwebui %}
 
@@ -145,12 +142,9 @@ Available slash commands may vary, depending on your environment and the context
 
 | Command | Description |
 | --- | --- |
-| `/clear` | Start a new chat session. |
 | `/explain` | Explain how the code in your active editor works. |
 | `/fix` | Propose a fix for problems in the selected code. |
-| `/fixTestFailure` | Find and fix a failing test. |
 | `/help` | Quick reference and basics of using {% data variables.product.prodname_copilot %}. |
-| `/new` | Create a new project. |
 | `/tests` | Generate unit tests for the selected code. |
 
 ## Chat participants


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes #36574 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This pull request omits the following slash commands in the JetBrains and Web Browser sections of the GitHub Copilot Cheat tutorial:

1. JetBrains


`/clear`
`/fixTestFailure`
`/new`

2. Web Browser
`/file`
`/help`
`/search`

By making these changes, users would have an clearer understanding of the commands to use in GitHub Copilot. 
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [X] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [X] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
