### PR TITLE
Correct misspelling of "owner"

### DIFF
--- a/content/billing/managing-your-billing/using-budgets-control-spending.md
+++ b/content/billing/managing-your-billing/using-budgets-control-spending.md
@@ -111,7 +111,7 @@ If you are an organization owner, enterprise owner, or billing manager, your bud
 
 ### Creating a budget
 
-As the onwer of an enterprise or organization account, or as a billing manager, you can set a budget at the account level, or at any level below this.
+As the owner of an enterprise or organization account, or as a billing manager, you can set a budget at the account level, or at any level below this.
 
 1. In the "Budgets and alerts" view, click **New budget**.
 1. Under "Budget", set a budget amount.


### PR DESCRIPTION
### Why:

This is a simple spelling correction in the billing/budget docs.

> [!NOTE]
> I assume opening an issue for a minor misspelling is unnecessary.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I noticed there was a misspelling in this section: <https://docs.github.com/en/billing/managing-your-billing/using-budgets-control-spending#creating-a-budget>

<img width="411" height="75" alt="image" src="https://github.com/user-attachments/assets/d4857dd5-5c3c-4d68-8231-5622aac60a4d" />

"onwer" should be "owner"

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
