### PR TITLE
Added warning to documentation.

### DIFF
--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
@@ -289,6 +289,7 @@ Write-Output "::add-mask::Mona The Octocat"
 
 > [!WARNING]
 > Make sure you register the secret with 'add-mask' before outputting it in the build logs or using it in any other workflow commands.
+> This will still leak the string initialy as part of the echo statment.
 
 ### Example: Masking an environment variable
 
@@ -323,6 +324,9 @@ jobs:
 ```
 
 {% endpowershell %}
+
+> [!WARNING]
+> This will still leak the string as part of the env.
 
 ### Example: Masking a generated output within a single job
 


### PR DESCRIPTION
These strings leaking has been a known issue since at least 5 years (See github issue: https://github.com/actions/runner/issues/475) regardless of whether or not this will ever be fixed the least that can be done is give the user a heads up that these 2 use cases will not mask the values. (Removing the 2 sections in their entirety might also be an option 🤔).

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes:  github issue: https://github.com/actions/runner/issues/475

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Merly adding two warnings to two sections giving the user a heads up that these "masks" will still leak the string that should be masked.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
