### PR TITLE
Update autolinked references section for clarity

### DIFF
--- a/content/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls.md
@@ -78,7 +78,7 @@ When referencing a commit from a private repository inside of a commit message, 
 By default, references generate a backlink. For example, manually linking to an issue in a pull request will automatically generate another link from the issue _back_ to the pull request.
 To avoid this behavior, you can use `redirect.github.com` instead of `github.com` when constructing the URL in your reference. If you do use a `redirect.github.com` URL in your reference link, no pop-up window will appear when hovering over it.
 > [!NOTE]
-> This method is not supported in GitHub Enterprise Cloud with Data Residency (`ghe.com`).
+> This method is not supported in {% data variables.product.prodname_ghe_cloud %} with Data Residency (`ghe.com`).
 
 ## Further reading
 

--- a/content/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls.md
@@ -77,6 +77,8 @@ When referencing a commit from a private repository inside of a commit message, 
 
 By default, references generate a backlink. For example, manually linking to an issue in a pull request will automatically generate another link from the issue _back_ to the pull request.
 To avoid this behavior, you can use `redirect.github.com` instead of `github.com` when constructing the URL in your reference. If you do use a `redirect.github.com` URL in your reference link, no pop-up window will appear when hovering over it.
+> [!NOTE]
+> This method is not supported in GitHub Enterprise Cloud with Data Residency (`ghe.com`).
 
 ## Further reading
 


### PR DESCRIPTION
Clarify that `redirect.github.com` can be used to avoid backlinks in references and note its incompatibility with GitHub Enterprise Cloud with Data Residency.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
