### PR TITLE
Update about-service-containers.md

### DIFF
--- a/content/actions/use-cases-and-examples/using-containerized-services/about-service-containers.md
+++ b/content/actions/use-cases-and-examples/using-containerized-services/about-service-containers.md
@@ -154,3 +154,4 @@ jobs:
 
 * [AUTOTITLE](/actions/using-containerized-services/creating-redis-service-containers)
 * [AUTOTITLE](/actions/using-containerized-services/creating-postgresql-service-containers)
+* https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions


### PR DESCRIPTION
Link to the schema in further reading

### Why:

Docs for `services:` in workflow files don't have a link to the schema docs.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

One liner to add a link to the Further Reading section.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
