### PR TITLE
fix: remove duplicated word aka typo

### DIFF
--- a/content/copilot/how-tos/provide-context/use-copilot-spaces/create-and-use-copilot-spaces.md
+++ b/content/copilot/how-tos/provide-context/use-copilot-spaces/create-and-use-copilot-spaces.md
@@ -38,7 +38,7 @@ You can add two types of context to your space:
 
    For example:
 
-   > You are a SQL generator. Your job is to take the sample queries and data schemas defined in the attached files and and generate SQL queries based on the user's goals.
+   > You are a SQL generator. Your job is to take the sample queries and data schemas defined in the attached files and generate SQL queries based on the user's goals.
 
 * **Attachments**: This context will be used to provide more relevant answers to your questions. Additionally, {% data variables.copilot.copilot_spaces_short %} will always refer to the latest version of the code on the `main` branch of the repository.
 


### PR DESCRIPTION
### Why:

Fix single  typo / duplicated word for better readability

Closes: 
-
If required, I can create an Issue for this typo before merging.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fix single typo / duplicated word for better readability

### Check off the following:

The checklist is for the official team to work on, right?

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
