### PR TITLE
Document possible values for webhook target type

### DIFF
--- a/content/webhooks/webhook-events-and-payloads.md
+++ b/content/webhooks/webhook-events-and-payloads.md
@@ -44,6 +44,15 @@ HTTP POST payloads that are delivered to your webhook's configured URL endpoint 
 * `X-Hub-Signature-256`: This header is sent if the webhook is configured with a `secret`. This is the HMAC hex digest of the request body, and is generated using the SHA-256 hash function and the `secret` as the HMAC `key`. For more information, see [AUTOTITLE](/webhooks/using-webhooks/securing-your-webhooks).
 * `User-Agent`: This header will always have the prefix `GitHub-Hookshot/`.
 * `X-GitHub-Hook-Installation-Target-Type`: The type of resource where the webhook was created.
+     Possible values:
+
+  | Value | Description |
+  | ----- | ----------- |
+  | `repository` | Webhooks created at the repository level |
+  | `organization` | Webhooks created at the organization level |
+  | `app` | Webhooks created by GitHub Apps |
+
+  This header can be used to distinguish between repository, organization, and GitHub App webhooks without relying solely on the webhook payload.
 * `X-GitHub-Hook-Installation-Target-ID`: The unique identifier of the resource where the webhook was created.
 
 To see what each header might look like in a webhook payload, see [Example webhook delivery](#example-webhook-delivery).


### PR DESCRIPTION
Added possible values for X-GitHub-Hook-Installation-Target-Type header.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The documentation for the X-GitHub-Hook-Installation-Target-Type webhook delivery header previously described its purpose but did not specify the possible values it may contain. This lack of detail made it difficult for developers to reliably distinguish between repository, organization, and GitHub App webhooks using header information alone.

This change improves clarity and completeness for developers implementing webhook handlers.

Closes: #41739

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (included screenshots):
<img width="1081" height="371" alt="image" src="https://github.com/user-attachments/assets/d1cfae84-f453-4fa1-ae54-8af4c50ea18a" />
Expanded the documentation for the X-GitHub-Hook-Installation-Target-Type header in the Delivery headers section.
Added a structured table listing the currently used values:
*repository
*organization
*app

Included concise descriptions for each value to clearly indicate the webhook source.

Added a short explanatory note describing how this header can be used to distinguish webhook origins without relying solely on the payload structure.

This update is documentation-only and does not change any existing webhook behavior.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet the docs fundamentals that are required for all content.
- [x] All CI checks are passing and the changes look good in the review environment.

