### PR TITLE
Update Docker actions to use tags instead hashes

### DIFF
--- a/content/actions/tutorials/publish-packages/publish-docker-images.md
+++ b/content/actions/tutorials/publish-packages/publish-docker-images.md
@@ -196,13 +196,13 @@ jobs:
         uses: {% data reusables.actions.action-checkout %}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@v3
         with:
           username: {% raw %}${{ secrets.DOCKER_USERNAME }}{% endraw %}
           password: {% raw %}${{ secrets.DOCKER_PASSWORD }}{% endraw %}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: {% ifversion fpt or ghec %}ghcr.io{% elsif ghes %}{% data reusables.package_registry.container-registry-hostname %}{% endif %}
           username: {% raw %}${{ github.actor }}{% endraw %}
@@ -210,7 +210,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: |
             my-docker-hub-namespace/my-docker-hub-repository
@@ -218,7 +218,7 @@ jobs:
 
       - name: Build and push Docker images
         id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true


### PR DESCRIPTION
### Why:

Those hashes were very old and in general it recommended (by other parts of the GitHub documentation) that people use tags to specify version of actions.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The versions used in the example.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
