### PR TITLE
Fix model name not found with gh models commands

### DIFF
--- a/content/github-models/use-github-models/integrating-ai-models-into-your-development-workflow.md
+++ b/content/github-models/use-github-models/integrating-ai-models-into-your-development-workflow.md
@@ -105,5 +105,5 @@ To see a list of all available commands, run `gh models`.
 
 There are a few key ways you can use the extension:
    * **To ask a model multiple questions using a chat experience**, run `gh models run`. Select your model from the listed models, then send your prompts.
-   * **To ask a model a single question**, run `gh models run MODEL-NAME "QUESTION"` in your terminal. For example, to ask the {% data variables.copilot.copilot_gpt_41 %} model why the sky is blue, you can run `gh models run gpt-4.1 "why is the sky blue?"`.
-   * **To provide the output of a command as context when you call a model**, you can join a separate command and the call to the model with the pipe character (`|`). For example, to summarize the README file in the current directory using the {% data variables.copilot.copilot_gpt_41 %} model, you can run `cat README.md | gh models run gpt-4.1 "summarize this text"`.
+   * **To ask a model a single question**, run `gh models run MODEL-NAME "QUESTION"` in your terminal. For example, to ask the {% data variables.copilot.copilot_gpt_41 %} model why the sky is blue, you can run `gh models run openai/gpt-4.1 "why is the sky blue?"`.
+   * **To provide the output of a command as context when you call a model**, you can join a separate command and the call to the model with the pipe character (`|`). For example, to summarize the README file in the current directory using the {% data variables.copilot.copilot_gpt_41 %} model, you can run `cat README.md | gh models run openai/gpt-4.1 "summarize this text"`.


### PR DESCRIPTION
### Why:
This PR updates the documentation for the `gh models run` command to use a valid model name.  
Previously, the docs referenced `gpt-4.1`, which is not a recognized model name and results in an error.  
The example has been updated to use `openai/gpt-4.1`, which is a valid model name according to the CLI help and available models.

Closes: #38606

**Screenshots:**

- Before:  
![image](https://github.com/user-attachments/assets/77763be9-3706-42fe-9627-af9d9c55e061)

- After:  
![image](https://github.com/user-attachments/assets/3cacbf31-6fd0-4f43-bb34-ff73645254fd)


**Code snippet changed:**
```diff
-* **To ask a model a single question**, run `gh models run MODEL-NAME "QUESTION"` in your terminal. For example, to ask the {% data variables.copilot.copilot_gpt_41 %} model why the sky is blue, you can run `gh models run gpt-4.1 "why is the sky blue?"`.
+* **To ask a model a single question**, run `gh models run MODEL-NAME "QUESTION"` in your terminal. For example, to ask the {% data variables.copilot.copilot_gpt_41 %} model why the sky is blue, you can run `gh models run openai/gpt-4.1 "why is the sky blue?"`.
```
```diff
-* **To provide the output of a command as context when you call a model**, you can join a separate command and the call to the model with the pipe character (`|`). For example, to summarize the README file in the current directory using the {% data variables.copilot.copilot_gpt_41 %} model, you can run `cat README.md | gh models run gpt-4.1 "summarize this text"`.
+* **To provide the output of a command as context when you call a model**, you can join a separate command and the call to the model with the pipe character (`|`). For example, to summarize the README file in the current directory using the {% data variables.copilot.copilot_gpt_41 %} model, you can run `cat README.md | gh models run openai/gpt-4.1 "summarize this text"`.
```

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.