### PR TITLE
Remove warning about `nuget-feed` not supporting `replaces-base`

### DIFF
--- a/content/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot.md
@@ -46,8 +46,6 @@ The top-level `registries` key is optional and specifies authentication details.
 
 {% data reusables.dependabot.dependabot-updates-registries-options %}
 
-{% data reusables.dependabot.dependabot-replaces-base-nuget %}
-
 For more information about the configuration options that are available and about the supported types, see [AUTOTITLE](/code-security/dependabot/working-with-dependabot/dependabot-options-reference#top-level-registries-key).
 
 ## Storing credentials for Dependabot to use

--- a/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
+++ b/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
@@ -818,8 +818,6 @@ updates:
 
 {% data reusables.dependabot.dependabot-updates-registries-options %}
 
-{% data reusables.dependabot.dependabot-replaces-base-nuget %}
-
 {% data reusables.dependabot.advanced-private-registry-config-link %}
 
 ### `type` and authentication details
@@ -850,5 +848,3 @@ All sensitive data used for authentication should be stored securely and referen
 ### `url` and `replaces-base`
 
 The `url` parameter defines where to access a registry. When the optional `replaces-base` parameter is enabled (`true`), {% data variables.product.prodname_dependabot %} resolves dependencies using the value of `url` rather than the base URL of that specific ecosystem.
-
-{% data reusables.dependabot.dependabot-replaces-base-nuget %}

--- a/data/reusables/dependabot/dependabot-replaces-base-nuget.md
+++ b/data/reusables/dependabot/dependabot-replaces-base-nuget.md
@@ -1,2 +1,0 @@
->[!NOTE]
-> `nuget-feed` doesn't support the `replaces-base` parameter.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
This was resolved back in April https://github.com/dependabot/dependabot-core/pull/12105

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This removes the `dependabot-replaces-base-nuget.md` reusable snippet and any uses of it.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
