### PR TITLE
Suggest 1s Postgres service healthcheck interval

### DIFF
--- a/content/actions/tutorials/use-containerized-services/create-postgresql-service-containers.md
+++ b/content/actions/tutorials/use-containerized-services/create-postgresql-service-containers.md
@@ -65,7 +65,7 @@ jobs:
         options: >-
           --health-cmd pg_isready
           --health-interval 1s
-          --health-timeout 1s
+          --health-timeout 5s
           --health-retries 30
 
     steps:
@@ -118,7 +118,7 @@ jobs:
         options: >-
           --health-cmd pg_isready
           --health-interval 1s
-          --health-timeout 1s
+          --health-timeout 5s
           --health-retries 30
 ```
 
@@ -183,7 +183,7 @@ jobs:
         options: >-
           --health-cmd pg_isready
           --health-interval 1s
-          --health-timeout 1s
+          --health-timeout 5s
           --health-retries 30
         ports:
           # Maps tcp port 5432 on service container to the host
@@ -240,7 +240,7 @@ jobs:
         options: >-
           --health-cmd pg_isready
           --health-interval 1s
-          --health-timeout 1s
+          --health-timeout 5s
           --health-retries 30
         ports:
           # Maps tcp port 5432 on service container to the host

--- a/content/actions/tutorials/use-containerized-services/create-postgresql-service-containers.md
+++ b/content/actions/tutorials/use-containerized-services/create-postgresql-service-containers.md
@@ -64,9 +64,9 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 1s
+          --health-timeout 1s
+          --health-retries 30
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests
@@ -117,9 +117,9 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 1s
+          --health-timeout 1s
+          --health-retries 30
 ```
 
 ### Configuring the steps for jobs in containers
@@ -182,9 +182,9 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 1s
+          --health-timeout 1s
+          --health-retries 30
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
@@ -239,9 +239,9 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 1s
+          --health-timeout 1s
+          --health-retries 30
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

The GitHub Actions platform uses its own, hardcoded startup interval that checks the service status as reported by Docker that is itself checked at a user-configured interval. This is explained in this issue:

https://github.com/actions/runner/issues/496

The GitHub Actions startup service performs an incremental backoff at intervals of approximately 2, 4, 8, 16, 32 seconds. This means that the check-in points are:

1. +2 seconds
2. +6 seconds (2 + 4 seconds)
3. +14 seconds (2 + 4 + 8 seconds)
4. +30 seconds (2 + 4 + 8 + 16 seconds)
5. +62 seconds (2 + 4 + 8 + 16 + 32 seconds)
6. +94 seconds (2 + 4 + 8 + 16 + 32 + 32 seconds)
7. ... and so forth

The Postgres service documentation currently suggests Docker check the status at an interval of 10 seconds. **In practice, this means that Postgres will never report being started sooner than +14 seconds.**

This reporting inefficiency probably represents thousands of Actions Minutes spent waiting to check a Postgres service that has already started 😰 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

This PR changes the healthcheck interval from 10 seconds to 1 second. The Postgres `pg_isready` is a lightweight check and this should not represent significant compute overhead. 

This PR also changes the health-retries value from 5 (5 x 10 seconds = 50 seconds total) to 30 (30 x 1 second = 30 seconds total). I don't think this is a material change, but it could be further changed to 50 if no change to that behavior is desired. 30 just seemed less weird than 50.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
