### PR TITLE
Update in initialize-with-readme.md

### DIFF
--- a/content/repositories/creating-and-managing-repositories/quickstart-for-repositories.md
+++ b/content/repositories/creating-and-managing-repositories/quickstart-for-repositories.md
@@ -25,18 +25,13 @@ topics:
 {% webui %}
 
 {% data reusables.repositories.create_new %}
-{% data reusables.repositories.owner-drop-down %}
 1. Type a short, memorable name for your repository. For example, "hello-world".
 
    ![Screenshot of the first step in creating a repository. The "Repository name" field contains the text "hello-world" and is outlined in dark orange.](/assets/images/help/repository/create-repository-name.png)
 1. Optionally, add a description of your repository. For example, "My first repository on {% data variables.product.github %}."
 {% data reusables.repositories.choose-repo-visibility %}
 {% data reusables.repositories.initialize-with-readme %}
-1. Add **.gitignore.**
-1. Add **license.**
 {% data reusables.repositories.create-repo %}
-
-For more information, see [AUTOTITLE](/repositories/creating-and-managing-repositories/creating-a-new-repository).
 
 Congratulations! You've successfully created your first repository, and initialized it with a _README_ file.
 

--- a/content/repositories/creating-and-managing-repositories/quickstart-for-repositories.md
+++ b/content/repositories/creating-and-managing-repositories/quickstart-for-repositories.md
@@ -25,13 +25,18 @@ topics:
 {% webui %}
 
 {% data reusables.repositories.create_new %}
+{% data reusables.repositories.owner-drop-down %}
 1. Type a short, memorable name for your repository. For example, "hello-world".
 
    ![Screenshot of the first step in creating a repository. The "Repository name" field contains the text "hello-world" and is outlined in dark orange.](/assets/images/help/repository/create-repository-name.png)
 1. Optionally, add a description of your repository. For example, "My first repository on {% data variables.product.github %}."
 {% data reusables.repositories.choose-repo-visibility %}
 {% data reusables.repositories.initialize-with-readme %}
+1. Add **.gitignore.**
+1. Add **license.**
 {% data reusables.repositories.create-repo %}
+
+For more information, see [AUTOTITLE](/repositories/creating-and-managing-repositories/creating-a-new-repository).
 
 Congratulations! You've successfully created your first repository, and initialized it with a _README_ file.
 

--- a/data/reusables/repositories/initialize-with-readme.md
+++ b/data/reusables/repositories/initialize-with-readme.md
@@ -1,1 +1,1 @@
-1. Select **Add README**.
+1. Toggle **Add README** to **On**.

--- a/data/reusables/repositories/initialize-with-readme.md
+++ b/data/reusables/repositories/initialize-with-readme.md
@@ -1,1 +1,1 @@
-1. Select **Initialize this repository with a README**.
+1. Select **Add README**.


### PR DESCRIPTION
Document url:
https://docs.github.com/en/repositories/creating-and-managing-repositories/quickstart-for-repositories

### Why:
Under **Create a repository**  section, as per instruction

If I click + icon, then New repository, 
then, in a New repository UI page:
Under Step **2. Configuration**: There were some missing instruction

<img width="774" height="174" alt="newRepos" src="https://github.com/user-attachments/assets/67ed78b7-75ad-4525-bef0-8520a8006d48" />




### What's being changed (if available, include any code snippets, screenshots, or gifs):

Made changes:
In initialize-with-readme.md
Changed the text **Initialize this repository with a README.** to **Add README.**

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
