### PR TITLE
Improve clarity and readability in GitHub Sponsors for open source contributors

### DIFF
--- a/content/sponsors/receiving-sponsorships-through-github-sponsors/about-github-sponsors-for-open-source-contributors.md
+++ b/content/sponsors/receiving-sponsorships-through-github-sponsors/about-github-sponsors-for-open-source-contributors.md
@@ -20,7 +20,7 @@ shortTitle: Open source contributors
 
 {% data reusables.sponsors.you-can-be-a-sponsored-organization %} For more information, see [AUTOTITLE](/sponsors/receiving-sponsorships-through-github-sponsors/setting-up-github-sponsors-for-your-organization).
 
-After you join {% data variables.product.prodname_sponsors %}, you can add a sponsor button to the open source repository you contribute to, to increase the visibility of your {% data variables.product.prodname_sponsors %} profile and other funding platforms. For more information, see [AUTOTITLE](/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository).
+After you join {% data variables.product.prodname_sponsors %}, you can add a sponsor button to the open source repositories you contribute to in order to increase the visibility of your {% data variables.product.prodname_sponsors %} profile and other funding platforms. For more information, see [AUTOTITLE](/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository).
 
 You can set a goal for your sponsorships. For more information, see [AUTOTITLE](/sponsors/receiving-sponsorships-through-github-sponsors/managing-your-sponsorship-goal).
 


### PR DESCRIPTION
### Summary
This PR improves clarity and readability in the
`about-github-sponsors-for-open-source-contributors.md` page by refining
sentence flow and reducing repetitive phrasing.

### Changes
- Improved sentence structure for better readability
- Made wording more inclusive and beginner-friendly
- Preserved all existing links, data variables, and reusable content

### Notes
- No functional or behavioral changes
- Internal docs links use relative paths and AUTOTITLE and were not modified