### PR TITLE
Update email preferences instructions with warning

### DIFF
--- a/content/account-and-profile/how-tos/email-preferences/changing-your-primary-email-address.md
+++ b/content/account-and-profile/how-tos/email-preferences/changing-your-primary-email-address.md
@@ -26,7 +26,10 @@ contentType: how-tos
 {% data reusables.user-settings.emails %}
 1. If you'd like to add a new email address to set as your primary email address, under "Add email address", type a new email address and click **Add**.
 1. Under "Primary email address", use the drop-down menu to click the email address you'd like to set as your primary email address, and click **Save**.
-1. To remove the old email address from your account, next to the old email, click {% octicon "trash" aria-label="The trash symbol" %}.
+> [!WARNING]
+> If you remove an email address that was used for previous commits, those commits may no longer be associated with your account and may stop appearing in your contribution graph. Before removing an email address, make sure your commits are linked to another verified email on your account.
+
+1. To remove the old email address from your account, next to the old email, click the trash icon.
 {% ifversion fpt or ghec %}
 1. Verify your new primary email address. Without a verified email address, you won't be able to use all of {% data variables.product.github %}'s features. For more information, see [AUTOTITLE](/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/verifying-your-email-address).
 {% endif %}


### PR DESCRIPTION
Added a warning about removing old email addresses affecting commit associations.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Users may remove an old email address from their account without realizing that commits made with that email may no longer be associated with their profile. When this happens, those commits may stop appearing in the user's contribution graph.
This behavior is not currently mentioned in the documentation for changing the primary email address, which can lead to confusion or accidental loss of visible contribution history.

<!-- Paste the issue link or number here -->
Closes: N/A

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
This pull request adds a warning note before the step that instructs users to remove an old email address.
The warning explains that removing an email address used in previous commits may cause those commits to no longer be associated with the user’s account or appear in their contribution graph. It also advises users to ensure their commits are linked to another verified email before removing the address.
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
