### PR TITLE
Change Events API event retention to 30 days

### DIFF
--- a/content/rest/activity/events.md
+++ b/content/rest/activity/events.md
@@ -35,6 +35,6 @@ $    -H 'If-None-Match: "a18c3bded88eb5dbb5c849a489412bf3"'
 > X-Poll-Interval: 60
 ```
 
-The timeline will include up to 300 events. Only events created within the past 90 days will be included. Events older than 90 days will not be included (even if the total number of events in the timeline is less than 300).
+The timeline will include up to 300 events. Only events created within the past 30 days will be included. Events older than 30 days will not be included (even if the total number of events in the timeline is less than 300).
 
 <!-- Content after this section is automatically generated -->


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

For https://github.com/github/sunset-squad/issues/33

Stratocaster now only stores data for 30 days.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This changes the doc about the Events API to indicate that data is now only shown from the last 30 days. It used to be 90 but was recently reduced to 30.

### Check off the following:

- [X] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
