### PR TITLE
Fix accessibility violation in VersionPicker (Visible label mismatch)

### DIFF
--- a/src/versions/components/VersionPicker.tsx
+++ b/src/versions/components/VersionPicker.tsx
@@ -95,7 +95,9 @@ export const VersionPicker = ({ xs }: Props) => {
         pickerLabel={xs ? `Version\n` : `Version: `}
         dataTestId="field"
         descriptionFontSize={xs ? 6 : 5}
-        ariaLabel={`Select GitHub product version: current version is ${currentVersion}`}
+        ariaLabel={`${xs ? 'Version\n' : 'Version: '}${
+          allVersions[currentVersion]?.versionTitle || t('version_picker_default_text')
+        }, Select GitHub product version: current version is ${currentVersion}`}
         renderItem={(item) => {
           return (
             <div data-testid="version-picker-item" className={styles.itemsWidth}>


### PR DESCRIPTION
### Why:

<!-- Paste the issue link or number here -->
Closes: #42592


<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

This PR fixes an accessibility violation in the VersionPicker component where the accessible name (aria-label) did not contain the visible label text, violating WCAG 2.1 Level A (Label in Name - 2.5.3).

```typescript
// Before
ariaLabel={`Select GitHub product version: current version is ${currentVersion}`}

// After  
ariaLabel={`${xs ? 'Version\n' : 'Version: '}${
  allVersions[currentVersion]?.versionTitle || t('version_picker_default_text')
}, Select GitHub product version: current version is ${currentVersion}`}
```

### Testing

- Run accessibility audit (IBM Equal Access, axe)
- Test with screen reader (NVDA, JAWS, VoiceOver)

**Fix Before**
<img width="2560" height="379" alt="image" src="https://github.com/user-attachments/assets/05d1b030-0c78-4684-9a74-0ea92604b337" />

**Fix After**
<img width="2560" height="365" alt="image" src="https://github.com/user-attachments/assets/418f229b-a29f-46bc-ab17-3fd1dfd57e39" />


### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.

