### PR TITLE
Update note on organization membership visibility

### DIFF
--- a/content/account-and-profile/how-tos/organization-membership/publicizing-or-hiding-organization-membership.md
+++ b/content/account-and-profile/how-tos/organization-membership/publicizing-or-hiding-organization-membership.md
@@ -29,3 +29,5 @@ contentType: how-tos
     * To hide your membership, choose **Private**.
 
    ![Screenshot of an entry in the list of organization members. Next to the username, a dropdown menu, labeled "Private", is outlined in dark orange.](/assets/images/help/organizations/member-visibility-link.png)
+
+Note: Making an organization public on your profile in GitHub does not mean its private repositories and your contributions to them become visible. Private repositories remain private and can only be accessed by organization members or collaborators who have been explicitly granted permission, regardless of the organization’s public profile status.


### PR DESCRIPTION
Clarify that private repositories and contributions remain inaccessible even if the organization is public on GitHub.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- https://github.com/github/docs/issues/42642    Issue: 42642 -->
Closes: 


### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- I have added 2 additional lines for more clarity. Nothing big-->

### Check off the following:

- [Checked ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [Checked ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ Checked] All CI checks are passing and the changes look good in the review environment.
