### PR TITLE
Add Dependabot permissions warnings

### DIFF
--- a/content/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions.md
+++ b/content/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions.md
@@ -82,6 +82,9 @@ jobs:
 
 By default, {% data variables.product.prodname_actions %} workflows triggered by {% data variables.product.prodname_dependabot %} get a `GITHUB_TOKEN` with read-only permissions. You can use the `permissions` key in your workflow to increase the access for the token:
 
+> [!WARNING]
+> Increasing the permissions for {% data variables.product.prodname_dependabot %} workflow runs can cause compromised dependencies to immediately infect your repository. Only grant the minimally required permissions to the workflow.
+
 {% raw %}
 
 ```yaml copy

--- a/content/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions.md
+++ b/content/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions.md
@@ -154,6 +154,9 @@ For more information, see [AUTOTITLE](/pull-requests/collaborating-with-pull-req
 
 You can instead use {% data variables.product.prodname_actions %} and the {% data variables.product.prodname_cli %}. Here is an example that automerges all patch updates to `my-dependency`:
 
+> [!WARNING]
+> Enabling automerge for {% data variables.product.prodname_dependabot %} pull requests can cause compromised dependencies to immediately infect your repository. Consider only automerging dependencies you fully trust, or adding additional checks which need to pass before the merge is performed.
+
 {% raw %}
 
 ```yaml copy


### PR DESCRIPTION
### Why:

Dependabot intentionally has no built-in automerge feature (https://github.com/dependabot/dependabot-core/issues/1973#issuecomment-640918321), and in the past permissions for Dependabot workflows were changed to read-only by default ([changelog entry](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)).

If I understand it correctly, the concern is that a Dependabot workflow with write permissions could be exploited by a compromised dependency to immediately compromise the consuming repository as soon as the Dependabot PR is created, without any interaction of the owner.

Therefore adding a custom automerge workflow for Dependabot or giving its workflows write permissions can be a security risk, and is probably worth pointing out in the documentation.

Slightly related to #37657, but does not resolve it

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Add warnings to the documentation to inform users about the risk of giving Dependabot workflows more permissions.

I hope these warnings do not seem like fear mongering (any feedback regarding wording is welcome!). Maybe some users who set up auto merging of Dependabot PRs might not consider this a big issue (or an issue at all).

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
