### PR TITLE
fix: Minor typo in reusing-workflow-configurations.md

### DIFF
--- a/content/actions/reference/workflows-and-actions/reusing-workflow-configurations.md
+++ b/content/actions/reference/workflows-and-actions/reusing-workflow-configurations.md
@@ -44,7 +44,7 @@ For {% ifversion ghes or ghec %}internal or {% endif %}private repositories, the
 
 {% data reusables.actions.actions-redirects-workflows %}
 
-### Limitations of reusable worklows
+### Limitations of reusable workflows
 
 * You can connect up to four levels of workflows. For more information, see [Nesting reusable workflows](/actions/how-tos/sharing-automations/reuse-workflows#nesting-reusable-workflows).
 * You can call a maximum of 20 unique reusable workflows from a single workflow file. This limit includes any trees of nested reusable workflows that may be called starting from your top-level caller workflow file.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

There is a misspelled word in one of the headings within [reusing-workflow-configurations.md](https://github.com/github/docs/blob/237ccacac3b87b040d3353f93760eb2d111bc153/content/actions/reference/workflows-and-actions/reusing-workflow-configurations.md?plain=1#L47).

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Worklows --> Workflows

> <img width="771" height="209" alt="reusing-workflow-configurations" src="https://github.com/user-attachments/assets/c2e88934-5ed4-4fb2-899c-2cba949c381d" style="border: 1px solid #000;" />

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
