### PR TITLE
events-that-trigger-workflows: add unreachable tag note

### DIFF
--- a/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
+++ b/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
@@ -846,6 +846,8 @@ on:
       - v1.**
 ```
 
+A push to a tag that is not reachable from the repository's branches does not run any workflows.
+
 ### Running your workflow only when a push affects specific files
 
 You can use the `paths` or `paths-ignore` filter to configure your workflow to run when a push to specific files occurs. For more information, see [AUTOTITLE](/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore).


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

It's worth documenting, imo.

It's true though, right? Reproduce this behavior:

```sh
git checkout -b feature
cat >.github/workflows/build.yml <<EOF
...
EOF
git add .github/workflows/build.yml
git commit -m "ci: add build"
git tag feature-workflow-test-1
git push origin feature-workflow-test-1 # push tag but not branch
```

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
