### PR TITLE
Update `Preinstalling tools or dependencies in Copilot's environment` Docs

### DIFF
--- a/content/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment.md
+++ b/content/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment.md
@@ -40,6 +40,9 @@ Instead, you can preconfigure {% data variables.product.prodname_copilot_short %
 
 A `copilot-setup-steps.yml` file looks like a normal {% data variables.product.prodname_actions %} workflow file, but must contain a single `copilot-setup-steps` job. This job will be executed in {% data variables.product.prodname_actions %} before {% data variables.product.prodname_copilot_short %} starts working. For more information on {% data variables.product.prodname_actions %} workflow files, see [AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions).
 
+> [!NOTE]
+> You must have merged the yml file into your default branch
+
 Here is a simple example of a `copilot-setup-steps.yml` file for a TypeScript project that clones the project, installs Node.js and downloads and caches the project's dependencies. You should customize this to fit your own project's language(s) and dependencies:
 
 ```yaml copy

--- a/content/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment.md
+++ b/content/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment.md
@@ -41,7 +41,7 @@ Instead, you can preconfigure {% data variables.product.prodname_copilot_short %
 A `copilot-setup-steps.yml` file looks like a normal {% data variables.product.prodname_actions %} workflow file, but must contain a single `copilot-setup-steps` job. This job will be executed in {% data variables.product.prodname_actions %} before {% data variables.product.prodname_copilot_short %} starts working. For more information on {% data variables.product.prodname_actions %} workflow files, see [AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions).
 
 > [!NOTE]
-> You must have merged the yml file into your default branch
+> You must have merged the yml file into your default branch for it to be triggered
 
 Here is a simple example of a `copilot-setup-steps.yml` file for a TypeScript project that clones the project, installs Node.js and downloads and caches the project's dependencies. You should customize this to fit your own project's language(s) and dependencies:
 

--- a/content/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment.md
+++ b/content/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment.md
@@ -41,7 +41,7 @@ Instead, you can preconfigure {% data variables.product.prodname_copilot_short %
 A `copilot-setup-steps.yml` file looks like a normal {% data variables.product.prodname_actions %} workflow file, but must contain a single `copilot-setup-steps` job. This job will be executed in {% data variables.product.prodname_actions %} before {% data variables.product.prodname_copilot_short %} starts working. For more information on {% data variables.product.prodname_actions %} workflow files, see [AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions).
 
 > [!NOTE]
-> You must have merged the yml file into your default branch for it to be triggered
+> The `copilot-setup-steps.yml` workflow won't trigger unless it's present on your main branch.
 
 Here is a simple example of a `copilot-setup-steps.yml` file for a TypeScript project that clones the project, installs Node.js and downloads and caches the project's dependencies. You should customize this to fit your own project's language(s) and dependencies:
 


### PR DESCRIPTION
Add note to explain how the setup-steps yml file must live on your default branch for it to be triggered when copilot opens a PR

### Why:

The documentation does not clearly explain that the `agent-setup-steps.yml` file must live on the default branch in order for it to run before copilot starts working on a PR.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added a note to the docs page for https://docs.github.com/en/copilot/how-tos/manage-and-track-spending/monitor-premium-requests to explain that the yml file must be on the default branch.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
