### PR TITLE
doc: remove prefix "Premium" of GPT-4.1 to reduce confusion

### DIFF
--- a/content/copilot/managing-copilot/monitoring-usage-and-entitlements/about-premium-requests.md
+++ b/content/copilot/managing-copilot/monitoring-usage-and-entitlements/about-premium-requests.md
@@ -47,7 +47,7 @@ Each model has a premium request multiplier, based on its complexity and resourc
 | Model                                                                   | Premium requests                                                             |
 |-------------------------------------------------------------------------|------------------------------------------------------------------------------|
 | Base model (currently {% data variables.copilot.copilot_gpt_41 %}) [^2] | 0 (paid users), 1 ({% data variables.copilot.copilot_free_short %}) |
-| Premium {% data variables.copilot.copilot_gpt_41 %}                     | 1                                                                            |
+| {% data variables.copilot.copilot_gpt_41 %}                             | 1                                                                            |
 | {% data variables.copilot.copilot_gpt_4o %}                             | 1                                                                            |
 | {% data variables.copilot.copilot_gpt_45 %}                             | 50                                                                           |
 | {% data variables.copilot.copilot_claude_sonnet_35 %}                   | 1                                                                            |


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
- While other models do not have the "Premium" prefix, the prefix "Premium" of GPT-4.1 has caused a lot of misunderstanding, like:
  -  Most people who look at this table will understand that there are 2 different models: the (Base) GPT-4.1 as the Base Model and the Premium GPT-4.1 as the Premium Model.
  - Therefore, some customers have asked me "Where can I find the setting to enable the Premium version of GPT-4.1?" 
 
So, please remove this prefix so that it is easier to understand.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->
- `about-premium-requests.md`

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
