### PR TITLE
Typo 2.5 pro Gemini in docs

### DIFF
--- a/content/copilot/using-github-copilot/ai-models/choosing-the-right-ai-model-for-your-task.md
+++ b/content/copilot/using-github-copilot/ai-models/choosing-the-right-ai-model-for-your-task.md
@@ -331,7 +331,7 @@ The following table summarizes the strengths of {% data variables.copilot.copilo
 
 {% rowheaders %}
 
-| Task                      | Description                                                       | Why {% data variables.copilot.copilot_gemini_flash %} is a good fit |
+| Task                      | Description                                                       | Why {% data variables.copilot.copilot_gemini_25_pro %} is a good fit |
 |---------------------------|-------------------------------------------------------------------|---------------------------------------------------------------------|
 | Complex code generation   | Write full functions, classes, or multi-file logic.               | Provides better structure, consistency, and fewer logic errors.     |
 | Debugging complex systems | Isolate and fix performance bottlenecks or multi-file issues.     | Provides step-by-step analysis and high reasoning accuracy.         |


### PR DESCRIPTION
Typo in documentation regarding 2.5 pro Gemini

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/37534

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
