### PR TITLE
docs: clarify definition of GitHub Actions

### DIFF
--- a/content/actions/get-started/understand-github-actions.md
+++ b/content/actions/get-started/understand-github-actions.md
@@ -79,7 +79,7 @@ For more information, see [AUTOTITLE](/actions/using-jobs).
 
 ### Actions
 
-An **action** is a custom application for the GitHub Actions platform that performs a complex but frequently repeated task. Actions can perform tasks such as:
+An **action** is a custom application for the GitHub Actions platform that performs a specific, repeated task in your workflow. Actions can perform tasks such as:
 
 * Pulling your Git repository from {% data variables.product.prodname_dotcom %}
 * Setting up the correct toolchain for your build environment

--- a/content/actions/get-started/understand-github-actions.md
+++ b/content/actions/get-started/understand-github-actions.md
@@ -79,7 +79,7 @@ For more information, see [AUTOTITLE](/actions/using-jobs).
 
 ### Actions
 
-An **action** is a pre-defined, reusable set of jobs or code that performs specific tasks within a **workflow**, reducing the amount of repetitive code you write in your workflow files. Actions can perform tasks such as:
+An **action** is a custom application for the GitHub Actions platform that performs a complex but frequently repeated task. Actions can perform tasks such as:
 
 * Pulling your Git repository from {% data variables.product.prodname_dotcom %}
 * Setting up the correct toolchain for your build environment


### PR DESCRIPTION
## What
Clarified the definition of "action" in the Understanding GitHub Actions guide.

## Why
The previous definition incorrectly described actions as "a set of jobs or code," which is misleading. Actions are custom applications used as steps within jobs, not collections of jobs themselves.

## Changes
- Updated line 82 to accurately define actions as "custom applications for the GitHub Actions platform"
- Removed the inaccurate "set of jobs" phrasing