### PR TITLE
Updated docs/content/authentication/troubleshooting-ssh/error-permiss…

### DIFF
--- a/content/authentication/troubleshooting-ssh/error-permission-denied-publickey.md
+++ b/content/authentication/troubleshooting-ssh/error-permission-denied-publickey.md
@@ -246,3 +246,110 @@ If you don't see your public key in {% data variables.product.github %}, you'll 
 
 > [!WARNING]
 > If you see an SSH key you're not familiar with on {% data variables.product.github %}, delete it immediately and contact {% data variables.contact.contact_support %} for further help. An unidentified public key may indicate a possible security concern. For more information, see [AUTOTITLE](/authentication/keeping-your-account-and-data-secure/reviewing-your-ssh-keys).
+
+
+## Verify local SSH permissions 
+
+{% mac %}
+
+1. Open Terminal.
+1. Start SSH agent in the background.
+
+   ```shell
+   $ eval "$(ssh-agent -s)"
+   > Agent pid 59566 # Example output
+   ```
+
+1. Reattempt to add the appropriate SSH key to the authentication agent. If there is a problem with permissions, the return will specify this. 
+
+   ```shell
+   $ ssh-add ~/ssh-directory/<keyfile>
+   > Permissions 0604 for '/ssh-directory/<keyfile>' are too open. It is required that your private key files are NOT accessible by others. This private key will be ignored.
+   ```
+
+1. This may be fixed with the `chmod` command.
+
+   ```shell
+   $ chmod 700 /ssh-directory
+   $ chmod 600 /ssh-directory/*
+   $ chmod 644 /ssh-directory/*.pub
+   ```
+
+1. After setting permissions, reattempt to add the keyfile. An `Identity added` message indicates success.
+
+   ```shell
+   $ ssh-add ~/ssh-directory/<keyfile>
+   > Identity added: /ssh-directory/keyfile (username@hostname)
+   ```
+
+{% endmac %}
+
+{% windows %}
+
+1. Open Terminal.
+1. Start SSH agent in the background.
+
+   ```shell
+   $ eval "$(ssh-agent -s)"
+   > Agent pid 59566 # Example output
+   ```
+
+1. Reattempt to add the appropriate SSH key to the authentication agent. If there is a problem with permissions, the return will specify this. 
+
+   ```shell
+   $ ssh-add ~/ssh-directory/<keyfile>
+   > Permissions 0604 for '/ssh-directory/<keyfile>' are too open. It is required that your private key files are NOT accessible by others. This private key will be ignored.
+   ```
+
+1. This may be fixed with the `chmod` command.
+
+   ```shell
+   $ chmod 700 /ssh-directory
+   $ chmod 600 /ssh-directory/*
+   $ chmod 644 /ssh-directory/*.pub
+   ```
+
+1. After setting permissions, reattempt to add the keyfile. An `Identity added` message indicates success.
+
+   ```shell
+   $ ssh-add ~/ssh-directory/<keyfile>
+   > Identity added: /ssh-directory/keyfile (username@hostname)
+   ```
+
+{% endwindows %}
+
+{% linux %}
+
+1. Open Terminal.
+1. Start SSH agent in the background.
+
+   ```shell
+   $ eval "$(ssh-agent -s)"
+   > Agent pid 59566 # Example output
+   ```
+
+1. Reattempt to add the appropriate SSH key to the authentication agent. If there is a problem with permissions, the return will specify this. 
+
+   ```shell
+   $ ssh-add ~/ssh-directory/<keyfile>
+   > Permissions 0604 for '/ssh-directory/<keyfile>' are too open. It is required that your private key files are NOT accessible by others. This private key will be ignored.
+   ```
+
+1. This may be fixed with the `chmod` command.
+
+   ```shell
+   $ chmod 700 /ssh-directory
+   $ chmod 600 /ssh-directory/*
+   $ chmod 644 /ssh-directory/*.pub
+   ```
+
+1. After setting permissions, reattempt to add the keyfile. An `Identity added` message indicates success.
+
+   ```shell
+   $ ssh-add ~/ssh-directory/<keyfile>
+   > Identity added: /ssh-directory/keyfile (username@hostname)
+   ```
+
+{% endlinux %}
+
+The GitHub operation may be reattempted.

--- a/content/authentication/troubleshooting-ssh/error-permission-denied-publickey.md
+++ b/content/authentication/troubleshooting-ssh/error-permission-denied-publickey.md
@@ -271,8 +271,8 @@ If you don't see your public key in {% data variables.product.github %}, you'll 
 
    ```shell
    $ chmod 700 /ssh-directory
-   $ chmod 600 /ssh-directory/*
-   $ chmod 644 /ssh-directory/*.pub
+   $ chmod 600 /ssh-directory/<keyfile>
+   $ chmod 644 /ssh-directory/<keyfile>.pub
    ```
 
 1. After setting permissions, reattempt to add the keyfile. An `Identity added` message indicates success.
@@ -305,8 +305,8 @@ If you don't see your public key in {% data variables.product.github %}, you'll 
 
    ```shell
    $ chmod 700 /ssh-directory
-   $ chmod 600 /ssh-directory/*
-   $ chmod 644 /ssh-directory/*.pub
+   $ chmod 600 /ssh-directory/<keyfile>
+   $ chmod 644 /ssh-directory/<keyfile>.pub
    ```
 
 1. After setting permissions, reattempt to add the keyfile. An `Identity added` message indicates success.
@@ -339,8 +339,8 @@ If you don't see your public key in {% data variables.product.github %}, you'll 
 
    ```shell
    $ chmod 700 /ssh-directory
-   $ chmod 600 /ssh-directory/*
-   $ chmod 644 /ssh-directory/*.pub
+   $ chmod 600 /ssh-directory/<keyfile>
+   $ chmod 644 /ssh-directory/<keyfile>.pub
    ```
 
 1. After setting permissions, reattempt to add the keyfile. An `Identity added` message indicates success.


### PR DESCRIPTION
…ion-denied-publickey.md with steps to verify local ssh permissions. Changes only include additions; nothing removed.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

When troubleshooting my own connectivity issues I found that local permissions were the cause of non-connectivity, and the steps necessary to check and adjust those permissions have been added to this PR. 

Closes: #41382 

### What's being changed (if available, include any code snippets, screenshots, or gifs):

In brief I've added the following SSH file permission troubleshooting console/terminal commands:

```bash
$ eval "$(ssh-agent -s)"
$ ssh-add ~/ssh-directory/<keyfile>
$ chmod 700 /ssh-directory
$ chmod 600 /ssh-directory/<keyfile>
$ chmod 644 /ssh-directory/<keyfile>.pub
$ ssh-add ~/ssh-directory/<keyfile>
```

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
