### PR TITLE
Replace incorrect example search term

### DIFF
--- a/content/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https.md
+++ b/content/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https.md
@@ -54,7 +54,7 @@ Assets are commonly found in the following locations:
 * Images are often found in the `<body>` section.
 
 > [!TIP]
-> If you can't find your assets in your site's source files, try searching your site's source files for `http` in your text editor or on {% data variables.product.github %}.
+> If you can't find your assets in your site's source files, try searching your site's source files for `http://` in your text editor or on {% data variables.product.github %}.
 
 ### Examples of assets referenced in an HTML file
 


### PR DESCRIPTION
### Why:

This tip box suggests methods for finding http (non-https) resources in the source code of a GitHub Pages site. However, the suggested search term, `http`, would match both http and https URIs.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Change `http` to `http://` as the suggested search term&mdash;this will prevent https URIs being matched.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [X] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
