### PR TITLE
Correct instructions to avoid 403 when Copilot CLI auths via PAT

### DIFF
--- a/content/copilot/how-tos/copilot-cli/install-copilot-cli.md
+++ b/content/copilot/how-tos/copilot-cli/install-copilot-cli.md
@@ -118,7 +118,7 @@ On first launch, if you're not currently logged in to {% data variables.product.
 
 ### Authenticating with a {% data variables.product.pat_generic %}
 
-You can also authenticate using a {% data variables.product.pat_v2 %} with the "{% data variables.product.prodname_copilot_short %} Requests" permission enabled.
+You can also authenticate using a {% data variables.product.pat_v2 %} with the "{% data variables.product.prodname_copilot_short %} Requests" and "Models" permissions enabled.
 
 1. Visit [{% data variables.product.pat_v2_caps_plural %}](https://github.com/settings/personal-access-tokens/new).
 1. Under "Permissions," click **Add permissions** and select **{% data variables.product.prodname_copilot_short %} Requests**.


### PR DESCRIPTION
You need to give the token "Models" permissions, otherwise when authing non-interactively with COPILOT_GITHUB_TOKEN you get a 403. There are a few open issues in the Copilot CLI repo about this, eg https://github.com/github/copilot-cli/issues/1316

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
