### PR TITLE
Remove sudo explanation

### DIFF
--- a/content/authentication/keeping-your-account-and-data-secure/sudo-mode.md
+++ b/content/authentication/keeping-your-account-and-data-secure/sudo-mode.md
@@ -38,8 +38,6 @@ After you authenticate to perform a sensitive action, your session is temporaril
 
 {% endif %}
 
-"sudo" is a reference to a program on Unix systems, where the name is short for "**su**bstitute user **do**." For more information, see [sudo](https://wikipedia.org/wiki/Sudo) on Wikipedia.
-
 ## Confirming access for sudo mode
 
 To confirm access for sudo mode, you can authenticate with your password. Optionally, you can use a different authentication method, like a passkey, {% ifversion fpt or ghec %}a security key, {% data variables.product.prodname_mobile %}, or a 2FA code{% elsif ghes %}a security key or a 2FA code{% endif %}.

--- a/content/authentication/keeping-your-account-and-data-secure/sudo-mode.md
+++ b/content/authentication/keeping-your-account-and-data-secure/sudo-mode.md
@@ -38,7 +38,7 @@ After you authenticate to perform a sensitive action, your session is temporaril
 
 {% endif %}
 
-"sudo" is a reference to a program on Unix systems, where the name is short for "**su**peruser **do**." For more information, see [sudo](https://wikipedia.org/wiki/Sudo) on Wikipedia.
+"sudo" is a reference to a program on Unix systems, where the name is short for "**su**bstitute user **do**." For more information, see [sudo](https://wikipedia.org/wiki/Sudo) on Wikipedia.
 
 ## Confirming access for sudo mode
 


### PR DESCRIPTION
### Why:

The passage contradicts what's said in the Wikipedia article we link to, and it doesn't add any value to the reader (https://github.com/github/docs/pull/42919#issuecomment-3928472300).

### What's being changed:

Removed sudo explanation.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
