### PR TITLE
Fix support status for 'uv' Security Updates for package manager

### DIFF
--- a/data/reusables/dependabot/supported-package-managers.md
+++ b/data/reusables/dependabot/supported-package-managers.md
@@ -49,7 +49,7 @@ poetry         | `pip`            | v1               | {% octicon "check" aria-l
 | {% endif %} |
 [Swift](#swift)      | `swift`      | v5  | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} (git only) | {% octicon "x" aria-label="Not supported" %} |
 [Terraform](#terraform)      | `terraform`      | >= 0.13, <= 1.13.x  | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | Not applicable |
-uv        | `uv`            | v0               | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | Not applicable |
+uv        | `uv`            | v0               | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | Not applicable |
 | {% ifversion dependabot-vcpkg-support %} |
 [vcpkg](#vcpkg) | `vcpkg`          | Not applicable   | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} | Not applicable |
 | {% endif %} |


### PR DESCRIPTION
This pull request updates the documentation for supported package managers by marking `uv` as supported for the `pip` ecosystem, instead of not supported.Since the [announcement](https://github.blog/changelog/2025-12-16-dependabot-security-updates-now-support-uv/) of this feature in the Blog post Security Updates for the `uv` package-ecosystem is now supported.

This Pull Request aims to update the public documentation to reflect the latest changes to Supportablity

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

This pull request updates the documentation for supported package managers by marking `uv` as supported for the `pip` ecosystem, instead of not supported.Since the [announcement](https://github.blog/changelog/2025-12-16-dependabot-security-updates-now-support-uv/) of this feature in the Blog post Security Updates for the `uv` package-ecosystem is now supported.

This Pull Request aims to update the public documentation to reflect the latest changes to Supportablity
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

Currently the public [documentation](https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#supported-ecosystems-and-repositories) states that Security Updates are not supported for the `uv` package-ecosystem:
<img width="761" height="154" alt="Screenshot 2026-01-05 at 11 14 23 AM" src="https://github.com/user-attachments/assets/1a556713-5231-49f5-95b9-82bd80a2c6ae" />

Since Dec 16th Security Updates is indeed supported, as per this [Blog post](https://github.blog/changelog/2025-12-16-dependabot-security-updates-now-support-uv/).

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
