### PR TITLE
fix: typo in manage-policies.md

### DIFF
--- a/content/copilot/how-tos/administer-copilot/manage-for-organization/manage-policies.md
+++ b/content/copilot/how-tos/administer-copilot/manage-for-organization/manage-policies.md
@@ -42,7 +42,7 @@ contentType: how-tos
 
 {% data reusables.copilot.mcp-servers-policy-note %}
 
-## Opting in to to previews or feedback
+## Opting in to previews or feedback
 
 If your organization has a {% data variables.copilot.copilot_business_short %} or {% data variables.copilot.copilot_enterprise_short %} plan and you enable "{% data variables.product.prodname_copilot_short %} in {% data variables.product.prodname_dotcom_the_website %}", two additional options are displayed:
 


### PR DESCRIPTION
Fixed a typo in manage-policies.md (duplicate word)

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Issue link: https://github.com/github/docs/issues/40184

Closes: 

Issue Link: https://github.com/github/docs/issues/40184

I removed the extra "to" word in the section title
<img width="899" height="330" alt="image" src="https://github.com/user-attachments/assets/7b0042d9-9864-41ae-801d-3e53e8b94f39" />


### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
