### PR TITLE
Update `macos-26-intel` runner links

### DIFF
--- a/data/reusables/actions/supported-github-runners.md
+++ b/data/reusables/actions/supported-github-runners.md
@@ -69,7 +69,7 @@ For public repositories, jobs using the workflow labels shown in the table below
       <td> Intel </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md">macos-15-intel</a></code>,
-        <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-26-intel-Readme.md">macos-26-intel</a></code>
+        <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md">macos-26-intel</a></code>
       </td>
     </tr>
     <tr>
@@ -159,7 +159,7 @@ For {% ifversion ghec %}internal and{% endif %} private repositories, jobs using
       <td> Intel </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md">macos-15-intel</a></code>,
-        <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-26-intel-Readme.md">macos-26-intel</a></code>
+        <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md">macos-26-intel</a></code>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Why:

Closes: #43198

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The link bound to `macos-26-intel` runner label.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
