### PR TITLE
Update terminology from 'transient' to 'transitive'

### DIFF
--- a/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
+++ b/content/code-security/dependabot/working-with-dependabot/dependabot-options-reference.md
@@ -106,7 +106,7 @@ For most package managers, you should define a value that will match the depende
 | Dependency types | Supported by package managers | Allow updates |
 |------------------|-------------------------------|--------|
 | `direct` | All | All explicitly defined dependencies. |
-| `indirect` | `bundler`, `pip`, `composer`, `cargo`, `gomod` | Dependencies of direct dependencies (also known as sub-dependencies, or transient dependencies).|
+| `indirect` | `bundler`, `pip`, `composer`, `cargo`, `gomod` | Dependencies of direct dependencies (also known as sub-dependencies, or transitive dependencies).|
 | `all` | All | All explicitly defined dependencies. For `bundler`, `pip`, `composer`, `cargo`, `gomod`, also the dependencies of direct dependencies.|
 | `production` | `bundler`, `composer`, `mix`, `maven`, `npm`, `pip` (not all managers) | Only to dependencies defined by the package manager as production dependencies. |
 | `development`| `bundler`, `composer`, `mix`, `maven`, `npm`, `pip` (not all managers) | Only to dependencies defined by the package manager as development dependencies. |


### PR DESCRIPTION
### Why:

While both terms describe the same concept, “transitive dependency” is more commonly used, and the term “transient dependency” may lead to confusion for some audiences.

See https://en.wikipedia.org/wiki/Transitive_dependency and https://github.com/dependabot/dependabot-core/issues/13456

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
