### PR TITLE
Updated managing-the-default-branch-name-for-your-repositories.md

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-default-branch-name-for-your-repositories.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-default-branch-name-for-your-repositories.md
@@ -27,7 +27,7 @@ When you create a new repository on {% data variables.product.github %}, the rep
 
 {% data reusables.user-settings.access_settings %}
 {% data reusables.user-settings.repo-tab %}
-1. In the text field, type the default name that you would like to use for new branches.
+1. In the text field, type the default name that you would like to use for new repositories.
 1. Click **Update**.
 
 ## Further reading


### PR DESCRIPTION
Document url:
https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-default-branch-name-for-your-repositories

### Why:

Under the section below:
## Setting the default branch name

line says:
3. In the text field, type the default name that you would like to use for new branches
is not clear. (can be updated with **for default branch** or **for new repositories**)
Because, there is only a default branch when create a new repository as mentioned in the document.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updated as:
3. In the text field, type the default name that you would like to use for new repositories.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
