### PR TITLE
dependabot: auto-merge requires on pull_request types

### DIFF
--- a/content/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions.md
+++ b/content/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions.md
@@ -159,7 +159,9 @@ You can instead use {% data variables.product.prodname_actions %} and the {% dat
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
 name: Dependabot auto-merge
-on: pull_request
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: write


### PR DESCRIPTION
### Why:

Auto-merge appears to function correctly with `pull_request` with types, allowing it to authenticate and operate within the context of the target repository. Without this, a 401 error is returned due to insufficient scope.

```
> Run gh pr merge --auto --merge "$PR_URL"
non-200 OK status code: 401 Unauthorized body: "{\r\n  \"message\": \"Bad credentials\",\r\n  \"documentation_url\": \"[https://docs.github.com/rest\](https://docs.github.com/rest/)",\r\n  \"status\": \"401\"\r\n}"
```

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
