### PR TITLE
Clarify built-in MCP servers in Copilot CLI reference

### DIFF
--- a/content/copilot/reference/copilot-cli-reference/cli-command-reference.md
+++ b/content/copilot/reference/copilot-cli-reference/cli-command-reference.md
@@ -433,9 +433,6 @@ The CLI includes built-in MCP servers that are available without additional setu
 | Server | Description |
 |--------|-------------|
 | `github-mcp-server` | {% data variables.product.github %} API integration: issues, pull requests, commits, code search, and {% data variables.product.prodname_actions %}. |
-| `playwright` | Browser automation: navigate, click, type, screenshot, and form handling. |
-| `fetch` | HTTP requests via the `fetch` tool. |
-| `time` | Time utilities: `get_current_time` and `convert_time`. |
 
 Use `--disable-builtin-mcps` to disable all built-in servers, or `--disable-mcp-server SERVER-NAME` to disable a specific one.
 


### PR DESCRIPTION
_GitHub Copilot generated this pull request._

fixes github/docs#43371

## Summary

This pull request updates the Copilot CLI command reference to make the Built-in MCP servers section consistent with the documented behavior of the `--disable-builtin-mcps` option on the same page.

Before this change, the page said two conflicting things:

* The Built-in MCP servers table listed `github-mcp-server`, `playwright`, `fetch`, and `time`.
* The `--disable-builtin-mcps` option said the built-in MCP servers are currently `github-mcp-server`.

This change resolves that inconsistency by keeping only `github-mcp-server` in the Built-in MCP servers table.

## What changed

* Removed `playwright` from the Built-in MCP servers table.
* Removed `fetch` from the Built-in MCP servers table.
* Removed `time` from the Built-in MCP servers table.

## Why

The safest documentation change here is to align the table with the more specific option text that already says the current built-in MCP server set is `github-mcp-server`.

Local verification also supported treating at least some of the removed entries as not built in in this environment:

* A Playwright-specific runtime check returned `Browser automation is unavailable.`
* A time-tool runtime check returned `Time tools are unavailable.`

Given that evidence, keeping only `github-mcp-server` is the most conservative fix and removes the page's internal contradiction without making broader product claims.

<details><summary>Prompt summary - submitted by @aosama</summary>

> Investigated an inconsistency in the Copilot CLI reference about built-in MCP servers, confirmed the conflict in source, compared it against local Copilot CLI behavior, and updated the reference table so it matches the documented `--disable-builtin-mcps` behavior.

</details>
