### PR TITLE
docs: update branch name to `main` from `master`

### DIFF
--- a/content/contributing/writing-for-github-docs/templates.md
+++ b/content/contributing/writing-for-github-docs/templates.md
@@ -345,7 +345,7 @@ The language guide introduction should include the following in a short paragrap
 
 {% comment %}
 Language guides typically walk through and build upon a workflow template. If that format doesn't work, you can include a boilerplate workflow.
-- Link to the GitHub Actions CI workflow template as the boilerplate reference code and then walk through and build on that code in this guide - https://github.com/actions/starter-workflows/tree/master/ci
+- Link to the GitHub Actions CI workflow template as the boilerplate reference code and then walk through and build on that code in this guide - https://github.com/actions/starter-workflows/tree/main/ci
 - Provide instructions for adding the workflow template to a repository.
 - Include the starter template workflow code.
 {% endcomment %}

--- a/content/repositories/creating-and-managing-repositories/repository-limits.md
+++ b/content/repositories/creating-and-managing-repositories/repository-limits.md
@@ -55,7 +55,7 @@ To avoid throttling and performance issues, we recommend staying within the foll
 
 ## Text limits
 
-{% data variables.product.prodname_dotcom %} displays formatted previews of some files, such as Markdown and Mermaid diagrams. {% data variables.product.prodname_dotcom %} always attempts to render these previews if the files are small (generally less than 2 MB), but more complex files may time out and either fall back to plain text or not be displayed at all. These files are always available in their raw formats, which are served through `{% data variables.product.raw_github_com %}`; for example, `https://{% data variables.product.raw_github_com %}/octocat/Spoon-Knife/master/index.html`. Click the **Raw** button to get the raw URL for a file.
+{% data variables.product.prodname_dotcom %} displays formatted previews of some files, such as Markdown and Mermaid diagrams. {% data variables.product.prodname_dotcom %} always attempts to render these previews if the files are small (generally less than 2 MB), but more complex files may time out and either fall back to plain text or not be displayed at all. These files are always available in their raw formats, which are served through `{% data variables.product.raw_github_com %}`; for example, `https://{% data variables.product.raw_github_com %}/octocat/Spoon-Knife/main/index.html`. Click the **Raw** button to get the raw URL for a file.
 
 ## Pull requests limits
 

--- a/contributing/debugging-the-docs-application.md
+++ b/contributing/debugging-the-docs-application.md
@@ -10,4 +10,4 @@ This repo has configuration for debugging the codebase with VS Code's built-in N
 1. Select the node process that's started with the `--inspect` flag.
 1. Debugger has now been attached. Enjoy!
 
-For more detailed instructions, please see this [VS Code recipe](https://github.com/Microsoft/vscode-recipes/tree/master/nodemon). You can also learn more about debugging using VS Code [here](https://code.visualstudio.com/docs/editor/debugging).
+For more detailed instructions, please see this [VS Code recipe](https://github.com/Microsoft/vscode-recipes/tree/main/nodemon). You can also learn more about debugging using VS Code [here](https://code.visualstudio.com/docs/editor/debugging).


### PR DESCRIPTION
### Why:

Some repository branches were renamed from `master` to `main`.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Update default branch references in documentation from `master` to `main`.

Documentation:
- Replace `master` branch with `main` in the GitHub Actions CI workflow template link.
- Update raw repository URL example to use `main` branch in repository limits documentation.
- Change VS Code recipe link to point to the `main` branch in debugging guide.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
