### PR TITLE
Fix typo in reviewing-a-pull-request-created-by-copilot.md

### DIFF
--- a/content/copilot/how-tos/agents/copilot-coding-agent/reviewing-a-pull-request-created-by-copilot.md
+++ b/content/copilot/how-tos/agents/copilot-coding-agent/reviewing-a-pull-request-created-by-copilot.md
@@ -41,7 +41,7 @@ If {% data variables.product.prodname_copilot_short %} starts a new agent sessio
 {% data variables.product.prodname_copilot_short %} may ignore a comment if it considers that the comment was not intended for it. If you are sure that you want {% data variables.product.prodname_copilot_short %} to respond to your comment, you can @mention {% data variables.product.prodname_copilot_short %} by including `@copilot` in your comment.
 
 > [!TIP]
-> If you don't want {% data variables.product.prodname_copilot_short %} to respond to comments on a pull request, you can unassign {% data variables.product.prodname_copilot_short %} from the pull request. If you later reassign {% data variables.product.prodname_copilot_short %} to the same pull request it will respond to new comments and push more changes. It will not respond to comment that were added while it was not assigned.
+> If you don't want {% data variables.product.prodname_copilot_short %} to respond to comments on a pull request, you can unassign {% data variables.product.prodname_copilot_short %} from the pull request. If you later reassign {% data variables.product.prodname_copilot_short %} to the same pull request it will respond to new comments and push more changes. It will not respond to comments that were added while it was not assigned.
 
 For more information, see the section "Use comments to iterate on a pull request" in [AUTOTITLE](/copilot/using-github-copilot/coding-agent/best-practices-for-using-copilot-to-work-on-tasks#using-comments-to-iterate-on-a-pull-request).
 


### PR DESCRIPTION
### Why:

There is a minor grammatical typo in reviewing-a-pull-request-created-by-copilot.md

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Update the text of the tip.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
