### PR TITLE
Fix typos in "Private keys" and "Use a webhook secret" sections

### DIFF
--- a/content/apps/creating-github-apps/about-creating-github-apps/best-practices-for-creating-a-github-app.md
+++ b/content/apps/creating-github-apps/about-creating-github-apps/best-practices-for-creating-a-github-app.md
@@ -40,7 +40,7 @@ The private key for your {% data variables.product.prodname_github_app %} grants
 
 Consider storing your {% data variables.product.prodname_github_app %}'s private key in a key vault, such as [Azure Key Vault](https://azure.microsoft.com/en-gb/products/key-vault), and making it sign-only.
 
-Alternatively, you can store the key as an environment variable. However, this not as strong as storing the key in a key vault. If an attacker gains access to the environment, they can read the private key and gain persistent authentication as the {% data variables.product.prodname_github_app %}.
+Alternatively, you can store the key as an environment variable. However, this is not as strong as storing the key in a key vault. If an attacker gains access to the environment, they can read the private key and gain persistent authentication as the {% data variables.product.prodname_github_app %}.
 
 You should never hard code your private key in your app, even if your code is stored in a private repository. If your app is a native client, client-side app, or runs on a user device (as opposed to running on your servers), you should never ship your private key with your app.
 
@@ -122,7 +122,7 @@ Only subscribe to the webhook events that your app needs. This will help reduce 
 
 ## Use a webhook secret
 
-You should set a webhook secret for your {% data variables.product.prodname_github_app %} and verify that the signature of incoming webhook events match the secret. This helps to ensure that the incoming webhook event is a valid {% data variables.product.company_short %} event.
+You should set a webhook secret for your {% data variables.product.prodname_github_app %} and verify that the signature of incoming webhook events matches the secret. This helps to ensure that the incoming webhook event is a valid {% data variables.product.company_short %} event.
 
 For more information, see [AUTOTITLE](/apps/creating-github-apps/setting-up-a-github-app/using-webhooks-with-github-apps#securing-your-webhooks-with-a-webhook-secret). For an example, see [AUTOTITLE](/apps/creating-github-apps/guides/building-a-github-app-that-responds-to-webhook-events).
 


### PR DESCRIPTION
Corrected grammatical issues:

- Added missing verb "is" in "However, this is not as strong..."
- Fixed subject-verb agreement in "signature... matches the secret"

These changes improve clarity and maintain the professional quality of the documentation.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
