### PR TITLE
Fixed a typo in disabling-github-copilot-free.md

### DIFF
--- a/content/copilot/managing-copilot/managing-copilot-as-an-individual-subscriber/managing-copilot-free/disabling-github-copilot-free.md
+++ b/content/copilot/managing-copilot/managing-copilot-as-an-individual-subscriber/managing-copilot-free/disabling-github-copilot-free.md
@@ -16,7 +16,7 @@ topics:
 You can disable {% data variables.product.prodname_copilot_free_short %} in your {% data variables.product.github %} account settings. This will disable all features of {% data variables.product.prodname_copilot_short %} on {% data variables.product.github %}.
 
 1. In the upper-right corner of any page, click your profile photo, then click **{% octicon "copilot" aria-hidden="true" %} Your {% data variables.product.prodname_copilot_short %}**.
-1. Under "Visibility", to the right of "Show {% data variables.product.prodname_copilot_short %}", select **Disabled** from the dropdown.
+1. Under "Visibility", to the right of "Show {% data variables.product.prodname_copilot_short %}," select **Disabled** from the dropdown.
 
 ## Disabling {% data variables.product.prodname_copilot_free_short %} in your IDE
 

--- a/content/copilot/managing-copilot/managing-copilot-as-an-individual-subscriber/managing-copilot-free/disabling-github-copilot-free.md
+++ b/content/copilot/managing-copilot/managing-copilot-as-an-individual-subscriber/managing-copilot-free/disabling-github-copilot-free.md
@@ -16,7 +16,7 @@ topics:
 You can disable {% data variables.product.prodname_copilot_free_short %} in your {% data variables.product.github %} account settings. This will disable all features of {% data variables.product.prodname_copilot_short %} on {% data variables.product.github %}.
 
 1. In the upper-right corner of any page, click your profile photo, then click **{% octicon "copilot" aria-hidden="true" %} Your {% data variables.product.prodname_copilot_short %}**.
-1. Under "Visibility", to the right of "Show {% data variables.product.prodname_copilot_short %}, select **Disabled** from the dropdown.
+1. Under "Visibility", to the right of "Show {% data variables.product.prodname_copilot_short %}", select **Disabled** from the dropdown.
 
 ## Disabling {% data variables.product.prodname_copilot_free_short %} in your IDE
 


### PR DESCRIPTION
"Show Copilot" was missing quotations.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

![image](https://github.com/user-attachments/assets/0ea38a1e-de11-42c3-b1a5-b59f7013bdee)

Changed "Show Copilot to "Show Copilot".

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
