### PR TITLE
Use up-to-date maven domain

### DIFF
--- a/content/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry.md
@@ -65,7 +65,7 @@ If your instance has subdomain isolation enabled:
       <repositories>
         <repository>
           <id>central</id>
-          <url>https://repo1.maven.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <repository>
           <id>github</id>
@@ -107,7 +107,7 @@ If your instance has subdomain isolation disabled:
       <repositories>
         <repository>
           <id>central</id>
-          <url>https://repo1.maven.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
         </repository>
         <repository>
           <id>github</id>


### PR DESCRIPTION
See also https://stackoverflow.com/a/36156652

### Why:

Closes: #39136

### What's being changed (if available, include any code snippets, screenshots, or gifs):

``repo1.maven.org`` → ``repo.maven.apache.org``

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
