### PR TITLE
Clarified that permanent links can include column ranges

### DIFF
--- a/content/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/creating-a-permanent-link-to-a-code-snippet.md
@@ -1,6 +1,7 @@
 ---
 title: Creating a permanent link to a code snippet
-intro: You can create a permanent link to a specific line or range of lines of code in a specific version of a file or pull request.
+intro: You can create a permanent link to a specific line, range of lines, or even a range of columns in a file in a specific version of a file or pull request. When you select part of the code, GitHub automatically generates a link that includes line or column references (for example, `#L2C4-L2C16`).
+
 product: '{% data reusables.gated-features.markdown-ui %}'
 redirect_from:
   - /github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/creating-a-permanent-link-to-a-code-snippet
@@ -19,6 +20,8 @@ shortTitle: Permanent links to code
 ## Linking to code
 
 This type of permanent link will render as a code snippet only in the repository it originated in. In other repositories, the permalink code snippet will render as a URL. This does not work in Markdown files, only in comments.
+
+> **Note:** Column-level links (like `#L2C4-L2C16`) may not be supported in all browsers or views yet.
 
 ![Screenshot of an issue comment. A code snippet has a header that lists the file name and line numbers, and a body that lists the code on those lines.](/assets/images/help/repository/rendered-code-snippet.png)
 


### PR DESCRIPTION
Added a clarification note explaining that users can create permanent links to specific columns within a line, and that column-level links may not work in all browsers. Fixes issue #40794.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
