### PR TITLE
Removed reference to bulk converting issues to discussions via labels

### DIFF
--- a/content/discussions/managing-discussions-for-your-community/moderating-discussions.md
+++ b/content/discussions/managing-discussions-for-your-community/moderating-discussions.md
@@ -38,7 +38,7 @@ It's appropriate to lock a conversation when the entire conversation is not cons
 
 ## Converting an issue to a discussion
 
-When you convert an issue to a discussion, the discussion is automatically created using the content from the issue.
+When you convert an issue to a discussion, the discussion is automatically created using the content from the issue. For more information, see [AUTOTITLE](/discussions/managing-discussions-for-your-community/managing-discussions).
 
 {% data reusables.discussions.navigate-to-repo-or-org %}
 {% data reusables.repositories.sidebar-issues %}

--- a/content/discussions/managing-discussions-for-your-community/moderating-discussions.md
+++ b/content/discussions/managing-discussions-for-your-community/moderating-discussions.md
@@ -38,7 +38,7 @@ It's appropriate to lock a conversation when the entire conversation is not cons
 
 ## Converting an issue to a discussion
 
-When you convert an issue to a discussion, the discussion is automatically created using the content from the issue. People with write access to a repository, or source repository for organization discussions, can bulk convert issues based on labels. For more information, see [AUTOTITLE](/discussions/managing-discussions-for-your-community/managing-discussions).
+When you convert an issue to a discussion, the discussion is automatically created using the content from the issue.
 
 {% data reusables.discussions.navigate-to-repo-or-org %}
 {% data reusables.repositories.sidebar-issues %}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: 

<!-- Paste the issue link or number here -->
Closes: #39996 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
- This updates the "Moderating discussions" article to remove the sentence about bulk converting issues to discussions based on labels

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
