### PR TITLE
docs: bump `actions/setup-python` from 5 to 6

### DIFF
--- a/data/reusables/actions/action-setup-python.md
+++ b/data/reusables/actions/action-setup-python.md
@@ -1,1 +1,1 @@
-actions/setup-python@v5
+actions/setup-python@v6


### PR DESCRIPTION
### Summary:

Bumps the [actions/setup-python](https://github.com/actions/setup-python) GitHub Actions.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updates `actions/setup-python` from [5](https://github.com/actions/setup-python/releases/tag/v5.6.0) to [6](https://github.com/actions/setup-python/releases/tag/v6.0.0).

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
