### PR TITLE
Normalize use of string in git command.

### DIFF
--- a/data/reusables/gpg/set-auto-sign.md
+++ b/data/reusables/gpg/set-auto-sign.md
@@ -1,7 +1,7 @@
 1. Optionally, to configure Git to sign all commits and tags by default, enter the following command:
 
    ```shell
-   git config --global commit.gpgsign true
+   git config --global commit.gpgSign true
    git config --global tag.gpgSign true
    ```
 


### PR DESCRIPTION
"gpgSign" instead of "gpgsign" for both invocations: (a) avoids confusion, (b) matches use of camel case as in Git documentation.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The invocation `git config --global x true` spells the string `x` in two different ways. The case is probably not important but to maintain parity with Git documentation the suffix of `x` should use camel case: `gpgSign`. Also, having two versions of the same suffix in the same block of text may confuse readers.

<!-- Paste the issue link or number here -->
Closes: NA

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Text formatting of this "reusable text block," located at `data/reusables/gpg/set-auto-sign.md`, specifying a git invocation that sets Git's global configuration to enable automatic commit-signing, is being changed.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
