### PR TITLE
fix tip callout

### DIFF
--- a/content/organizations/organizing-members-into-teams/about-teams.md
+++ b/content/organizations/organizing-members-into-teams/about-teams.md
@@ -20,7 +20,8 @@ You can use teams to manage access for people in an organization, and for sendin
 
 {% ifversion not ghes %}
 
->![TIP] If you use an enterprise account, you can also create teams at the enterprise level. For more information, see [AUTOTITLE](/enterprise-cloud@latest/admin/overview/about-teams).
+> [!TIP]
+> If you use an enterprise account, you can also create teams at the enterprise level. For more information, see [AUTOTITLE](/enterprise-cloud@latest/admin/overview/about-teams).
 
 {% endif %}
 


### PR DESCRIPTION
This PR fixes a broken tip callout in the ['About organization teams' page](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams#about-teams:~:text=!%5BTIP%5D%20If%20you%20use%20an%20enterprise%20account%2C%20you%20can%20also%20create%20teams%20at%20the%20enterprise%20level.%20For%20more%20information%2C%20see%20Teams%20in%20an%20enterprise.)

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
