### PR TITLE
Update responsible-use-autofix-code-scanning to recomend dependabot

### DIFF
--- a/content/code-security/code-scanning/managing-code-scanning-alerts/responsible-use-autofix-code-scanning.md
+++ b/content/code-security/code-scanning/managing-code-scanning-alerts/responsible-use-autofix-code-scanning.md
@@ -109,6 +109,9 @@ Sometimes a suggested fix includes a change in the dependencies of the codebase.
 * _Unsupported or insecure dependencies:_ The system does not know which versions of an existing dependency are supported or secure.
 * _Fabricated dependencies:_ The system has incomplete knowledge of the dependencies published in the wider ecosystem. This can lead to suggestions that add a new dependency on malicious software that attackers have published under a statistically probable dependency name.
 
+> [!NOTE]
+> Our comprehensive dependency management recommendation continues to be “[AUTOTITLE](/code-security/dependabot)“
+
 ## Mitigating the limitations of suggestions
 
 The best way to mitigate the limitations of suggestions from {% data variables.product.prodname_copilot_autofix_short %} is to follow best practices. For example, using CI testing of pull requests to verify functional requirements are unaffected and using dependency management solutions, such as the dependency review API and action. For more information, see “[AUTOTITLE](/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review).”


### PR DESCRIPTION

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
