### PR TITLE
Update events-that-trigger-workflows.md

### DIFF
--- a/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
+++ b/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
@@ -1107,7 +1107,7 @@ on: workflow_call
 | [workflow_dispatch](/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch) | Not applicable | Last commit on the `GITHUB_REF` branch or tag | Branch or tag that received dispatch |
 
 > [!NOTE]
-> {% data reusables.actions.branch-requirement %}
+> To trigger the workflow manually using the Github UI, the workflow file must exist on the default branch.
 
 To enable a workflow to be triggered manually, you need to configure the `workflow_dispatch` event. You can manually trigger a workflow run using the {% data variables.product.github %} API, {% data variables.product.prodname_cli %}, or the {% data variables.product.github %} UI. For more information, see [AUTOTITLE](/actions/managing-workflow-runs/manually-running-a-workflow).
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/43081

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

workflow_dispatch is absolutely able to be triggered when the workflow file is not in the default branch. The issue lies in HOW it can be triggered: when it is in the default branch, the Github UI can be used. When it is not, then the Github UI cannot be used. The "Note" regarding this should be updated, as it misleads the reader into thinking that workflow_dispatch is more limited than it is.

Please also refer to the Issue linked above. 

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
