### PR TITLE
Update customizing-dependabot-prs.md to fix broken link

### DIFF
--- a/content/code-security/dependabot/dependabot-version-updates/customizing-dependabot-prs.md
+++ b/content/code-security/dependabot/dependabot-version-updates/customizing-dependabot-prs.md
@@ -228,7 +228,7 @@ updates:
 
 {% data reusables.dependabot.option-affects-security-updates %}
 
-See also [`pull-request-branch-name.separator`](/code-security/dependabot/working-with-dependabot/dependabot-options-reference#pull-request-branch-name.separator--).
+See also [`pull-request-branch-name.separator`](/code-security/dependabot/working-with-dependabot/dependabot-options-reference#pull-request-branch-nameseparator--).
 
 ## Targeting pull requests against a non-default branch
 


### PR DESCRIPTION
Update customizing-dependabot-prs.md to fix broken link to pull-request-branch-name.separator option

### Why:

Closes: #39165

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updates link anchor to match the anchor value used on target dependabot-options-reference page by removing the `.`.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
