### PR TITLE
docs: add explanation about MIT License for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ This project is dual-licensed under:
 
 * **Creative Commons Attribution 4.0** - for documentation and content in the assets, content, and data folders (see [LICENSE](LICENSE))
 * **MIT License** - for code (see [LICENSE-CODE](LICENSE-CODE))
+
+### About the MIT License
+
+The **MIT License** is a permissive open-source license that allows you to freely use, modify, and distribute the code with minimal restrictions.  
+In simple terms:
+- ✅ You can use the code in personal and commercial projects.
+- 🛠️ You can modify or merge it with your own work.
+- ⚖️ You must include the original copyright and license notice.
+
+This flexibility encourages collaboration and learning within the open-source community, which aligns with GitHub’s mission to make software development more open and accessible.


### PR DESCRIPTION
This pull request adds a short explanation about the MIT License section in the README to make it clearer for contributors and readers.

Changes made

Added a brief note explaining the scope of the MIT License and what it covers.

Ensured formatting aligns with existing README style and tone.

Reason for change

The README mentions the MIT License but does not clarify its purpose.
This update helps contributors better understand how the code portions of the repository are licensed differently from documentation content (which uses Creative Commons Attribution 4.0).

Checklist
Followed contribution guidelines
Markdown formatting verified
Content reviewed for clarity and tone