### PR TITLE
fix: change 'day' to 'Tuesday' in optimizing docs

### DIFF
--- a/content/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates.md
+++ b/content/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates.md
@@ -35,7 +35,7 @@ However, to reduce distraction, or to better organize time and resources for rev
 
 You can use `schedule` with a combination of options to modify the frequency and timings of when {% data variables.product.prodname_dependabot %} checks for version updates
 
-The example `dependabot.yml` file below changes the npm configuration to specify that {% data variables.product.prodname_dependabot %} should check for version updates to npm dependencies every day at 02:00 Japanese Standard Time (UTC +09:00).
+The example `dependabot.yml` file below changes the npm configuration to specify that {% data variables.product.prodname_dependabot %} should check for version updates to npm dependencies every Tuesday at 02:00 Japanese Standard Time (UTC +09:00).
 
 ```yaml copy
 # `dependabot.yml` file with


### PR DESCRIPTION
In dependabot optimizing docs (https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates), there is an example, for which the dependabot should run each Tuesday. However, in the explaining text it says that it should run 'every day', which is not correct.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/37136

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

changed _every day_ to _every Tuesday_, to match the example code block.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
