### PR TITLE
Update billing_plans.md

### DIFF
--- a/data/reusables/user-settings/billing_plans.md
+++ b/data/reusables/user-settings/billing_plans.md
@@ -1,1 +1,1 @@
-1. In the "Access" section of the sidebar, click **{% octicon "credit-card" aria-hidden="true" %} Billing and plans**, then click **Plans and usage**.
+1. In the "Access" section of the sidebar, click **{% octicon "credit-card" aria-hidden="true" %} Billing and Licensing**, then click **Licensing**.


### PR DESCRIPTION
Updated sidebar headings to match new layout of https://github.com/settings/

### Why:

Closes: https://github.com/github/docs/issues/37120

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Headings referred to in billing_plans.md updated to reflect new headings on https://github.com/settings/.

Billing and plans > Billing and Licensing
Plans and usage > Licensing

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
