### PR TITLE
Add .agents/skills skill storage paths in documentation

### DIFF
--- a/content/copilot/concepts/agents/about-agent-skills.md
+++ b/content/copilot/concepts/agents/about-agent-skills.md
@@ -22,8 +22,8 @@ You can create your own skills to teach {% data variables.product.prodname_copil
 
 {% data variables.product.prodname_copilot_short %} supports:
 
-* Project skills, stored in your repository (`.agents/skills`, `.github/skills` or `.claude/skills`)
-* Personal skills, stored in your home directory and shared across projects (`~/.agents/skills`, `~/.copilot/skills` or `~/.claude/skills`) ({% data variables.copilot.copilot_coding_agent %} and {% data variables.copilot.copilot_cli %} only)
+* Project skills, stored in your repository (`.github/skills`, `.agents/skills` or `.claude/skills`)
+* Personal skills, stored in your home directory and shared across projects (`~/.copilot/skills`, `~/.agents/skills` or `~/.claude/skills`) ({% data variables.copilot.copilot_coding_agent %} and {% data variables.copilot.copilot_cli %} only)
 
 Support for organization-level and enterprise-level skills is coming soon.
 

--- a/content/copilot/concepts/agents/about-agent-skills.md
+++ b/content/copilot/concepts/agents/about-agent-skills.md
@@ -22,8 +22,8 @@ You can create your own skills to teach {% data variables.product.prodname_copil
 
 {% data variables.product.prodname_copilot_short %} supports:
 
-* Project skills, stored in your repository (`.github/skills` or `.claude/skills`)
-* Personal skills, stored in your home directory and shared across projects (`~/.copilot/skills` or `~/.claude/skills`) ({% data variables.copilot.copilot_coding_agent %} and {% data variables.copilot.copilot_cli %} only)
+* Project skills, stored in your repository (`.agents/skills`, `.github/skills` or `.claude/skills`)
+* Personal skills, stored in your home directory and shared across projects (`~/.agents/skills`, `~/.copilot/skills` or `~/.claude/skills`) ({% data variables.copilot.copilot_coding_agent %} and {% data variables.copilot.copilot_cli %} only)
 
 Support for organization-level and enterprise-level skills is coming soon.
 

--- a/content/copilot/reference/copilot-cli-reference/cli-command-reference.md
+++ b/content/copilot/reference/copilot-cli-reference/cli-command-reference.md
@@ -479,6 +479,7 @@ Skills are loaded from these locations in priority order (first found wins for d
 | `.claude/skills/` | Project | Claude-compatible location. |
 | Parent `.github/skills/` | Inherited | Monorepo parent directory support. |
 | `~/.copilot/skills/` | Personal | Personal skills for all projects. |
+| `~/.agents/skills/` | Personal | Alternative personal location. |
 | `~/.claude/skills/` | Personal | Claude-compatible personal location. |
 | Plugin directories | Plugin | Skills from installed plugins. |
 | `COPILOT_SKILLS_DIRS` | Custom | Additional directories (comma-separated). |

--- a/content/copilot/reference/copilot-cli-reference/cli-plugin-reference.md
+++ b/content/copilot/reference/copilot-cli-reference/cli-plugin-reference.md
@@ -193,9 +193,10 @@ The following diagram illustrates the loading order and precedence rules.
   │  3. <project>/.claude/skills/        (project)                      │
   │  4. <parents>/.github/skills/ etc.   (inherited)                    │
   │  5. ~/.copilot/skills/               (personal-copilot)             │
-  │  6. ~/.claude/skills/                (personal-claude)              │
-  │  7. PLUGIN: skills/ dirs             (plugin)                       │
-  │  8. COPILOT_SKILLS_DIRS env + config (custom)                       │
+  │  6. ~/.agents/skills/                (personal-skills)              │
+  │  7. ~/.claude/skills/                (personal-claude)              │
+  │  8. PLUGIN: skills/ dirs             (plugin)                       │
+  │  9. COPILOT_SKILLS_DIRS env + config (custom)                       │
   │  --- then commands (.claude/commands/), skills override commands ---│
   └──────────────────────┬──────────────────────────────────────────────┘
                          │

--- a/data/reusables/copilot/creating-adding-skills.md
+++ b/data/reusables/copilot/creating-adding-skills.md
@@ -6,9 +6,9 @@ To add a skill, you save the `SKILL.md` file, and any subsidiary resources, to a
 
 1. Create a `skills` directory to store your skill and any others you may want to create in the future.
 
-    For **project skills**, specific to a single repository, store your skill under `.github/skills` or `.claude/skills`.
+    For **project skills**, specific to a single repository, store your skill under `.agents/skills`, `.github/skills` or `.claude/skills`.
 
-    For **personal skills**, shared across projects, store your skill under `~/.copilot/skills` or `~/.claude/skills`.
+    For **personal skills**, shared across projects, store your skill under `~/.agents/skills`, `~/.copilot/skills` or `~/.claude/skills`.
 
 1. Create a subdirectory for your new skill. Each skill should have its own directory (for example, `.github/skills/webapp-testing`).
 

--- a/data/reusables/copilot/creating-adding-skills.md
+++ b/data/reusables/copilot/creating-adding-skills.md
@@ -6,9 +6,9 @@ To add a skill, you save the `SKILL.md` file, and any subsidiary resources, to a
 
 1. Create a `skills` directory to store your skill and any others you may want to create in the future.
 
-    For **project skills**, specific to a single repository, store your skill under `.agents/skills`, `.github/skills` or `.claude/skills`.
+    For **project skills**, specific to a single repository, store your skill under `.github/skills`, `.agents/skills` or `.claude/skills`.
 
-    For **personal skills**, shared across projects, store your skill under `~/.agents/skills`, `~/.copilot/skills` or `~/.claude/skills`.
+    For **personal skills**, shared across projects, store your skill under `~/.copilot/skills`, `~/.agents/skills` or `~/.claude/skills`.
 
 1. Create a subdirectory for your new skill. Each skill should have its own directory (for example, `.github/skills/webapp-testing`).
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

As stated in stated in https://agentskills.io/client-implementation/adding-skills-support#where-to-scan, the `.agents/skills` paths are a convention for cross-client skill sharing.

These paths are already supported by VSCode Chat: https://code.visualstudio.com/docs/copilot/customization/agent-skills#_create-a-skill, and a bug in the Copilot CLI https://github.com/github/copilot-cli/issues/2161 that made them partially supported has been resolved.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

Added the `.agents/skills` project and personal paths.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
