### PR TITLE
Fix LFX Crowdfunding name in FUNDING file description

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository.md
@@ -21,7 +21,7 @@ You can add one username, package name, or project name per external funding pla
 
 Platform | Syntax
 -------- | -----
-[LFX Mentorship (formerly CommunityBridge)](https://lfx.linuxfoundation.org/tools/mentorship) | `community_bridge: PROJECT-NAME`
+[LFX Crowdfunding (formerly CommunityBridge)](https://lfx.linuxfoundation.org/tools/crowdfunding/) | `community_bridge: PROJECT-NAME`
 [{% data variables.product.prodname_sponsors %}](https://github.com/sponsors) | `github: USERNAME` or `github: [USERNAME, USERNAME, USERNAME, USERNAME]`
 [IssueHunt](https://issuehunt.io/) | `issuehunt: USERNAME`
 [Ko-fi](https://ko-fi.com/) | `ko_fi: USERNAME`


### PR DESCRIPTION
The Linux Foundation Community Bridge became LFX Crowdfunding. LFX Mentorship is more like Google Summer of Code.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: Correct the service name

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/39525

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Change name "LFX Mentorship" to "LFX Crowdfunding" and update the link

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
