### PR TITLE
fix: GHCR attestation example by listing GHCR first in metadata images

### DIFF
--- a/content/actions/tutorials/publish-packages/publish-docker-images.md
+++ b/content/actions/tutorials/publish-packages/publish-docker-images.md
@@ -215,8 +215,8 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: |
-            my-docker-hub-namespace/my-docker-hub-repository
             {% data reusables.package_registry.container-registry-hostname %}/{% raw %}${{ github.repository }}{% endraw %}
+            my-docker-hub-namespace/my-docker-hub-repository
 
       - name: Build and push Docker images
         id: push


### PR DESCRIPTION
The attestation step targets GHCR, but docker/build-push-action exposes the digest for the first image produced by docker/metadata-action. The previous doc snippet listed Docker Hub first, so the attestation attempted to fetch a Docker Hub digest from GHCR, resulting in 404.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #40291 

`docker/build-push-action` exposes a single `digest` output. In practice, that digest aligns with the **first image target** from the tags generated by `docker/metadata-action`.
In the original file, **Docker Hub** (`lindon18/glu`) was listed **before** GHCR. The attestation then tried to fetch that digest on GHCR, which did not exist yet → **404**.

Error excerpt:
```
Error: OCIError: Error uploading artifact to container registry
Error: Error fetching https://ghcr.io/v2/glu-lang/glu/manifests/sha256:91bc8e85a2ba...
expected 200, received 404
```

Run: https://github.com/glu-lang/glu/actions/runs/17557475866/job/49865233829

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

## Fix
Reverse the `images` order so **GHCR comes first**. This makes `${{ steps.push.outputs.digest }}` point to a manifest that **exists on GHCR** when the attestation runs.

### Minimal diff
```diff
-          images: |
-            my-docker-hub-namespace/my-docker-hub-repository
-            ghcr.io/${{ github.repository }}
+          images: |
+            ghcr.io/${{ github.repository }}
+            my-docker-hub-namespace/my-docker-hub-repository
```

## Why it works
- The digest now references the **GHCR** artifact.
- `actions/attest-build-provenance@v2` can fetch the manifest. No more 404.
- Images are still pushed to **both registries**.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
