### PR TITLE
Replace stale.yml with the workflow from another repo

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -44,7 +44,7 @@
 name: 'Marks stale issues and PRs'
 on:
   schedule:
-    - cron: '20 16 * * *' # 1:30 AM UTC
+    - cron: '20 16 * * *' # Run every day at 16:20 UTC / 8:20 PST
 
 permissions:
   issues: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,42 +1,63 @@
-name: Stale
+#name: Stale
 
 # **What it does**: Close issues and pull requests after no updates for 365 days.
 # **Why we have it**: We want to manage our queue of issues and pull requests.
 # **Who does it impact**: Everyone that works on docs or docs-internal.
 
+#on:
+  #schedule:
+   # - cron: '20 16 * * *' # Run every day at 16:20 UTC / 8:20 PST
+
+#permissions:
+  #contents: read
+  #issues: write
+  #pull-requests: write
+
+#jobs:
+  #stale:
+    #if: github.repository == 'github/docs-internal' || github.repository == 'github/docs'
+    #runs-on: ubuntu-latest
+    #steps:
+      #- uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        #with:
+          #repo-token: ${{ secrets.GITHUB_TOKEN }}
+          #stale-issue-message: 'This issue is stale because there have been no updates in 365 days.'
+          #stale-pr-message: 'This PR is stale because there have been no updates in 365 days.'
+          #days-before-stale: 365
+          #days-before-close: 0
+          #stale-issue-label: 'stale'
+          #stale-pr-label: 'stale'
+          #exempt-pr-labels: 'never-stale,waiting for review'
+          #exempt-issue-labels: 'never-stale,help wanted,waiting for review'
+          #operations-per-run: 1000
+          #close-issue-reason: not_planned
+
+      #- name: Check out repo
+        #if: ${{ failure() }}
+        #uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      #- uses: ./.github/actions/slack-alert
+        #if: ${{ failure() }}
+        #with:
+          #slack_channel_id: ${{ secrets.DOCS_ALERTS_SLACK_CHANNEL_ID }}
+          #slack_token: ${{ secrets.SLACK_DOCS_BOT_TOKEN }}
+
+name: 'Marks stale issues and PRs'
 on:
   schedule:
-    - cron: '20 16 * * *' # Run every day at 16:20 UTC / 8:20 PST
+    - cron: '30 1 * * *' # 1:30 AM UTC
 
 permissions:
-  contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   stale:
-    if: github.repository == 'github/docs-internal' || github.repository == 'github/docs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+      - uses: actions/stale@v9
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because there have been no updates in 365 days.'
-          stale-pr-message: 'This PR is stale because there have been no updates in 365 days.'
+          stale-issue-label: 'stale, triage' # The label that will be added to the issues when automatically marked as stale
+          start-date: '2024-11-25T00:00:00Z' # Skip stale action for issues/PRs created before it
           days-before-stale: 365
-          days-before-close: 0
-          stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
-          exempt-pr-labels: 'never-stale,waiting for review'
-          exempt-issue-labels: 'never-stale,help wanted,waiting for review'
-          operations-per-run: 1000
-          close-issue-reason: not_planned
-
-      - name: Check out repo
-        if: ${{ failure() }}
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: ./.github/actions/slack-alert
-        if: ${{ failure() }}
-        with:
-          slack_channel_id: ${{ secrets.DOCS_ALERTS_SLACK_CHANNEL_ID }}
-          slack_token: ${{ secrets.SLACK_DOCS_BOT_TOKEN }}
+          days-before-close: -1 # If -1, the issues nor pull requests will never be closed automatically.
+          days-before-pr-stale: -1 # If  -1, no pull requests will be marked as stale automatically.
+          exempt-issue-labels: 'never-stale, help wanted, ' # issues labeled as such will be excluded them from being marked as stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,6 +47,7 @@ on:
     - cron: '20 16 * * *' # Run every day at 16:20 UTC / 8:20 PST
 
 permissions:
+  contents: read
   issues: write
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -60,4 +60,4 @@ jobs:
           days-before-stale: 365
           days-before-close: -1 # If -1, the issues nor pull requests will never be closed automatically.
           days-before-pr-stale: -1 # If  -1, no pull requests will be marked as stale automatically.
-          exempt-issue-labels: 'never-stale, help wanted, ' # issues labeled as such will be excluded them from being marked as stale
+          exempt-issue-labels: 'never-stale, help wanted' # issues labeled as such will be excluded them from being marked as stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -44,7 +44,7 @@
 name: 'Marks stale issues and PRs'
 on:
   schedule:
-    - cron: '30 1 * * *' # 1:30 AM UTC
+    - cron: '20 16 * * *' # 1:30 AM UTC
 
 permissions:
   issues: write


### PR DESCRIPTION
Trying the stale workflow from desktop/desktop to make sure it's a script problem not a yaml problem.

I don't know if this will work properly, our stale workflow has a lot of values and checks this doesn't, but I guess the worst it can do is fail.

### Why:

Our stale check isn't working right.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
