### PR TITLE
Fix template variables in pass-job-outputs.md

### DIFF
--- a/content/actions/how-tos/write-workflows/choose-what-workflows-do/pass-job-outputs.md
+++ b/content/actions/how-tos/write-workflows/choose-what-workflows-do/pass-job-outputs.md
@@ -23,8 +23,8 @@ redirect_from:
      job1:
        runs-on: ubuntu-latest
        outputs:
-         output1: ${{ steps.step1.outputs.test }}
-         output2: ${{ steps.step2.outputs.test }}
+         output1: {% raw %}${{ steps.step1.outputs.test }}{% endraw %}
+         output2: {% raw %}${{ steps.step2.outputs.test }}{% endraw %}
        steps:
          - id: step1
            run: echo "test=hello" >> "$GITHUB_OUTPUT"
@@ -52,8 +52,8 @@ redirect_from:
         needs: job1
         steps:
           - env:
-              OUTPUT1: ${{needs.job1.outputs.output1}}
-              OUTPUT2: ${{needs.job1.outputs.output2}}
+              OUTPUT1: {% raw %}${{needs.job1.outputs.output1}}{% endraw %}
+              OUTPUT2: {% raw %}${{needs.job1.outputs.output2}}{% endraw %}
             run: echo "$OUTPUT1 $OUTPUT2"
     ```
 


### PR DESCRIPTION
These were rendered as just `$` in the output HTML.

See https://github.com/github/docs/commit/ad6f8893d3f87b5ff50fb0585fd6947b739f217a#diff-60d2ad0fd3412116cc786ec81cf58060a950d1605eff32c64cb5bc2324e42b17

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: https://github.com/github/docs/issues/39697

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Add `{% raw %}` blocks to wrap variables to fix rendering.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
