### PR TITLE
Fix typo in coding-agent/index.md

### DIFF
--- a/content/copilot/how-tos/use-copilot-agents/coding-agent/index.md
+++ b/content/copilot/how-tos/use-copilot-agents/coding-agent/index.md
@@ -1,7 +1,7 @@
 ---
 title: '{% data variables.copilot.copilot_coding_agent %}'
 shortTitle: '{% data variables.copilot.copilot_coding_agent_short_cap_c %}'
-intro: 'Find out how {% data variables.product.prodname_copilot_short %} can work on {% data variables.product.github %} issues and raise pull requests for your to review.'
+intro: 'Find out how {% data variables.product.prodname_copilot_short %} can work on {% data variables.product.github %} issues and raise pull requests for you to review.'
 versions:
   feature: copilot
 topics:


### PR DESCRIPTION
This PR fixes a minor typo in the sub header of https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent
