### PR TITLE
Update configure-automatic-review.md

### DIFF
--- a/content/copilot/how-tos/use-copilot-agents/request-a-code-review/configure-automatic-review.md
+++ b/content/copilot/how-tos/use-copilot-agents/request-a-code-review/configure-automatic-review.md
@@ -29,7 +29,7 @@ The three sections in this article tell you how to configure automatic code revi
 ## Configuring automatic code review for your own pull requests
 
 > [!NOTE]
-> This is only available if you are on the {% data variables.copilot.copilot_pro_short %} or {% data variables.copilot.copilot_pro_plus_short %} plan.
+> **Support:** This is only available if you are on the {% data variables.copilot.copilot_pro_short %} or {% data variables.copilot.copilot_pro_plus_short %} plan on {% data variables.product.prodname_dotcom_the_website %}.
 
 {% data reusables.copilot.your-copilot %}
 1. Locate the **Automatic {% data variables.copilot.copilot_code-review_short %}** option and click the dropdown button.


### PR DESCRIPTION
Make "Support:" consistent with other pages. Specify only available at github.com.


### Why:

Current doc does not tell you that the feature is only available in GitHub.com.

Closes: 

None.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Only one MD file. I added the word "Support:" to be consistent with other pages. I added that the feature is available only "on github.com."

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
