### PR TITLE
Clarify custom image storage billing in Actions docs

### DIFF
--- a/content/actions/concepts/runners/github-hosted-runners.md
+++ b/content/actions/concepts/runners/github-hosted-runners.md
@@ -91,7 +91,7 @@ Custom images let you start with a {% data variables.product.github %}-provided 
 
 Custom images can include repository code, container images, binaries, certificates, and other dependencies to create a consistent build environment across workflows. This helps you gain control over your supply chain. They help reduce setup time, improve build performance, and strengthen security by reducing the surface attack vector on your images. Administrators can also apply policies to manage image versions, retention, and age to meet organizational security and compliance requirements.
 
-Custom images can only be used with larger runners and are billed at the same per-minute rates as those runners. Storage for custom images is billed and metered through {% data variables.product.prodname_actions %} storage. For more information about billing, see [AUTOTITLE](/billing/concepts/product-billing/github-actions).
+Custom images can only be used with larger runners and are billed at the same per-minute rates as those runners. Storage for custom images is billed and metered through {% data variables.product.prodname_actions %} storage. For more information, see [AUTOTITLE](/billing/concepts/product-billing/github-actions#custom-image-storage).
 
 To get started with custom images, see [AUTOTITLE](/actions/how-tos/manage-runners/larger-runners/use-custom-images).
 

--- a/content/actions/how-tos/manage-runners/larger-runners/use-custom-images.md
+++ b/content/actions/how-tos/manage-runners/larger-runners/use-custom-images.md
@@ -123,6 +123,12 @@ If you specify an older major version in the YAML (for example, version: 1.* whe
 > [!NOTE]
 > {% data variables.actions.github_hosted_larger_runner %} creation does not support wildcards in image version selection.
 
+## Billing and storage for custom images
+
+Jobs that use custom images are billed at the same per-minute rate as the {% data variables.actions.hosted_runner %} that uses the image. Storage for custom images is billed separately through {% data variables.product.prodname_actions %} storage.
+
+If you rebuild images frequently and retain older versions, your storage usage can grow quickly because each successful workflow job that includes the `snapshot` keyword creates a new image version. For more information, see [AUTOTITLE](/billing/concepts/product-billing/github-actions#custom-image-storage) and [AUTOTITLE](/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#custom-images-retention-policies).
+
 ## Managing custom images
 
 You can view detailed information about each image, delete unused images or specific versions, and track image versions over time.

--- a/content/billing/concepts/product-billing/github-actions.md
+++ b/content/billing/concepts/product-billing/github-actions.md
@@ -73,6 +73,27 @@ Deleting artifacts reduces your current storage and prevents future charges, but
 
 Your monthly bill converts GB-Hours to GB-Months by dividing by the hours in the month (usually 720 hours for a 30-day month).
 
+### Custom image storage
+
+For {% data variables.actions.github_hosted_larger_runners %}, storage for custom images is billed through {% data variables.product.prodname_actions %} storage.
+
+Custom image storage uses the same hourly accrual model as other {% data variables.product.prodname_actions %} storage. Your bill is based on the amount of image data that is stored over time, measured in GB-Hours.
+
+Storage usage for custom images depends on:
+
+* The size of each image version
+* The number of image versions that you retain
+* How long each version is stored
+
+Each successful workflow job that includes the `snapshot` keyword creates a new custom image version. Each retained version contributes to your storage usage until the version is deleted or removed by a retention policy. For more information, see [AUTOTITLE](/actions/how-tos/manage-runners/larger-runners/use-custom-images) and [AUTOTITLE](/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#custom-images-retention-policies).
+
+Custom image storage is based on retained image data over time, not on the number of times that a runner uses or pulls an existing image.
+
+For example:
+
+* Storing one 150 GB custom image version for 24 hours uses 3,600 GB-Hours.
+* Storing four 150 GB versions of the same image for 24 hours uses 14,400 GB-Hours.
+
 ### Examples of how usage is measured
 
 * If you run a workflow on a Linux runner and it takes 10 minutes to complete, you'll use 10 minutes of the repository owner's allowance. If the workflow generates a 10 MB artifact, then you'll also use 10 MB of the repository owner's artifact storage allowance.

--- a/content/billing/reference/actions-runner-pricing.md
+++ b/content/billing/reference/actions-runner-pricing.md
@@ -67,4 +67,4 @@ redirect_from:
 * For {% data variables.actions.hosted_runner %}s, there is no additional cost for configurations that assign public static IP addresses to a {% data variables.actions.hosted_runner %}. For more information on {% data variables.actions.hosted_runner %}s, see [AUTOTITLE](/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners).
 * Included minutes cannot be used for {% data variables.actions.hosted_runner %}s.
 * The {% data variables.actions.hosted_runner %}s are not free for public repositories.
-* Custom images can only be used with larger runners and are billed at the same per-minute rates as those runners.
+* Custom images can only be used with larger runners. Jobs that use custom images are billed at the same per-minute rates as those runners, and storage for custom images is billed separately through {% data variables.product.prodname_actions %} storage based on the amount of stored image data over time. For more information, see [AUTOTITLE](/billing/concepts/product-billing/github-actions#custom-image-storage).


### PR DESCRIPTION
_GitHub Copilot generated this pull request._

## Summary
* add a canonical billing explanation for custom image storage in the GitHub Actions billing docs
* trim the custom images task doc to a shorter summary that links to the billing source of truth
* clarify related runner pricing and hosted runner reference copy

## Validation
* checked editor diagnostics for all changed files
* attempted to run content lint, but the local environment is missing  ()
