### PR TITLE
Fixed missing curly brace for variable in the docs (comparing-ai-models-using-diff…)

### DIFF
--- a/content/copilot/using-github-copilot/ai-models/comparing-ai-models-using-different-tasks.md
+++ b/content/copilot/using-github-copilot/ai-models/comparing-ai-models-using-different-tasks.md
@@ -133,7 +133,7 @@ You’re designing a shopping cart system and have a UML class diagram that outl
 
 {% data reusables.copilot.example-prompts.response-is-an-example %}
 
-% data variables.product.prodname_copilot_short %} will generate a class for each of the classes in the diagram, including the relationships between them. Here’s the example code generated for the `Cart` class:
+{% data variables.product.prodname_copilot_short %} will generate a class for each of the classes in the diagram, including the relationships between them. Here’s the example code generated for the `Cart` class:
 
 ```python
 from cart_item import CartItem


### PR DESCRIPTION
A simple GitHub documentation update to fix a malformed dynamic variable.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
