### PR TITLE
docs: bump `actions/checkout` GitHub Actions

### DIFF
--- a/data/reusables/actions/action-checkout.md
+++ b/data/reusables/actions/action-checkout.md
@@ -1,1 +1,1 @@
-actions/checkout@v4
+actions/checkout@v5


### PR DESCRIPTION
### Why:

[Checkout v5](https://github.com/actions/checkout/releases/tag/v5.0.0) now supports Node.js 24.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Documentation:
- Bump [actions/checkout](https://github.com/actions/checkout) version from v4 to v5 in [data/reusables/actions/action-checkout.md](https://github.com/github/docs/blob/main/data/reusables/actions/action-checkout.md)

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
