### PR TITLE
fix: dead link to register to exams

### DIFF
--- a/content/get-started/showcase-your-expertise-with-github-certifications/registering-for-a-github-certifications-exam.md
+++ b/content/get-started/showcase-your-expertise-with-github-certifications/registering-for-a-github-certifications-exam.md
@@ -16,7 +16,7 @@ shortTitle: Registering for an exam
 
 ## About registration
 
-When you’re prepared and ready to schedule your exam, you can register from any certification details page on the [{% data variables.product.prodname_certifications_singular %} Registration](https://examregistration.github.com/overview) page.
+When you’re prepared and ready to schedule your exam, you can register from any certification details page on the [{% data variables.product.prodname_certifications_singular %} Registration](https://learn.github.com/credentials) page.
 
 During the scheduling process you can choose if you want to take the exam in a local test center or online. With an online proctored exam, you can take your exam at almost any time using your own computer, but it requires installation of a secure browser and reliable access to the internet. Local test centers provide a secure computer environment to take your exam. For more information, see [Computer specifications](https://www.psiexams.com/become-psi-test-center/computer-specifications/) in the PSI documentation.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
Dead link to register to Github certifications exam on https://docs.github.com/en/get-started/showcase-your-expertise-with-github-certifications/registering-for-a-github-certifications-exam

<!-- Paste the issue link or number here -->

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Changed the link to match the sibling page https://docs.github.com/en/get-started/showcase-your-expertise-with-github-certifications/about-github-certifications
(and thus not be broken anymore)

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
