### PR TITLE
Add 'agents' folder creation instructions

### DIFF
--- a/content/copilot/how-tos/administer-copilot/manage-for-organization/prepare-for-custom-agents.md
+++ b/content/copilot/how-tos/administer-copilot/manage-for-organization/prepare-for-custom-agents.md
@@ -29,6 +29,7 @@ Before following this article, you should understand what {% data variables.copi
      * To **manually grant access after creation**, or if internal visibility is not an option, click {% octicon "lock" aria-hidden="true" aria-label="lock" %} **Private**.
 {% data reusables.repositories.create-repo %}
 1. Update the template README as needed. Consider including creation guidelines for {% data variables.copilot.custom_agents_short %} or compliance considerations specific to your organization.
+1. Create folder `agents` in the root folder.  This is where your organization agents will be defined.
 
 ## Next steps
 


### PR DESCRIPTION
Added instructions for creating an 'agents' folder for organization agents.

### Why:

Improve documentation to differentiate between folder `agents`, which is used for organization-level agents from `.github/agents` which is used for repository-level agents.

Closes: #

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added folder creation step for folder `agents`.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
