### PR TITLE
Add additional skill storage paths for copilot

### DIFF
--- a/content/copilot/concepts/agents/about-agent-skills.md
+++ b/content/copilot/concepts/agents/about-agent-skills.md
@@ -22,8 +22,8 @@ You can create your own skills to teach {% data variables.product.prodname_copil
 
 {% data variables.product.prodname_copilot_short %} supports:
 
-* Project skills, stored in your repository (`.agents/skills`, `.github/skills` or `.claude/skills`)
-* Personal skills, stored in your home directory and shared across projects (`~/.agents/skills`, `~/.copilot/skills` or `~/.claude/skills`) ({% data variables.copilot.copilot_coding_agent %} and {% data variables.copilot.copilot_cli %} only)
+* Project skills, stored in your repository (`.github/skills/`, `.agents/skills/` or `.claude/skills/`)
+* Personal skills, stored in your home directory and shared across projects (`~/.copilot/skills/` or `~/.claude/skills/`) ({% data variables.copilot.copilot_coding_agent %} and {% data variables.copilot.copilot_cli %} only)
 
 Support for organization-level and enterprise-level skills is coming soon.
 

--- a/content/copilot/concepts/agents/about-agent-skills.md
+++ b/content/copilot/concepts/agents/about-agent-skills.md
@@ -22,8 +22,8 @@ You can create your own skills to teach {% data variables.product.prodname_copil
 
 {% data variables.product.prodname_copilot_short %} supports:
 
-* Project skills, stored in your repository (`.github/skills` or `.claude/skills`)
-* Personal skills, stored in your home directory and shared across projects (`~/.copilot/skills` or `~/.claude/skills`) ({% data variables.copilot.copilot_coding_agent %} and {% data variables.copilot.copilot_cli %} only)
+* Project skills, stored in your repository (`.agents/skills`, `.github/skills` or `.claude/skills`)
+* Personal skills, stored in your home directory and shared across projects (`~/.agents/skills`, `~/.copilot/skills` or `~/.claude/skills`) ({% data variables.copilot.copilot_coding_agent %} and {% data variables.copilot.copilot_cli %} only)
 
 Support for organization-level and enterprise-level skills is coming soon.
 


### PR DESCRIPTION
Updated paths for project and personal skills in documentation. `copilot-cli` successfully reads skills from these locations.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/43418

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

I am adding documentation for the following paths where `copilot-cli` reads skills from:
- `~/agents/skills/`
- `./agents/skill` (in agent working directory)


### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
