### PR TITLE
tweak wording in `actions-is-preferred.md` to be more generically applicable

### DIFF
--- a/data/reusables/pages/actions-is-preferred.md
+++ b/data/reusables/pages/actions-is-preferred.md
@@ -1,1 +1,1 @@
-> [!NOTE] While this `github-pages` gem remains supported for some workflows, {% data variables.product.prodname_actions %} is now the recommended approach for deploying and automating {% data variables.product.prodname_pages %} sites.
+> [!NOTE] While the `github-pages` gem remains supported for some workflows, {% data variables.product.prodname_actions %} is now the recommended approach for deploying and automating {% data variables.product.prodname_pages %} sites.


### PR DESCRIPTION
### Why:

> I was just clicking through some of the pages this reusable is included on, and I think in most places it's used the wording would probably be better as:
> 
> > While **the** `github-pages` gem remains...
> 
> Instead of:
> 
> > While **this** `github-pages` gem remains...
> 
> As many places it's used are seemingly talking about Jekyll more generically; so 'this' doesn't make as much sense as 'the' RE: the `pages-gem` IMO.
> 
> _Originally posted by @0xdevalias in https://github.com/github/docs/pull/39148#discussion_r2252923151_

> Nooooo, I changed that thinking it would read better, but I was wrong. 😢 If you feel like opening a PR to fix it that would probably be fastest, because it takes a while for small PRs to get reviewed internally, but I can also open it if you don't feel like doing it.
> 
> _Originally posted by @Sharra-writes in https://github.com/github/docs/pull/39148#discussion_r2255275599_

Followup to: https://github.com/github/docs/pull/39148
Closes: https://github.com/github/docs/issues/36740

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Changes the word 'this' to 'the' in the `actions-is-preferred.md` reusable that @Sharra-writes created to better / more generically fit the vibe/flow where the reusable it being used.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
