### PR TITLE
Explicitly mention SMS as insecure method

### DIFF
--- a/content/organizations/keeping-your-organization-secure/managing-two-factor-authentication-for-your-organization/requiring-two-factor-authentication-in-your-organization.md
+++ b/content/organizations/keeping-your-organization-secure/managing-two-factor-authentication-for-your-organization/requiring-two-factor-authentication-in-your-organization.md
@@ -71,7 +71,7 @@ Before you require use of two-factor authentication, we recommend notifying {% i
 
 ### Requiring secure methods of two-factor authentication in your organization
 
-Alongside requiring two-factor authentication, you can require that organization members, billing managers, and outside collaborators use secure methods of 2FA. Secure two-factor methods are passkeys, security keys, authenticator apps, and the GitHub mobile app. Users who do not have a secure method of 2FA configured, or who have any insecure method configured, will be prevented from accessing organization resources.
+Alongside requiring two-factor authentication, you can require that organization members, billing managers, and outside collaborators use secure methods of 2FA. Secure two-factor methods are passkeys, security keys, authenticator apps, and the GitHub mobile app. Users who do not have a secure method of 2FA configured, or who have any insecure method (such as SMS) configured, will be prevented from accessing organization resources.
 
 Before you require secure methods of two-factor authentication, we recommend notifying organization members, outside collaborators, and billing managers and asking them to set up secure 2FA for their accounts. You can see if members and outside collaborators already use secure methods of 2FA on each organization's People page. For more information, see [AUTOTITLE](/organizations/keeping-your-organization-secure/managing-two-factor-authentication-for-your-organization/viewing-whether-users-in-your-organization-have-2fa-enabled).
 


### PR DESCRIPTION
### Why:

When completing some security checks, we were having multiple team members flagged up as 'insecure' despite the fact that they had many different secure methods enabled in their settings. I was not able to find anywhere what might be causing the insecure flag to be applied, because it isn't explicitly called out in the docs anywhere. It's mentioned in passing here:

https://github.blog/changelog/2024-11-21-enhanced-2fa-management-for-orgs-and-enterprises-public-preview/

> Currently, GitHub defines SMS/text message as an insecure method of 2FA, and TOTP authentication applications, the GitHub Mobile app, security keys, and passkeys as secure methods.

This PR adds a specific reference to SMS being an insecure method.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

It just adds an explicit mention that SMS is considered an insecure method.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
