### PR TITLE
Enhance guidance for go proxy server in Dependabot

### DIFF
--- a/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
@@ -270,9 +270,15 @@ GONOSUMDB=my-company.com/*
 
 #### Notes
 
-{% data reusables.dependabot.access-private-dependencies-link %}
-
 This feature enables unified dependency management for both public and private Go modules within a single {% data variables.product.prodname_dependabot %} workflow, making it ideal for organizations using corporate artifact management systems like JFrog Artifactory or Nexus.
+
+**Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system(VCS) access, but for private modules for example published to only a private repository like Jfrog artifactory. the VCS fall back will not work since they are only accessible through the proxy.
+
+**Private Proxy Serving Private Modules**: add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern(eg. `GONOSUMDB=my-company.com/*`. For all private modules starting with my-company.com/). This will disable the public checksum validation of your private modules. Because the public checksum does not have your private modules. 
+
+**Direct Access to Private Modules**: Set `GOPRIVATE=my-company.com/*` to bypass proxies and fetch directly from VCS. This only works if private modules are properly published with semantic version tags in your source control.
+
+{% data reusables.dependabot.access-private-dependencies-link %}
 
 ### Maven
 

--- a/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
@@ -274,7 +274,7 @@ This feature enables unified dependency management for both public and private G
 
 **Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system(VCS) access, but for private modules for example published to only a private repository like JFrog Artifactory. The VCS fall back will not work since they are only accessible through the proxy.
 
-**Private Proxy Serving Private Modules**: add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern (e.g., `GONOSUMDB=my-company.com/*` for all private modules starting with my-company.com/). This will disable the public checksum validation of your private modules because the public checksum database does not have your private modules.
+**Private Proxy Serving Private Modules**: add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern (for example, `GONOSUMDB=my-company.com/*` for all private modules starting with my-company.com/). Doing this will disable the public checksum validation of your private modules because the public checksum database does not have those private modules.
 
 **Direct Access to Private Modules**: Set `GOPRIVATE=my-company.com/*` to bypass proxies and fetch directly from VCS. This only works if private modules are properly published with semantic version tags in your source control.
 

--- a/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
@@ -276,7 +276,7 @@ This feature enables unified dependency management for both public and private G
 
 **Private Proxy Serving Private Modules**: add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern (for example, `GONOSUMDB=my-company.com/*` for all private modules starting with my-company.com/). Doing this will disable the public checksum validation of your private modules because the public checksum database does not have those private modules.
 
-**Direct Access to Private Modules**: Set `GOPRIVATE=my-company.com/*` to bypass proxies and fetch directly from VCS. This only works if private modules are properly published with semantic version tags in your source control.
+**Direct Access to Private Modules**: Set `GOPRIVATE=my-company.com/*` to bypass proxies and fetch directly from VCS. This setting only works if private modules are properly published with semantic version tags in your source control.
 
 {% data reusables.dependabot.access-private-dependencies-link %}
 

--- a/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
@@ -272,7 +272,7 @@ GONOSUMDB=my-company.com/*
 
 This feature enables unified dependency management for both public and private Go modules within a single {% data variables.product.prodname_dependabot %} workflow, making it ideal for organizations using corporate artifact management systems like JFrog Artifactory or Nexus.
 
-**Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system(VCS) access, but for private modules for example published to only a private repository like Jfrog artifactory. the VCS fall back will not work since they are only accessible through the proxy.
+**Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system(VCS) access, but for private modules for example published to only a private repository like JFrog Artifactory. The VCS fall back will not work since they are only accessible through the proxy.
 
 **Private Proxy Serving Private Modules**: add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern(eg. `GONOSUMDB=my-company.com/*`. For all private modules starting with my-company.com/). This will disable the public checksum validation of your private modules. Because the public checksum does not have your private modules. 
 

--- a/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
@@ -274,7 +274,7 @@ This feature enables unified dependency management for both public and private G
 
 **Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system (VCS) access. For private modules, like those published only to a private repository like JFrog Artifactory, the VCS fall back will not work since they are only accessible through the proxy.
 
-**Private Proxy Serving Private Modules**: add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern (for example, `GONOSUMDB=my-company.com/*` for all private modules starting with my-company.com/). Doing this will disable the public checksum validation of your private modules because the public checksum database does not have those private modules.
+**Private Proxy Serving Private Modules**: Add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern (for example, `GONOSUMDB=my-company.com/*` for all private modules starting with my-company.com/). Doing this will disable the public checksum validation of your private modules because the public checksum database does not have those private modules.
 
 **Direct Access to Private Modules**: Set `GOPRIVATE=my-company.com/*` to bypass proxies and fetch directly from VCS. This setting only works if private modules are properly published with semantic version tags in your source control.
 

--- a/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
@@ -274,7 +274,7 @@ This feature enables unified dependency management for both public and private G
 
 **Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system(VCS) access, but for private modules for example published to only a private repository like JFrog Artifactory. The VCS fall back will not work since they are only accessible through the proxy.
 
-**Private Proxy Serving Private Modules**: add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern(eg. `GONOSUMDB=my-company.com/*`. For all private modules starting with my-company.com/). This will disable the public checksum validation of your private modules. Because the public checksum does not have your private modules. 
+**Private Proxy Serving Private Modules**: add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern (e.g., `GONOSUMDB=my-company.com/*` for all private modules starting with my-company.com/). This will disable the public checksum validation of your private modules because the public checksum database does not have your private modules.
 
 **Direct Access to Private Modules**: Set `GOPRIVATE=my-company.com/*` to bypass proxies and fetch directly from VCS. This only works if private modules are properly published with semantic version tags in your source control.
 

--- a/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
@@ -272,7 +272,7 @@ GONOSUMDB=my-company.com/*
 
 This feature enables unified dependency management for both public and private Go modules within a single {% data variables.product.prodname_dependabot %} workflow, making it ideal for organizations using corporate artifact management systems like JFrog Artifactory or Nexus.
 
-**Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system(VCS) access, but for private modules for example published to only a private repository like JFrog Artifactory. The VCS fall back will not work since they are only accessible through the proxy.
+**Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system (VCS) access. For private modules, like those published only to a private repository like JFrog Artifactory, the VCS fall back will not work since they are only accessible through the proxy.
 
 **Private Proxy Serving Private Modules**: add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern (for example, `GONOSUMDB=my-company.com/*` for all private modules starting with my-company.com/). Doing this will disable the public checksum validation of your private modules because the public checksum database does not have those private modules.
 

--- a/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
+++ b/content/code-security/dependabot/working-with-dependabot/guidance-for-the-configuration-of-private-registries-for-dependabot.md
@@ -272,7 +272,7 @@ GONOSUMDB=my-company.com/*
 
 This feature enables unified dependency management for both public and private Go modules within a single {% data variables.product.prodname_dependabot %} workflow, making it ideal for organizations using corporate artifact management systems like JFrog Artifactory or Nexus.
 
-**Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system (VCS) access. For private modules, like those published only to a private repository like JFrog Artifactory, the VCS fall back will not work since they are only accessible through the proxy.
+**Private Proxy Serving All Modules**: All module requests go through your proxy first. For public modules fetching failures, your proxy returns 404/410 and Go falls back to direct version control system (VCS) access. For private modules, such as those published only to a private repository like JFrog Artifactory, the VCS fall back will not work since they are only accessible through the proxy.
 
 **Private Proxy Serving Private Modules**: Add a go.env to your repository root, and set up a GONOSUMDB matching the private modules pattern (for example, `GONOSUMDB=my-company.com/*` for all private modules starting with my-company.com/). Doing this will disable the public checksum validation of your private modules because the public checksum database does not have those private modules.
 


### PR DESCRIPTION
Added details on configuring private proxies and direct access for Go modules.

### Why:
Improved documentation clarity for developers configuring Dependabot with private Go modules. The existing documentation lacked specific guidance on different proxy configurations and their trade-offs, leading to confusion about setup options and security implications.

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Enhanced the Notes section for Go module configuration with three distinct setup scenarios:

- **Private Proxy Serving All Modules**: Clarified proxy fallback behavior and limitations for JFrog-only modules
- **Private Proxy Serving Private Modules**: Added guidance on multiple registry configuration and security considerations  
- **Direct Access to Private Modules**: Explained VCS authentication requirements and proper module publishing prerequisites

Added emphasis on `GONOSUMDB` requirement for private modules and clarified when VCS fallback will/won't work based on module publishing strategy.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
