### PR TITLE
Add instructions for profile README creation

### DIFF
--- a/content/account-and-profile/concepts/personal-profile.md
+++ b/content/account-and-profile/concepts/personal-profile.md
@@ -48,6 +48,34 @@ You can format text and include emoji, images, and GIFs in your profile README b
 
 {% ifversion fpt %}
 
+# How to create a profile README:
+
+Create a new public repository with a name that exactly matches your username.
+
+Initialize the repository with a README.md file.
+
+Commit and push the README content.
+
+Once created, the contents of the README.md file will be shown at the top of your profile.
+
+Where to add it (important)
+
+Place it here in the document structure:
+
+~~~
+Your profile README
+  ├─ (existing intro paragraph)
+  ├─ Creating a profile README repository   ← ADD HERE
+  ├─ (examples of what to include)
+~~~
+This placement matters because:
+
+Readers learn the rule before writing content
+
+It prevents confusion when their README “doesn’t show up”
+
+It aligns with GitHub’s actual detection logic
+
 ## Private profiles
 
 To hide parts of your profile page, you can make your profile private. This also hides your activity in various social features on {% data variables.product.github %}. A private profile hides information from all users, and there is currently no option to allow specified users to see your activity.


### PR DESCRIPTION
Added instructions for creating a profile README and clarified where it appears in the document structure.

<!-- Thank you for contributing to this project! You must fill out the information below before we can review this pull request. -->
Why:

Closes: (no existing issue)

The current documentation explains what a profile README is, but does not mention the required condition that the repository name must exactly match the user’s GitHub username for the README to appear on the profile.

This omission commonly causes confusion for new users whose README does not render as expected. Documenting this requirement makes the setup process explicit and prevents failed configurations.

What's being changed:

Added a new subsection under “Your profile README” explaining that:

A profile README is only displayed when it exists in a public repository named exactly after the user’s username

GitHub automatically detects this repository and renders its README.md on the profile

README files in repositories with any other name will not appear on the profile

Included brief, step-by-step instructions for creating the correct repository

Placed the new content immediately after the introductory paragraph of the “Your profile README” section so users learn the requirement before writing content

This change documents existing behavior only and does not modify functionality.

### Check off the following:

- [x ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x ] All CI checks are passing and the changes look good in the review environment.
