### PR TITLE
sentence fix: remove duplicated verb in step list

### DIFF
--- a/content/actions/how-tos/write-workflows/use-workflow-templates.md
+++ b/content/actions/how-tos/write-workflows/use-workflow-templates.md
@@ -38,7 +38,7 @@ topics:
    There are guides to accompany many of the workflow templates for building and testing projects. For more information, see [AUTOTITLE](/actions/automating-builds-and-tests).
 
 1. Some workflow templates use secrets. For example, {% raw %}`${{ secrets.npm_token }}`{% endraw %}. If the workflow template uses a secret, store the value described in the secret name as a secret in your repository. For more information, see [AUTOTITLE](/actions/security-guides/using-secrets-in-github-actions).
-1. Optionally, make additional changes. For example, you might want to change the value of `on` to change when the workflow runs.
+1. Optionally, make additional changes. For example, you might want to change the value of `on` when the workflow runs.
 1. Click **Start commit**.
 1. Write a commit message and decide whether to commit directly to the default branch or to open a pull request.
 


### PR DESCRIPTION
Step 7 of the **Choosing and using a workflow template** procedure repeats the verb: "For example, you might want to change the value of `on` to change when the workflow runs."

This pull request removes the duplication and proposes the corrected sentence "For example, you might want to change the value of `on` when the workflow runs."

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/40310

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

```diff
-    Optionally, make additional changes. For example, you might want to change the value of `on` to change when the workflow runs.
+    Optionally, make additional changes. For example, you might want to change the value of `on` when the workflow runs.
```

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
