### PR TITLE
docs: bump `actions/setup-dotnet` from 4 to 5

### DIFF
--- a/data/reusables/actions/action-setup-dotnet.md
+++ b/data/reusables/actions/action-setup-dotnet.md
@@ -1,1 +1,1 @@
-actions/setup-dotnet@v4
+actions/setup-dotnet@v5


### PR DESCRIPTION
### Summary:

Bumps the [actions/setup-dotnet](https://github.com/actions/setup-dotnet) GitHub Actions.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updates `actions/setup-dotnet` from [4](https://github.com/actions/setup-dotnet/releases/tag/v4.3.1) to [5](https://github.com/actions/setup-dotnet/releases/tag/v5.0.0).

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
