### PR TITLE
Corrected search index limitations explanation

### DIFF
--- a/content/copilot/concepts/completions/code-referencing.md
+++ b/content/copilot/concepts/completions/code-referencing.md
@@ -78,7 +78,7 @@ Code in private {% data variables.product.prodname_dotcom %} repositories, or co
 
 ## Limitations
 
-The search index is refreshed every few months. As a result, newly committed code, and code from public repositories deleted before the index was created, may not be included in the search. For the same reason, the search may return matches to code that has been deleted or moved since the index was created.
+The search index is refreshed every few months. As a result, newly committed code may not be included in the search. For the same reason, the search may return matches to code that has been deleted or moved since the index was created.
 
 References to matching code are currently available in JetBrains IDEs, {% data variables.product.prodname_vs %}, {% data variables.product.prodname_vscode %}, and on the {% data variables.product.github %} website.
 


### PR DESCRIPTION
Updated the limitations section to remove references to public repositories deleted before the index was created as it's wrong to say deleted code before the index was created will be NOT be included. It will be included is the right thing to say and it's already explained in the sentence after that.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
