### PR TITLE
Update UI Reference for Dependency Graph settings

### DIFF
--- a/content/code-security/getting-started/quickstart-for-securing-your-repository.md
+++ b/content/code-security/getting-started/quickstart-for-securing-your-repository.md
@@ -61,7 +61,7 @@ For more information, see [AUTOTITLE](/code-security/supply-chain-security/under
 
 {% ifversion fpt or ghec %}
 1. Click your profile photo, then click **Settings**.
-1. Click **{% data variables.product.UI_advanced_security %}**.
+1. Click **{% data variables.product.UI_code_security_scanning %}**.
 1. Click **Enable** next to {% data variables.product.prodname_dependabot_alerts %}.
 {% endif %}
 
@@ -80,7 +80,7 @@ Dependency review is a {% data variables.product.prodname_GH_code_security %} fe
 To enable dependency review for a repository, ensure that the dependency graph is enabled and enable {% data variables.product.prodname_GH_code_security %}.
 
 1. From the main page of your repository, click **{% octicon "gear" aria-hidden="true" %} Settings**.
-1. Click **{% data variables.product.UI_advanced_security %}**.{% ifversion fpt or ghec %}
+1. Click **{% data variables.product.UI_code_security_scanning %}**.{% ifversion fpt or ghec %}
 1. To the right of {% data variables.product.prodname_code_security %}, click **Enable**.
 1. Under {% data variables.product.prodname_code_security %}, check that dependency graph is enabled for the repository.
    * For public repositories, dependency graph is always enabled.{% elsif ghes %}
@@ -91,7 +91,7 @@ To enable dependency review for a repository, ensure that the dependency graph i
 For any repository that uses {% data variables.product.prodname_dependabot_alerts %}, you can enable {% data variables.product.prodname_dependabot_security_updates %} to raise pull requests with security updates when vulnerabilities are detected.
 
 1. From the main page of your repository, click **{% octicon "gear" aria-hidden="true" %} Settings**.
-1. Click **{% data variables.product.UI_advanced_security %}**.
+1. Click **{% data variables.product.UI_code_security_scanning %}**.
 1. Next to {% data variables.product.prodname_dependabot_security_updates %}, click **Enable**.
 
 For more information, see [AUTOTITLE](/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates) and [AUTOTITLE](/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates).
@@ -102,7 +102,7 @@ You can enable {% data variables.product.prodname_dependabot %} to automatically
 
 {% ifversion dependabot-settings-update-37 %}
 1. From the main page of your repository, click **{% octicon "gear" aria-hidden="true" %} Settings**.
-1. Click **{% data variables.product.UI_advanced_security %}**.
+1. Click **{% data variables.product.UI_code_security_scanning %}**.
 1. Next to {% data variables.product.prodname_dependabot_version_updates %}, click **Enable** to create a basic `dependabot.yml` configuration file.
 1. Specify the dependencies to update and any associated configuration options, then commit the file to the repository. For more information, see [AUTOTITLE](/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates).
 
@@ -137,7 +137,7 @@ As an alternative to default setup, you can use advanced setup, which generates 
 {% ifversion ghas-products %}{% data variables.product.prodname_GH_secret_protection %} includes {% data variables.product.prodname_secret_scanning %} and push protection, as well as other features that help you detect and prevent secret leaks in your repository.{% endif %}
 
 1. From the main page of your repository, click **{% octicon "gear" aria-hidden="true" %} Settings**.
-1. Click **{% data variables.product.UI_advanced_security %}**.
+1. Click **{% data variables.product.UI_code_security_scanning %}**.
 1. If {% data variables.product.prodname_secret_protection %} is not already enabled, click **Enable**.{% ifversion ghes < 3.17 %}
 1. Next to {% data variables.product.prodname_secret_scanning_caps %}, click **Enable**.{% endif %}{% ifversion ghas-products %}
 1. Choose whether you want to enable additional features, such as validity checks, scanning for non-provider patterns, and push protection.{% endif %}

--- a/content/code-security/getting-started/quickstart-for-securing-your-repository.md
+++ b/content/code-security/getting-started/quickstart-for-securing-your-repository.md
@@ -43,7 +43,7 @@ From the main page of your repository, click **{% octicon "gear" aria-hidden="tr
 {% data reusables.dependency-graph.feature-availability %} The dependency graph interprets manifest and lock files in a repository to identify dependencies.
 
 1. From the main page of your repository, click **{% octicon "gear" aria-hidden="true" %} Settings**.
-1. Click **{% data variables.product.UI_advanced_security %}**.
+1. Click **{% data variables.product.UI_code_security_scanning %}**.
 1. Next to Dependency graph, click **Enable** or **Disable**.
 {% endif %}
 


### PR DESCRIPTION
The UI element name for accessing the dependency graph settings was changed from "Advanced Security" to "Code Security"

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
At some point, the name of the sub-menu that contains the settings for the Dependency Graph was changed from "Advanced Security" to "Code Security", and this PR aims to propagate that change to the docs.

<!-- Paste the issue link or number here -->
Closes: #37541

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
The UI-element that directs users to a repository settings sub-menu is changed from "Advanced Security" to "Code Security"

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
