### PR TITLE
docs: Add PowerShell v6+ prerequisite for Windows users to Copilot CLI install guide

### DIFF
--- a/content/copilot/how-tos/set-up/install-copilot-cli.md
+++ b/content/copilot/how-tos/set-up/install-copilot-cli.md
@@ -27,6 +27,7 @@ To find out about {% data variables.copilot.copilot_cli_short %} before you inst
 * **A {% data variables.product.prodname_copilot %} subscription**. See [Copilot plans](https://github.com/features/copilot/plans?ref_product=copilot&ref_type=engagement&ref_style=text).
 * **Node.js** version 22 or later
 * **npm** version 10 or later
+* **(On Windows)** PowerShell version 6 or later.
 
 If you have access to {% data variables.product.prodname_copilot %} via your organization or enterprise, you cannot use {% data variables.copilot.copilot_cli_short %} if your organization owner or enterprise administrator has disabled it in the organization or enterprise settings. See [AUTOTITLE](/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-github-copilot-features-in-your-organization/managing-policies-for-copilot-in-your-organization).
 


### PR DESCRIPTION
_Copilot Chat generated this pull request._

<details><summary>Prompt summary - submitted by @aymanaboghonim</summary>

> Add a Windows-specific prerequisite for PowerShell v6+ to the Copilot CLI install guide, as required by the official documentation. No other changes were made.

</details>

**Summary:**
This PR surgically adds a single prerequisite line for Windows users to the Copilot CLI installation guide, ensuring the documentation matches the official requirements. No other content was changed.

**Reference:**
See the official Copilot CLI prerequisites: https://github.com/github/copilot-cli?tab=readme-ov-file#prerequisites

