### PR TITLE
docs: fix a repo param on codespaces url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GitHub Docs <!-- omit in toc -->
-[![Build GitHub Docs On Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new/?repo=github)
+[![Build GitHub Docs On Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new/?repo=github/docs)
 
 This repository contains the documentation website code and Markdown source files for [docs.github.com](https://docs.github.com).
 


### PR DESCRIPTION
### Summary:

Documentation:
- Fix the repo parameter in the [Codespaces URL](https://github.com/codespaces/new/?repo=github/docs) in [README.md](https://github.com/github/docs/blob/main/README.md) to reference github/docs

### What's being changed (if available, include any code snippets, screenshots, or gifs):

| Before | After |
|--------|--------|
| https://github.com/codespaces/new/?repo=github | https://github.com/codespaces/new/?repo=github/docs | 
| <img width="1556" height="851" alt="before" src="https://github.com/user-attachments/assets/1a26f8aa-3324-4040-b69d-7bb193c6e0da" /> | <img width="1550" height="1121" alt="after" src="https://github.com/user-attachments/assets/51abfa2e-58c1-46b7-ad50-d98e4398c3e7" /> | 

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
