### PR TITLE
docs: update `rust` organization name to `rust-lang`

### DIFF
--- a/content/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/differences-between-commit-views.md
+++ b/content/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/differences-between-commit-views.md
@@ -13,8 +13,8 @@ shortTitle: Commit views
 ---
 On {% data variables.product.github %}, you can see the commit history of a repository by:
 
-* Navigating directly to [the commits page](https://github.com/mozilla/rust/commits/master) of a repository
-* Clicking on a file, then clicking **History**, to get to [the commit history for a specific file](https://github.com/mozilla/rust/commits/master/README.md)
+* Navigating directly to [the commits page](https://github.com/rust-lang/rust/commits/master) of a repository
+* Clicking on a file, then clicking **History**, to get to [the commit history for a specific file](https://github.com/rust-lang/rust/commits/master/README.md)
 
 These two commit views may show _different_ information at times. The history for a single file may omit commits found on the repository's commit history.
 


### PR DESCRIPTION
### Why:

The organization of [rust](https://github.com/rust-lang/rust/) repository was renamed to `rust-lang`

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Documentation:
- Replace instances of the ‘mozilla/rust’ repository path with ‘rust-lang/rust’ in commit history URLs

| Before | After |
|--------|--------|
| https://github.com/mozilla/rust/ | https://github.com/rust-lang/rust/ | 

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
