### PR TITLE
Update in product.yml(configuring-advanced-s…

### DIFF
--- a/data/variables/product.yml
+++ b/data/variables/product.yml
@@ -209,7 +209,7 @@ prodname_cs_or_sp: '{% ifversion ghas-products %}Secret Protection or Code Secur
 prodname_cs_and_sp: '{% ifversion ghas-products %}Secret Protection and Code Security{% else %}Advanced Security{% endif %}'
 UI_advanced_security: '{% ifversion ghas-products %}{% data variables.product.prodname_AS %}{% elsif ghes > 3.15 %}Code security{% else %}Code security and analysis{% endif %}'
 UI_advanced_security_ent: '{% ifversion ghas-products %}{% data variables.product.prodname_AS %}{% elsif ghes > 3.14 %}Code security{% else %}Code security and analysis{% endif %}'
-UI_code_security_scanning: '{% ifversion ghas-products %}Code scanning{% else %}Code Security{% endif %}'
+UI_code_security_scanning: '{% ifversion ghas-products %}Code Security{% else %}Code scanning{% endif %}'
 UI_secret_protection_scanning: '{% ifversion ghas-products %}Secret Protection{% else %}Secret scanning{% endif %}'
 
 ## OLD variables, DO NOT USE

--- a/data/variables/product.yml
+++ b/data/variables/product.yml
@@ -209,7 +209,7 @@ prodname_cs_or_sp: '{% ifversion ghas-products %}Secret Protection or Code Secur
 prodname_cs_and_sp: '{% ifversion ghas-products %}Secret Protection and Code Security{% else %}Advanced Security{% endif %}'
 UI_advanced_security: '{% ifversion ghas-products %}{% data variables.product.prodname_AS %}{% elsif ghes > 3.15 %}Code security{% else %}Code security and analysis{% endif %}'
 UI_advanced_security_ent: '{% ifversion ghas-products %}{% data variables.product.prodname_AS %}{% elsif ghes > 3.14 %}Code security{% else %}Code security and analysis{% endif %}'
-UI_code_security_scanning: '{% ifversion ghas-products %}Code Security{% else %}Code scanning{% endif %}'
+UI_code_security_scanning: '{% ifversion ghas-products %}Code scanning{% else %}Code Security{% endif %}'
 UI_secret_protection_scanning: '{% ifversion ghas-products %}Secret Protection{% else %}Secret scanning{% endif %}'
 
 ## OLD variables, DO NOT USE


### PR DESCRIPTION
Document url:
https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning

### Why: 

ghas product was set to Code Security

<img width="714" height="52" alt="clickCodeSecurity" src="https://github.com/user-attachments/assets/19f3ea47-d56c-4236-b4a8-5d116b8943db" />


### What's being changed (if available, include any code snippets, screenshots, or gifs):

I will create an issue #40987 on this, so someone make changes to it. Thanks for the update.


### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
