### PR TITLE
fix(docs): the copilot cli mcp configuration location

### DIFF
--- a/content/copilot/how-tos/use-copilot-agents/use-copilot-cli.md
+++ b/content/copilot/how-tos/use-copilot-agents/use-copilot-cli.md
@@ -133,7 +133,7 @@ To extend the functionality available to you in {% data variables.copilot.copilo
 1. Fill in the details for the MCP server you want to add, using the <kbd>Tab</kbd> key to move between fields.
 1. Press <kbd>Ctrl</kbd>+<kbd>S</kbd> to save the details.
 
-Details of your configured MCP servers are stored in the `mcp-config.json` file, which is located, by default, in the `~/.config` directory. This location can be changed by setting the `XDG_CONFIG_HOME` environment variable. For information about the JSON structure of a server definition, see [AUTOTITLE](/copilot/how-tos/use-copilot-agents/coding-agent/extend-coding-agent-with-mcp#writing-a-json-configuration-for-mcp-servers).
+Details of your configured MCP servers are stored in the `mcp-config.json` file, which is located in the `~/.copilot` directory. For information about the JSON structure of a server definition, see [AUTOTITLE](/copilot/how-tos/use-copilot-agents/coding-agent/extend-coding-agent-with-mcp#writing-a-json-configuration-for-mcp-servers).
 
 ## Find out more
 


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs/issues/40682

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This changes the directory for copilot cli to be the same directory that `/mcp add` uses

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.