### PR TITLE
Fix suggested alternative for deprecated Claude Sonnet 3.5

### DIFF
--- a/data/tables/copilot/model-deprecation-history.yml
+++ b/data/tables/copilot/model-deprecation-history.yml
@@ -13,7 +13,7 @@
 
 - name: 'Claude Sonnet 3.5'
   retirement_date: '2025-11-06'
-  suggested_alternative: 'Claude Sonnet 3.5'
+  suggested_alternative: 'Claude Haiku 4.5'
 
 - name: 'Claude Opus 4'
   retirement_date: '2025-10-23'


### PR DESCRIPTION
### Why:

In the current version of the documentation, a deprecated model's alternative is referencing to itself.

<img width="1546" height="468" alt="image" src="https://github.com/user-attachments/assets/cce8fc6f-2e8c-4186-a618-3ebc217170fb" />

Closes: https://github.com/github/docs/issues/41215

### What's being changed:

I chose to recommend Claude Haiku 4.5 instead, as it was the replacement used in other parts of the documentation (see https://github.com/github/docs/commit/1472523ef87cc1bd939a288fed580fbaa25c1d33 )

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
