### PR TITLE
Update section-running-jobs-in-a-container.md

### DIFF
--- a/data/reusables/actions/jobs/section-running-jobs-in-a-container.md
+++ b/data/reusables/actions/jobs/section-running-jobs-in-a-container.md
@@ -5,6 +5,9 @@ If you do not set a `container`, all steps will run directly on the host specifi
 > [!NOTE]
 > The default shell for `run` steps inside a container is `sh` instead of `bash`. This can be overridden with [`jobs.<job_id>.defaults.run`](/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun) or [`jobs.<job_id>.steps[*].shell`](/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell).
 
+> [!NOTE]
+> If you supply your own container image, the `WORKDIR` statement may not be detected and you will need to (re)specify it yourself with the [`jobs.<job_id>.defaults.run.working-directory](/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_iddefaultsrunworking-directory) option.
+
 ### Example: Running a job within a container
 
 ```yaml copy
@@ -36,4 +39,32 @@ jobs:
   container-test-job:
     runs-on: ubuntu-latest
     container: node:18
+```
+### Example: Running a job within a custom container with a working directory set
+```yaml copy
+name: CI
+on:
+  push:
+    branches: [ main ]
+jobs:
+  container-test-job:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: `/home/app/webapp`
+    container:
+      image: myimage
+      credentials:
+        username: MYUSERNAME
+        password: MYPASSWORD
+      env:
+        NODE_ENV: development
+      ports:
+        - 80
+      volumes:
+        - my_docker_volume:/volume_mount
+      options: --cpus 1
+    steps:
+      - name: Check for dockerenv file
+        run: (ls .dockerenv && echo Found dockerenv) || (echo No dockerenv)
 ```


### PR DESCRIPTION
Adds a note and example explaining that the working directory may need to be set when using a custom container.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #37027

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I'm adding a section to the Run jobs in a container article to warn users that they may need to set the `working-directory` option if they are supply a custom image. I also provide an example of the configuration file.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
