### PR TITLE
Add note about Poetry v2 support

### DIFF
--- a/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
+++ b/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
@@ -396,7 +396,7 @@ Package manager | YAML value      | Supported versions |
 | pip-compile | `pip`            | 6.1.0            |
 | pipenv         | `pip`            | <= 2021-05-29    |
 | pnpm   | `npm`            | v7, v8 <br>v9 (version updates only)    |
-| poetry         | `pip`            | v1               |
+| poetry         | `pip`            | v2               |
 | pub         | `pub`            | v2  |
 | Swift   | `swift`      | v5  |
 | Terraform    | `terraform`      | >= 0.13, <= 1.10.x  |


### PR DESCRIPTION
### Why:
Poetry v2 support was added in https://github.com/dependabot/dependabot-core/pull/11642

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
