### PR TITLE
Remove empty lines from control-jobs-with-conditions

### DIFF
--- a/content/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions.md
+++ b/content/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions.md
@@ -23,9 +23,7 @@ name: example-workflow
 on: [push]
 jobs:
   production-deploy:
-{% raw %}
-    if: ${{ github.repository == 'octo-org/octo-repo-prod' }}
-{% endraw %}
+    if: {% raw %}${{ github.repository == 'octo-org/octo-repo-prod' }}{% endraw %}
     runs-on: ubuntu-latest
     steps:
       - uses: {% data reusables.actions.action-checkout %}


### PR DESCRIPTION
### Why:

Hello again 😄,
My previous PR fixed the templating issue, but introduced some blank lines around the if. I think we should tidy this up.

<img width="518" height="135" alt="image" src="https://github.com/user-attachments/assets/c6b65460-f12a-4f40-acb2-43baeedade73" />

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Move the `raw` directives into the same line as the `if`.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
