### PR TITLE
Adds notice for Nuget ecosystem and other misc corrections

### DIFF
--- a/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
+++ b/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
@@ -755,7 +755,7 @@ Defines a **cooldown period** for dependency updates to delay updates for a conf
 > [!NOTE]
 > Cooldown is not applicable for security updates.
 >
-> Cooldown is not available for **Nuget** ecosystem
+> Cooldown is not available for the **NuGet** ecosystem
 
 ### **How Cooldown Works**
 

--- a/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
+++ b/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
@@ -750,27 +750,29 @@ The `url` parameter defines where to access a registry. When the optional `repla
 
 ## `cooldown` {% octicon "versions" aria-label="cooldown" height="24" %}
 
-Defines a **cooldown period** for dependency updates to delay updates for a configurable number of days. This feature enables dependabot users to customize how often they receive new version updates, offering greater control over update frequency.
+Defines a **cooldown period** for dependency updates to delay updates for a configurable number of days. This feature enables {% data variables.product.prodname_dependabot %} users to customize how often they receive new version updates, offering greater control over update frequency.
 
 > [!NOTE]
 > Cooldown is not applicable for security updates.
+>
+> Cooldown is not available for **Nuget** ecosystem
 
 ### **How Cooldown Works**
 
-* When Dependabot runs updates as per defined schedule, it checks the **cooldown settings** to determine if new release for dependency is still within its cooldown period.  
+* When {% data variables.product.prodname_dependabot %} runs updates as per defined schedule, it checks the **cooldown settings** to determine if new release for dependency is still within its cooldown period.  
 * If new version release date is within the cooldown period, dependency version update is **filtered out** and will not be updated until the cooldown period expires.  
 * Once the cooldown period ends for new version, the dependency update proceeds based on the standard update strategy defined in `dependabot.yml`.
 
-Without **`cooldown`** (default behaviour): {% data variables.product.prodname_dependabot %}
+Without **`cooldown`** (default behaviour):
 
 * Dependabot checks for updates according to the scheduled defined via `schedule.interval`.  
 * All new versions are considered for updates **immediately**.  
 
 With **`cooldown`** enabled:
 
-* Dependabot checks for updates based on the defined `schedule.interval` settings.  
+* {% data variables.product.prodname_dependabot %} checks for updates based on the defined `schedule.interval` settings.  
 * **Releases within the cooldown period are ignored.**  
-* Dependabot updates the dependency to the latest available version **that are no longer in cooldown period** following the configured `versioning-strategy`.
+* {% data variables.product.prodname_dependabot %} updates the dependency to the latest available version **that are no longer in cooldown period** following the configured `versioning-strategy`.
 
 ### **Cooldown Configuration**
 
@@ -824,7 +826,6 @@ With **`cooldown`** enabled:
 ### **Example `dependabot.yml` with cooldown**
 
 ```yaml copy
-
 version: 2
 updates:
   - package-ecosystem: "pip"


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: https://github.com/dependabot/dependabot-core/issues/3651 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

1. As cooldown option for nuget is not yet available, this PR adds a notice to the `content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md` file for the same
2. Makes miscellaneous corrections in the `content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md` file.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
