### PR TITLE
Fix example in control-jobs-with-conditions

### DIFF
--- a/content/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions.md
+++ b/content/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions.md
@@ -23,7 +23,9 @@ name: example-workflow
 on: [push]
 jobs:
   production-deploy:
+{% raw %}
     if: ${{ github.repository == 'octo-org/octo-repo-prod' }}
+{% endraw %}
     runs-on: ubuntu-latest
     steps:
       - uses: {% data reusables.actions.action-checkout %}


### PR DESCRIPTION
### Why:

My previous PR (https://github.com/github/docs/pull/40865) broke the example. The condition is now displaying as `$false`.

I didn't realise that the expression needs to be escaped.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Use the `{% raw %}` template directive (is this the right way to handle it?

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
