### PR TITLE
Add guidance on when to use GitHub Apps

### DIFF
--- a/content/apps/overview.md
+++ b/content/apps/overview.md
@@ -23,3 +23,7 @@ For more information about building {% data variables.product.prodname_github_ap
 ## {% data variables.product.prodname_github_apps %} and {% data variables.product.prodname_oauth_apps %}
 
 {% data variables.product.company_short %} also supports {% data variables.product.prodname_oauth_apps %}. In general, {% data variables.product.prodname_github_apps %} are preferred over {% data variables.product.prodname_oauth_apps %}. {% data variables.product.prodname_github_apps %} use fine-grained permissions, give the user more control over which repositories the app can access, and use short-lived tokens. These properties can harden the security of the app by limiting the damage that could be done if the app's credentials were leaked. For more information, see [AUTOTITLE](/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps).
+
+## When to use {% data variables.product.prodname_github_apps %}
+
+Use {% data variables.product.prodname_github_apps %} when you need to integrate deeply with {% data variables.product.company_short %}, require fine-grained permissions, or want better security through short-lived access tokens. {% data variables.product.prodname_github_apps %} are well suited for automation, CI/CD integrations, and services that need to act on behalf of multiple users or repositories.


### PR DESCRIPTION
Summary
Adds a new section to the GitHub Apps overview explaining when to use GitHub Apps.

Details
This change introduces a short “When to use GitHub Apps” section to help readers understand common use cases, such as deep integrations, fine-grained permissions, and security benefits like short-lived tokens. The content aligns with existing guidance and improves clarity for users deciding between GitHub Apps and other integration options.

Type of change

Documentation improvement (no functional changes)
