### PR TITLE
don't use 22.18.0 for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,7 +412,7 @@
     "esm": "^3.2.25"
   },
   "engines": {
-    "node": "^20 || ^22"
+    "node": "^20 || >=22.0.0 <22.18.0"
   },
   "cacheDirectories": [
     "node_modules",


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
fixes: https://github.com/github/docs-engineering/issues/5623
related? https://github.com/nodejs/node/issues/59364

seeeems like a node problem with 22.18.0?  only a problem in github/docs right now because in docs-internal i see node 22.14.0 getting installed during setup (I assume because different runners?)

my local testing with 22.17.0 vs. 22.18.0:

```
➜  docs git:(main) nvm use 22.17.0
Now using node v22.17.0 (npm v10.9.2)
➜  docs git:(main) npm run playwright-test -- src/fixtures/tests/playwright-local-dev.spec.ts:37 

> playwright-test
> playwright test --config src/fixtures/playwright.config.ts --project="Google Chrome" src/fixtures/tests/playwright-local-dev.spec.ts:37


Running 1 test using 1 worker

  ✓  1 [Google Chrome] › src/fixtures/tests/playwright-local-dev.spec.ts:37:1 › search "foo" and get results (1.9s)
[WebServer] (node:29205) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
[WebServer] (Use `node --trace-deprecation ...` to show where the warning was created)

  1 passed (5.7s)
➜  docs git:(main) nvm use 22.18.0                                                               
Now using node v22.18.0 (npm v10.9.3)
➜  docs git:(main) npm run playwright-test -- src/fixtures/tests/playwright-local-dev.spec.ts:37 

> playwright-test
> playwright test --config src/fixtures/playwright.config.ts --project="Google Chrome" src/fixtures/tests/playwright-local-dev.spec.ts:37

SyntaxError: The requested module '@playwright/test' does not provide an export named 'Page'
Error: No tests found.
Make sure that arguments are regular expressions matching test files.
You may need to escape symbols like "$" or "*" and quote the arguments.
```

so same error as https://github.com/github/docs-internal/actions/runs/16891261375/job/47851347313

### What's being changed (if available, include any code snippets, screenshots, or gifs):

* update engines to not use 22.18.0 temporarily

I think this `engines` syntax works and our setup action will use it?  if there's a better way to do it let me know!

https://github.com/github/docs-internal/blob/e739fc93cfeb77ce3be8a60c5c46b5dbafb21dc0/.github/actions/node-npm-setup/action.yml#L22

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
