### PR TITLE
docs: bump `actions/setup-java` from 4 to 5

### DIFF
--- a/data/reusables/actions/action-setup-java.md
+++ b/data/reusables/actions/action-setup-java.md
@@ -1,1 +1,1 @@
-actions/setup-java@v4
+actions/setup-java@v5


### PR DESCRIPTION
### Summary:

Bumps [actions/setup-java](https://github.com/actions/setup-java) Github Actions.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updates `actions/setup-java` from [4](https://github.com/actions/setup-java/releases/tag/v4.7.1) to [5](https://github.com/actions/setup-java/releases/tag/v5.0.0).

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
