### PR TITLE
Update telling-git-about-your-signing-key.md

### DIFF
--- a/content/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key.md
+++ b/content/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key.md
@@ -36,8 +36,8 @@ If you have multiple GPG keys, you need to tell Git which one to use.
 1. If you aren't using the GPG suite, run the following command in the `zsh` shell to add the GPG key to your `.zshrc` file, if it exists, or your `.zprofile` file:
 
    ```shell
-   $ if [ -r ~/.zshrc ]; then echo -e '\nexport GPG_TTY=$(tty)' >> ~/.zshrc; \
-     else echo -e '\nexport GPG_TTY=$(tty)' >> ~/.zprofile; fi
+   $ if [ -r ~/.zshrc ]; then echo -e '\nexport GPG_TTY=$TTY' >> ~/.zshrc; \
+     else echo -e '\nexport GPG_TTY=$TTY' >> ~/.zprofile; fi
    ```
 
    Alternatively, if you use the `bash` shell, run this command:


### PR DESCRIPTION
Edited the ZSH shell command to use the proper denotation for the TTY variable.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

This will fix GPG failing to sign commits/tags on macOS as it now properly able to reference the TTY variable.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

```
$(tty) --> $TTY
```
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [X] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [X] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [X] All CI checks are passing and the changes look good in the review environment.
