### PR TITLE
don't persist credentials so pat is used for repo-sync

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
 
       - name: Sync repo to branch
         uses: repo-sync/github-sync@3832fe8e2be32372e1b3970bbae8e7079edeec88


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
* x-ref: https://github.com/github/docs-engineering/issues/5808

repo-sync is failing:

https://github.com/github/docs/actions/runs/19864074248

```
UPSTREAM_REPO=https://***@github.com/github/docs-internal.git
BRANCHES=main:repo-sync
Resetting origin to: ***github.com/github/docs
Adding tmp_upstream https://***@github.com/github/docs-internal.git
Fetching tmp_upstream
remote: Repository not found.
fatal: repository 'https://github.com/github/docs-internal.git/' not found
```

and repo-sync sets the repo with a token in the URL:

```
          source_repo: https://${{ secrets.DOCS_BOT_PAT_REPO_SYNC }}@github.com/github/${{ github.repository ==
```

seems this started after the update to actions/checkout v6?

### What's being changed (if available, include any code snippets, screenshots, or gifs):

* set `persist-credentials: false` for actions/checkout

this defaults to true and we use a PAT anyways, so :copilot: 's theory is that v6 somehow is overriding the PAT even though it's embedded in the URL 🤔  worth a try? 

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
