### PR TITLE
Change command to install Git in Termux

### DIFF
--- a/content/get-started/git-basics/set-up-git.md
+++ b/content/get-started/git-basics/set-up-git.md
@@ -47,7 +47,7 @@ If you do not need to work with files locally, {% data variables.product.github 
    > If you are using an older Chrome OS device, another method is required:
    >
    > 1. Install a terminal emulator such as Termux from the Google Play Store on your Chrome OS device.
-   > 1. From the terminal emulator that you installed, install Git. For example, in Termux, enter `apt install git` and then type `y` when prompted.
+   > 1. From the terminal emulator that you installed, install Git. For example, in Termux, enter `pkg install git` and then type `y` when prompted.
 
 1. [Set your username in Git](/get-started/git-basics/setting-your-username-in-git).
 1. [Set your commit email address in Git](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address).


### PR DESCRIPTION
### Why:

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/39217

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Change `apt install git` to `pkg install git`.

Termux recommends using pkg instead of apt directly, pkg is a wrapper that performs useful tasks:

- Provides command shortcuts.
- Automatically runs "apt update" before installing a package.
- Performs some client side repository load-balancing by automatically switching mirrors.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
