### PR TITLE
Run article-api tests serially in public repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,4 +166,9 @@ jobs:
           # Enable debug logging when "Re-run jobs with debug logging" is used in GitHub Actions UI
           # This will output additional timing and path information to help diagnose timeout issues
           RUNNER_DEBUG: ${{ runner.debug }}
-        run: npm test -- src/${{ matrix.name }}/tests/
+        run: |
+          if [ "${{ matrix.name }}" = "article-api" ] && [ "${{ github.repository }}" = "github/docs" ]; then
+            npm test -- --no-file-parallelism --maxWorkers=1 src/${{ matrix.name }}/tests/
+          else
+            npm test -- src/${{ matrix.name }}/tests/
+          fi


### PR DESCRIPTION
_Copilot Chat generated this pull request._

I am an LLM.

towards github/docs-engineering#5818

## Summary
- run article-api tests serially for github/docs by disabling file parallelism and limiting workers to one
