### PR TITLE
Fix grammar error in Actions support documentation

### DIFF
--- a/content/actions/how-tos/get-support.md
+++ b/content/actions/how-tos/get-support.md
@@ -37,7 +37,7 @@ Some information that {% data variables.contact.github_support %} will request c
 * A copy of your workflow run logs for an example workflow run failure. For more information about workflow run logs, see [AUTOTITLE](/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#downloading-logs).
 * {% ifversion ghes %}A copy of your runner logs, {% else %}If you are running this workflow on a self-hosted runner, self-hosted runner logs{% endif %} which can be found under the `_diag` folder within the runner. For more information about self-hosted runners, see [AUTOTITLE](/actions/hosting-your-own-runners/managing-self-hosted-runners/monitoring-and-troubleshooting-self-hosted-runners#reviewing-the-self-hosted-runner-application-log-files).
 
-  Self-hosted runner log file names are be formatted: `Runner_YYYY####-xxxxxx-utc.log` and `Worker_YYYY####-xxxxxx-utc.log`.
+  Self-hosted runner log file names are formatted: `Runner_YYYY####-xxxxxx-utc.log` and `Worker_YYYY####-xxxxxx-utc.log`.
 
 > [!NOTE]
 > Attach files to your support ticket by changing the file's extension to `.txt` or `.zip`. If you include textual data such as log or workflow file snippets inline in your ticket, ensure they are formatted correctly as Markdown code blocks. For more information about proper Markdown formatting, see [AUTOTITLE](/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#quoting-code).


### PR DESCRIPTION
## Fix grammar error in Actions support documentation

### Description
This pull request fixes a grammatical error in the GitHub Actions support documentation. The sentence contained a duplicate verb that has been corrected for clarity and professionalism.

### Changes Made
Fixed a double verb error in the self-hosted runner log file names documentation:
- **Changed from:** "are be formatted"
- **Changed to:** "are formatted"

### Files Modified
- `content/actions/how-tos/get-support.md`

### Specific Change
**Location:** Line 40

**Before:**
Self-hosted runner log file names are be formatted: Runner_YYYY####-xxxxxx-utc.log and Worker_YYYY####-xxxxxx-utc.log.

**After:**
Self-hosted runner log file names are formatted: Runner_YYYY####-xxxxxx-utc.log and Worker_YYYY####-xxxxxx-utc.log.


### Why This Change Is Important
- ✅ Improves documentation clarity and readability
- ✅ Enhances professionalism of the GitHub Docs
- ✅ Prevents confusion, especially for non-native English speakers
- ✅ Maintains consistent grammar throughout the documentation

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [ ] New feature
- [ ] Breaking change

### Testing
This is a documentation-only change with no code impact. The fix has been verified to be accurate and grammatically correct.

### Checklist
- [x] My changes follow the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have corrected any grammar/spelling errors
- [x] My changes improve the documentation quality