### PR TITLE
Update docs about permissions required for managing dependabot-related secrets

### DIFF
--- a/data/reusables/repositories/permissions-statement-secrets-repository.md
+++ b/data/reusables/repositories/permissions-statement-secrets-repository.md
@@ -1,1 +1,1 @@
-To create secrets for a personal account repository, you must be the repository owner. To create secrets for an organization repository, you must have `admin` access.
+To create a repository secret, you must have `write` access.


### PR DESCRIPTION
### Why:

Historically, it was already possible to manage secrets via the REST API with **Write** permissions, even though the GitHub web interface did not provide a UI for it at the time. Recently, the web UI has also been updated to allow secret management directly.
(As of October 16, 2025, it appears that the current UI has an issue where, if there are no Dependabot secrets yet, the link to the page for adding them is not displayed. However, it is still possible to access and manage Dependabot secrets by directly entering the page’s URL)

According to the following documentation, users with **Write** permission can now manage repository secrets:

* [https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role)

This update to the documentation appears to have been made in the following pull request:

* [https://github.com/github/docs/pull/32565](https://github.com/github/docs/pull/32565)

Based on these facts, the current explanation stating that **Owner** or **Admin** permissions are required is no longer accurate.
I’d like to propose updating the description to reflect the actual behavior — namely, that **Write** permissions are sufficient to manage Dependabot-related secrets.

I verified this behavior in an **organization repository** where I have **Write** permission.
I haven’t tested it in a **personal repository**, so there’s a chance my understanding might not be entirely accurate in that case.
Reviewers are likely more familiar with the details here, so I’d appreciate it if you could double-check whether **write** permission is also sufficient for personal repositories.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I’ve updated the description, which previously stated that **Owner** or **Admin** permissions were required to create secrets, to now indicate that **Write** permission is sufficient.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
