### PR TITLE
Update metadata-syntax.md for node 24

### DIFF
--- a/content/actions/reference/workflows-and-actions/metadata-syntax.md
+++ b/content/actions/reference/workflows-and-actions/metadata-syntax.md
@@ -148,11 +148,11 @@ For more information on how to use context syntax, see [AUTOTITLE](/actions/lear
 
 **Required** Configures the path to the action's code and the runtime used to execute the code.
 
-### Example: Using Node.js v20
+### Example: Using Node.js v24
 
 ```yaml
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'
 ```
 
@@ -161,6 +161,7 @@ runs:
 **Required** The runtime used to execute the code specified in [`main`](#runsmain).
 
 * Use `node20` for Node.js v20.
+* Use `node24` for Node.js v24.
 
 ### `runs.main`
 
@@ -177,7 +178,7 @@ In this example, the `pre:` action runs a script called `setup.js`:
 
 ```yaml
 runs:
-  using: 'node20'
+  using: 'node24'
   pre: 'setup.js'
   main: 'index.js'
   post: 'cleanup.js'
@@ -204,7 +205,7 @@ In this example, the `post:` action runs a script called `cleanup.js`:
 
 ```yaml
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'
   post: 'cleanup.js'
 ```


### PR DESCRIPTION
### Why:

It is supported: https://github.com/actions/runner/releases/tag/v2.327.1

It is used: https://github.com/actions/checkout/releases/tag/v5.0.0

### What's being changed (if available, include any code snippets, screenshots, or gifs):

See title and diff.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
