### PR TITLE
Remove note about future Dependabot Actions default as this is the only option

### DIFF
--- a/content/code-security/dependabot/maintain-dependencies/managing-dependabot-on-self-hosted-runners.md
+++ b/content/code-security/dependabot/maintain-dependencies/managing-dependabot-on-self-hosted-runners.md
@@ -19,8 +19,6 @@ redirect_from:
 
 ## About {% data variables.product.prodname_dependabot %} on {% data variables.product.prodname_actions %} self-hosted runners
 
-{% data reusables.dependabot.dependabot-on-actions-future-note %}
-
 You can help users of your organization and repositories to create and maintain secure code by setting up {% data variables.product.prodname_dependabot %} security and version updates. With {% data variables.product.prodname_dependabot_updates %}, developers can configure repositories so that their dependencies are updated and kept secure automatically. Running {% data variables.product.prodname_dependabot %} on {% data variables.product.prodname_actions %} allows for better performance, and increased visibility and control of {% data variables.product.prodname_dependabot %} jobs.
 
 {% data reusables.dependabot.vnet-arc-note %}

--- a/content/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners.md
+++ b/content/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners.md
@@ -20,8 +20,6 @@ topics:
 > [!IMPORTANT]
 > If {% data variables.product.prodname_dependabot %} is enabled for a repository, it will always run on {% data variables.product.prodname_actions %}, **bypassing both Actions policy checks and disablement at the repository or organization level**. This ensures that security and version update workflows always run when Dependabot is enabled.
 
-{% data reusables.dependabot.dependabot-on-actions-future-note %}
-
 Using {% data variables.product.prodname_actions %} runners allows you to more easily identify {% data variables.product.prodname_dependabot %} job errors and manually detect and troubleshoot failed runs. You can also integrate {% data variables.product.prodname_dependabot %} into your CI/CD pipelines by using {% data variables.product.prodname_actions %} APIs and webhooks to detect {% data variables.product.prodname_dependabot %} job status such as failed runs, and perform downstream processing. For more information, see [AUTOTITLE](/rest/actions) and [AUTOTITLE](/webhooks/webhook-events-and-payloads).
 
 > [!NOTE]

--- a/data/reusables/dependabot/dependabot-on-actions-future-note.md
+++ b/data/reusables/dependabot/dependabot-on-actions-future-note.md
@@ -1,1 +1,0 @@
-> [!NOTE] Future releases of {% data variables.product.prodname_dotcom %} will always run {% data variables.product.prodname_dependabot %} using {% data variables.product.prodname_actions %}, and you will no longer have the option to enable or disable this setting.


### PR DESCRIPTION
### Why:

Follow up for https://github.com/github/docs/issues/41208

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Removes references about options to run Dependabot without GitHub Actions as that's no longer possible

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
