### PR TITLE
Fix typos in billing actions minutes documentation

### DIFF
--- a/content/billing/concepts/product-billing/github-actions.md
+++ b/content/billing/concepts/product-billing/github-actions.md
@@ -78,7 +78,7 @@ Storage is billed based on hourly usage of artifacts throughout the month. Minut
 
 ### Minute multipliers
 
-Each type of runner has a minute multipler that is determined by the operating system and processing power. For example, jobs that run on Windows and macOS runners hosted by {% data variables.product.github %} consume minutes at 2 and 10 times the rate that jobs on Linux runners consume.
+Each type of runner has a minute multiplier that is determined by the operating system and processing power. For example, jobs that run on Windows and macOS runners hosted by {% data variables.product.github %} consume minutes at 2 and 10 times the rate that jobs on Linux runners consume.
 
 | Operating system | Minute multiplier |
 |----------------- | :----------------:|
@@ -86,7 +86,7 @@ Each type of runner has a minute multipler that is determined by the operating s
 | Windows          | 2                 |
 | macOS            | 10                |
 
-For full details of minute multiplers for {% data variables.product.github %}-hosted runners, see [AUTOTITLE](/billing/reference/actions-minute-multipliers).
+For full details of minute multipliers for {% data variables.product.github %}-hosted runners, see [AUTOTITLE](/billing/reference/actions-minute-multipliers).
 
 ### Example minutes cost calculation
 


### PR DESCRIPTION
Corrects 'multipler' to 'multiplier' and 'multiplers' to 'multipliers' in Minute multipliers section of github-actions.md

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

To fix typos

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

'multipler' -> 'multiplier'

'multiplers' -> 'multipliers'

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
