### PR TITLE
Clarify billing cycle options for Copilot and GitHub plans

### DIFF
--- a/content/copilot/how-tos/manage-your-account/view-and-change-your-copilot-plan.md
+++ b/content/copilot/how-tos/manage-your-account/view-and-change-your-copilot-plan.md
@@ -90,12 +90,12 @@ You can cancel your {% data variables.copilot.copilot_pro_short %} trial at any 
 
 ## Changing your billing cycle
 
-If you're on a paid {% data variables.product.prodname_copilot_short %} plan, you can switch between monthly and yearly billing at any time. The change will take effect at the start of your next billing cycle.
+If you're on a paid {% data variables.product.prodname_copilot_short %} or GitHub plan, you can switch between monthly and yearly billing at any time. The change will take effect at the start of your next billing cycle.
 
 {% data reusables.user-settings.access_settings %}
 {% data reusables.user-settings.billing-plans-two-platforms %}
 
-1. In the "{% data variables.product.prodname_copilot %}" section, select the **Edit** dropdown on the right.
+1. In the designated plan section, select the **Edit** dropdown on the right.
 1. Choose the option to switch your billing cycle:
 
    * If you're billed monthly, click **Change to yearly billing**.


### PR DESCRIPTION
Updated instructions to include GitHub plans for billing cycle changes.

The previous doc for changing a GitHub billing cycle duration has been deleted but the content is still relevant and needed: 

https://docs.github.com/billing/managing-your-github-billing-settings/changing-the-duration-of-your-billing-cycle

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: Customers ask how to change their GitHub billing cycle and there is no corresponding doc since the previous one was deleted. 

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/40608, https://github.com/github/docs-content/issues/18387

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adds a mention of GitHub billing plans to make it more inclusive. 

Alternatively, it would be helpful to bring back the original doc that used to live here:

[Changing the duration of your billing cycle](https://docs.github.com/billing/managing-your-github-billing-settings/changing-the-duration-of-your-billing-cycle)

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
