### PR TITLE
Fix registration link and clean up content

### DIFF
--- a/content/get-started/showcase-your-expertise-with-github-certifications/about-github-certifications.md
+++ b/content/get-started/showcase-your-expertise-with-github-certifications/about-github-certifications.md
@@ -52,13 +52,8 @@ You can certify your ability to optimize and manage a healthy {% data variables.
 
 ## Getting started with {% data variables.product.prodname_certifications %}
 
-To get started with {% data variables.product.prodname_certifications %}, you can review the different certifications on the [{% data variables.product.prodname_certifications_singular %} Registration](https://examregistration.github.com/overview) page. Every certification page includes details about the skills measured in the exams, how you can prepare, and links to register for the exams.
+To get started with {% data variables.product.prodname_certifications %}, you can review the different certifications on the [{% data variables.product.prodname_certifications_singular %} Registration](https://learn.github.com/credentials) page. Every certification page includes details about the skills measured in the exams, how you can prepare, and links to register for the exams.
 
 If you have the skills, you can register for the exam. If you want additional training, refer to the courses or learning paths in the “Preparing for the certification” section.
 
 After successful completion of a certificate exam, you will receive a Credly badge and certificate to verify your credentials.
-
-## Further reading
-
-* [{% data variables.product.prodname_certifications %} Program FAQs](https://examregistration.github.com/faq)
-* [{% data variables.product.prodname_certifications %} - Candidate Handbook](https://examregistration.github.com/handbook)

--- a/content/get-started/showcase-your-expertise-with-github-certifications/about-github-certifications.md
+++ b/content/get-started/showcase-your-expertise-with-github-certifications/about-github-certifications.md
@@ -46,7 +46,7 @@ You can highlight your knowledge with the {% data variables.product.prodname_GHA
 
 You can certify your ability to optimize and manage a healthy {% data variables.product.prodname_dotcom %} environment with the {% data variables.product.prodname_dotcom %} Admin exam. This exam covers:
 
-* Repository management
+* Repository management 
 * Workflow optimization
 * Efficient collaboration
 
@@ -54,6 +54,18 @@ You can certify your ability to optimize and manage a healthy {% data variables.
 
 To get started with {% data variables.product.prodname_certifications %}, you can review the different certifications on the [{% data variables.product.prodname_certifications_singular %} Registration](https://learn.github.com/credentials) page. Every certification page includes details about the skills measured in the exams, how you can prepare, and links to register for the exams.
 
+### {% data variables.product.prodname_dotcom %} Copilot Certification
+
+You can certify your capability to optimize software development workflows efficiently {% data variables.product.prodname_dotcom %} with the {% data variables.product.prodname_dotcom %} Copilot exam. This exam covers:
+
+* Responsible AI
+* Copilot plans & features
+* Copilot data & functionality
+* Prompt engineering
+* AI developer use cases
+* Testing with Copilot
+* Privacy & exclusions
+
 If you have the skills, you can register for the exam. If you want additional training, refer to the courses or learning paths in the “Preparing for the certification” section.
 
-After successful completion of a certificate exam, you will receive a Credly badge and certificate to verify your credentials.
+After successful completion of a certificate exam, you will receive a badge and certificate to verify your credentials.


### PR DESCRIPTION
The exam registration page was replaced. I updated the link to the new certification registration page. Additionally the FAQ and handbook have been removed so I removed the "further reading" section of this page. 

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The exam registration page was replaced. I updated the link to the new certification registration page. Additionally the FAQ and handbook have been removed so I removed the "further reading" section of this page. 


### Check off the following:

- [ x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x ] All CI checks are passing and the changes look good in the review environment.
