### PR TITLE
docs: bump `actions/attest-build-provenance` from 2 to 3

### DIFF
--- a/content/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations.md
+++ b/content/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations.md
@@ -42,7 +42,7 @@ When you run your updated workflows, they will build your artifacts and generate
 
    ```yaml
    - name: Generate artifact attestation
-     uses: actions/attest-build-provenance@v2
+     uses: actions/attest-build-provenance@v3
      with:
        subject-path: 'PATH/TO/ARTIFACT'
    ```
@@ -65,7 +65,7 @@ When you run your updated workflows, they will build your artifacts and generate
 
    ```yaml
    - name: Generate artifact attestation
-     uses: actions/attest-build-provenance@v2
+     uses: actions/attest-build-provenance@v3
      with:
        subject-name: {% raw %}${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}{% endraw %}
        subject-digest: 'sha256:fedcba0...'

--- a/content/actions/tutorials/publish-packages/publish-docker-images.md
+++ b/content/actions/tutorials/publish-packages/publish-docker-images.md
@@ -117,7 +117,7 @@ jobs:
 
 {% ifversion artifact-attestations %}
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v3
         with:
           subject-name: index.docker.io/my-docker-hub-namespace/my-docker-hub-repository
           subject-digest: {% raw %}${{ steps.push.outputs.digest }}{% endraw %}
@@ -229,7 +229,7 @@ jobs:
 
 {% ifversion artifact-attestations %}
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v3
         with:
           subject-name: {% data reusables.package_registry.container-registry-hostname %}/{% raw %}${{ github.repository }}{% endraw %}
           subject-digest: {% raw %}${{ steps.push.outputs.digest }}{% endraw %}

--- a/data/reusables/package_registry/publish-docker-image.md
+++ b/data/reusables/package_registry/publish-docker-image.md
@@ -57,7 +57,7 @@ jobs:
       {% ifversion artifact-attestations %}
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v3
         with:
           subject-name: {% raw %}${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}{% endraw %}
           subject-digest: {% raw %}${{ steps.push.outputs.digest }}{% endraw %}


### PR DESCRIPTION
### Summary

Bumps the ci group with 1 update: [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance).

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updates `actions/attest-build-provenance` from 2 to 3
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/actions/attest-build-provenance/releases">actions/attest-build-provenance's releases</a>.</em></p>
<blockquote>
<h2>v3.0.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Adjust node max-http-header-size setting by <a href="https://github.com/bdehamer"><code>@​bdehamer</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/687">actions/attest-build-provenance#687</a></li>
<li>Bump actions/attest from v2.4.0 to <a href="https://github.com/actions/attest/releases/tag/v3.0.0">v3.0.0</a> by <a href="https://github.com/bdehamer"><code>@​bdehamer</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/691">actions/attest-build-provenance#691</a>
<ul>
<li>Bump to node24 runtime</li>
<li>Improved checksum parsing</li>
</ul>
</li>
<li>Bump attest-build-provenance/predicate to v2.0.0 by <a href="https://github.com/bdehamer"><code>@​bdehamer</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/693">actions/attest-build-provenance#693</a>
<ul>
<li>Bump to node24 runtime by <a href="https://github.com/bdehamer"><code>@​bdehamer</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/692">actions/attest-build-provenance#692</a></li>
</ul>
</li>
</ul>
<h2>⚠️ Minimum Compatible Runner Version</h2>
<p>v2.327.1
<a href="https://github.com/actions/runner/releases/tag/v2.327.1">Release Notes</a></p>
<p>Make sure your runner is updated to this version or newer to use this release.</p>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/attest-build-provenance/compare/v2.4.0...v3.0.0">https://github.com/actions/attest-build-provenance/compare/v2.4.0...v3.0.0</a></p>
<h2>v2.4.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Bump undici from 5.28.5 to 5.29.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/633">actions/attest-build-provenance#633</a></li>
<li>Bump actions/attest from 2.3.0 to <a href="https://github.com/actions/attest/releases/tag/v2.4.0">2.4.0</a> by <a href="https://github.com/bdehamer"><code>@​bdehamer</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/654">actions/attest-build-provenance#654</a>
<ul>
<li>Includes support for the new well-known summary file which will accumulate paths to all attestations generated in a given workflow run</li>
</ul>
</li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/attest-build-provenance/compare/v2.3.0...v2.4.0">https://github.com/actions/attest-build-provenance/compare/v2.3.0...v2.4.0</a></p>
<h2>v2.3.0</h2>
<h2>What's Changed</h2>
<ul>
<li>Bump <code>actions/attest</code> from 2.2.1 to 2.3.0 by <a href="https://github.com/bdehamer"><code>@​bdehamer</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/615">actions/attest-build-provenance#615</a>
<ul>
<li>Updates <code>@sigstore/oci</code> from 0.4.0 to 0.5.0</li>
</ul>
</li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/attest-build-provenance/compare/v2.2.3...v2.3.0">https://github.com/actions/attest-build-provenance/compare/v2.2.3...v2.3.0</a></p>
<h2>v2.2.3</h2>
<h2>What's Changed</h2>
<ul>
<li>Pin actions/attest reference by commit SHA by <a href="https://github.com/bdehamer"><code>@​bdehamer</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/493">actions/attest-build-provenance#493</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/attest-build-provenance/compare/v2.2.2...v2.2.3">https://github.com/actions/attest-build-provenance/compare/v2.2.2...v2.2.3</a></p>
<h2>v2.2.2</h2>
<h2>What's Changed</h2>
<ul>
<li>Bump predicate action from 1.1.4 to 1.1.5 by <a href="https://github.com/bdehamer"><code>@​bdehamer</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/485">actions/attest-build-provenance#485</a>
<ul>
<li>Bump <code>@​actions/attest</code> from 1.5.0 to 1.6.0 by <a href="https://github.com/bdehamer"><code>@​bdehamer</code></a> in <a href="https://redirect.github.com/actions/attest-build-provenance/pull/484">actions/attest-build-provenance#484</a>
<ul>
<li>Update buildSLSAProvenancePredicate to populate <code>workflow.ref</code> field from the <code>ref</code> claim in the OIDC token (<a href="https://redirect.github.com/actions/toolkit/pull/1969">actions/toolkit#1969</a>)</li>
</ul>
</li>
</ul>
</li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/actions/attest-build-provenance/compare/v2.2.1...v2.2.2">https://github.com/actions/attest-build-provenance/compare/v2.2.1...v2.2.2</a></p>
<h2>v2.2.1</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/actions/attest-build-provenance/commit/977bb373ede98d70efdf65b84cb5f73e068dcc2a"><code>977bb37</code></a> bump attest-build-provenance/predicate to v2.0.0 (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/693">#693</a>)</li>
<li><a href="https://github.com/actions/attest-build-provenance/commit/864457a58d4733d7f1574bd8821fa24e02cf7538"><code>864457a</code></a> Bump to node24 runtime (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/692">#692</a>)</li>
<li><a href="https://github.com/actions/attest-build-provenance/commit/57aa2b0928860f17511d3a8828161ffc4d0cc940"><code>57aa2b0</code></a> bump actions/attest from v2.4.0 to v3.0.0 (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/691">#691</a>)</li>
<li><a href="https://github.com/actions/attest-build-provenance/commit/8ee716368b9238b22c2d8d9579a01cb8630ee506"><code>8ee7163</code></a> refactor eslint config (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/690">#690</a>)</li>
<li><a href="https://github.com/actions/attest-build-provenance/commit/91ca1c25673125472e7081bed0d584ac6696d4de"><code>91ca1c2</code></a> Bump actions/checkout from 4.1.1 to 5.0.0 (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/684">#684</a>)</li>
<li><a href="https://github.com/actions/attest-build-provenance/commit/ff19f402b6e212671813b2ebe231d8a7c81ec049"><code>ff19f40</code></a> custom node max-http-header-size (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/687">#687</a>)</li>
<li><a href="https://github.com/actions/attest-build-provenance/commit/8bd83f1e055c41368a1664e71c43b9783931c8c7"><code>8bd83f1</code></a> pin workflow deps (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/683">#683</a>)</li>
<li><a href="https://github.com/actions/attest-build-provenance/commit/f0878de78276446bc2ff4a40ae81f8013db6d773"><code>f0878de</code></a> Bump the npm-development group with 4 updates (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/681">#681</a>)</li>
<li><a href="https://github.com/actions/attest-build-provenance/commit/463e6dfa26f7fa5e1171fc7e080434e7cf62bc59"><code>463e6df</code></a> Bump the npm-development group with 3 updates (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/678">#678</a>)</li>
<li><a href="https://github.com/actions/attest-build-provenance/commit/fef91c17b834a42bff3ffaaac52edf60146a8ead"><code>fef91c1</code></a> Bump the npm-development group with 6 updates (<a href="https://redirect.github.com/actions/attest-build-provenance/issues/673">#673</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/actions/attest-build-provenance/compare/v2...v3">compare view</a></li>
</ul>
</details>

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
