### PR TITLE
update in managing-teams-and-people-with-access-to-your-repository

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-teams-and-people-with-access-to-your-repository.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-teams-and-people-with-access-to-your-repository.md
@@ -36,7 +36,9 @@ For more information about repository roles, see [AUTOTITLE](/account-and-profil
 {% data reusables.repositories.navigate-to-repo %}
 {% data reusables.repositories.sidebar-settings %}
 {% data reusables.repositories.click-collaborators-teams %}
-1. Under "Manage access", in the search field, start typing the name of the team or person you'd like to find. Optionally, use the dropdown menus to filter your search. {% ifversion org-custom-role-with-repo-permissions %}
+
+1. Under "Manage access", click **Add people**.
+1. In the search field, start typing the name of the team or person you'd like to find. Optionally, use the dropdown menus to filter your search. {% ifversion org-custom-role-with-repo-permissions %}
 
    You can also toggle between the **Direct access** and **Organization access** tabs to view who has direct access to the repository and who can access the repository via a team or organization role.{% endif %}
 


### PR DESCRIPTION
Document url:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings
		/managing-teams-and-people-with-access-to-your-repository

### Why:
I am not able to see search field, in my UI below screenshot:
<img width="815" height="270" alt="searchField" src="https://github.com/user-attachments/assets/5d09c7b9-c96f-46e6-839f-dd5be6147ded" />



### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added missing instruction
in 
 ## Filtering the list of teams and people
section

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
