### PR TITLE
Correct billing manager instructions

### DIFF
--- a/content/organizations/managing-peoples-access-to-your-organization-with-roles/adding-a-billing-manager-to-your-organization.md
+++ b/content/organizations/managing-peoples-access-to-your-organization-with-roles/adding-a-billing-manager-to-your-organization.md
@@ -63,7 +63,8 @@ If your organization is owned by an enterprise account, you cannot invite billin
 The invited person will receive an invitation email asking them to become a billing manager for your organization. Once the invited person clicks the accept link in their invitation email, they will automatically be added to the organization as a billing manager. If they don't already have a {% data variables.product.prodname_dotcom %} account, they will be directed to sign up for one, and they will be automatically added to the organization as a billing manager after they create an account.
 
 {% data reusables.organizations.billing-settings %}
-1. Under "Billing management", next to "Billing managers", click **Add**.
+1. Click **Additional billing details**.
+1. Next to "Billing managers", click **Invite**.
 1. Type the username or email address of the person you want to add and click **Send invitation**.
 
 ## Further reading


### PR DESCRIPTION
### Why:

To correct  instructions that direct users towards links and sections that have different names (“Billing managers“ is now under “Additional billing details”):

![image](https://github.com/user-attachments/assets/8b3171da-b5a5-477b-9fc1-cdae58a0e77f)

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The final steps for adding a billing manager now reflect the current naming of links and sections.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
