### PR TITLE
Update copyright year in LICENSE-CODE

### DIFF
--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2025 GitHub
+Copyright 2026 GitHub
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/article-api/tests/rest-transformer.ts
+++ b/src/article-api/tests/rest-transformer.ts
@@ -63,7 +63,7 @@ describe('REST transformer', () => {
     expect(res.body).toContain('Setting to `application/vnd.github+json` is recommended.')
   })
 
-  test('Path and query parameters are listed', async () => {
+  test('Path and query parameters are listed', async () => {,15000)
     const res = await get(makeURL('/en/rest/actions/artifacts'))
     expect(res.statusCode).toBe(200)
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why: Updated copyright year from 2024 to 2025

<!-- Paste the issue link or number here --> 42458
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
