### PR TITLE
Fix missing echo call for powershell

### DIFF
--- a/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
+++ b/content/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions.md
@@ -600,7 +600,7 @@ steps:
 >     steps:
 >       - shell: powershell
 >         run: |
->           "mypath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+>           echo "mypath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 > ```
 >
 > PowerShell Core versions 6 and higher (`shell: pwsh`) use UTF-8 by default. For example:
@@ -640,7 +640,7 @@ echo "{environment_variable_name}={value}" >> "$GITHUB_ENV"
 * Using PowerShell version 5.1 and below:
 
   ```powershell copy
-  "{environment_variable_name}={value}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+  echo "{environment_variable_name}={value}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
   ```
 
 {% endpowershell %}
@@ -951,7 +951,7 @@ echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 This example demonstrates how to add the user `$env:HOMEPATH/.local/bin` directory to `PATH`:
 
 ```powershell copy
-"$env:HOMEPATH/.local/bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+echo "$env:HOMEPATH/.local/bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
 ```
 
 {% endpowershell %}


### PR DESCRIPTION

### Why:

I found this issue, while reading the docs

### What's being changed (if available, include any code snippets, screenshots, or gifs):

If you use `"<whatever>" | Out-File -FilePath "$env:GITHUB_PATH" -Append` you need to add an echo to the command before the pipe (`|`)

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
