### PR TITLE
Update description from 'Your organizations' to 'Organizations'

### DIFF
--- a/data/reusables/profile/access_org.md
+++ b/data/reusables/profile/access_org.md
@@ -1,1 +1,1 @@
-1. In the upper-right corner of {% data variables.product.prodname_dotcom %}, click your profile picture, then click **{% octicon "organization" aria-hidden="true" aria-label="organization" %} Your organizations**.
+1. In the upper-right corner of {% data variables.product.prodname_dotcom %}, click your profile picture, then click **{% octicon "organization" aria-hidden="true" aria-label="organization" %} Organizations**.


### PR DESCRIPTION
### Why:
The Github's Profile menu shows "Organizations", but the instructions from data/reusables/profile/access_org.md shows "Your Organizations".

After clicking the profile picture, the menu shows "Organizations" instead of "Your Organizations"

Closes: https://github.com/github/docs/issues/40394

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Replaced "Your Organizations" with "Organizations" in `data/reusables/profile/access_org.md`

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
