### PR TITLE
Fix haproxy-nbthread ghe-config key in release notes

### DIFF
--- a/data/release-notes/enterprise-server/3-16/16.yml
+++ b/data/release-notes/enterprise-server/3-16/16.yml
@@ -26,7 +26,7 @@ sections:
       Users experienced failures when migrating repositories with releases using GitHub Enterprise Importer. Migrations failed to import release assets that were incompletely uploaded at the time of export, as the export archive referenced assets without including the corresponding files.
   changes:
     - |
-      To improve performance on large instances, HAProxy automatically scales its thread count based on available CPUs and uses higher connection limits for high-traffic backend services including GitHub Actions, database connections, job queues, and package registry. Administrators can override the thread count using `ghe-config haproxy-nbthread` if needed. 
+      To improve performance on large instances, HAProxy automatically scales its thread count based on available CPUs and uses higher connection limits for high-traffic backend services including GitHub Actions, database connections, job queues, and package registry. Administrators can override the thread count using `ghe-config core.haproxy-nbthread` if needed. 
     - |
       On instances with a license for GitHub Advanced Security, code scanning-specific rate limits have been lifted and aligned with the default GitHub rate limits. Users can access higher limits through an exemption mechanism. 
   known_issues:

--- a/data/release-notes/enterprise-server/3-17/13.yml
+++ b/data/release-notes/enterprise-server/3-17/13.yml
@@ -28,7 +28,7 @@ sections:
       Users experienced failures when migrating repositories with releases using GitHub Enterprise Importer. Migrations failed to import release assets that were incompletely uploaded at the time of export, as the export archive referenced assets without including the corresponding files.
   changes:
     - |
-      To improve performance on large instances, HAProxy automatically scales its thread count based on available CPUs and uses higher connection limits for high-traffic backend services including GitHub Actions, database connections, job queues, and package registry. Administrators can override the thread count using `ghe-config haproxy-nbthread` if needed. 
+      To improve performance on large instances, HAProxy automatically scales its thread count based on available CPUs and uses higher connection limits for high-traffic backend services including GitHub Actions, database connections, job queues, and package registry. Administrators can override the thread count using `ghe-config core.haproxy-nbthread` if needed. 
     - |
       On instances with a license for GitHub Advanced Security, code scanning-specific rate limits have been lifted and aligned with the default GitHub rate limits. Users can access higher limits through an exemption mechanism. 
   known_issues:

--- a/data/release-notes/enterprise-server/3-18/7.yml
+++ b/data/release-notes/enterprise-server/3-18/7.yml
@@ -32,7 +32,7 @@ sections:
       Users experienced failures when migrating repositories with releases using GitHub Enterprise Importer. Migrations failed to import release assets that were incompletely uploaded at the time of export, as the export archive referenced assets without including the corresponding files.
   changes:
     - |
-      To improve performance on large instances, HAProxy automatically scales its thread count based on available CPUs and uses higher connection limits for high-traffic backend services including GitHub Actions, database connections, job queues, and package registry. Administrators can override the thread count using `ghe-config haproxy-nbthread` if needed. 
+      To improve performance on large instances, HAProxy automatically scales its thread count based on available CPUs and uses higher connection limits for high-traffic backend services including GitHub Actions, database connections, job queues, and package registry. Administrators can override the thread count using `ghe-config core.haproxy-nbthread` if needed. 
     - |
       API consumers can update issues via the REST API (PATCH) or the GraphQL `updateIssue` mutation using fine-grained permissions for closing and reopening issues, and for setting milestones. 
   known_issues:

--- a/data/release-notes/enterprise-server/3-19/4.yml
+++ b/data/release-notes/enterprise-server/3-19/4.yml
@@ -46,7 +46,7 @@ sections:
       After upgrading to 3.19, site administrators could not delete users via the Management Console  or the REST API. User deletion attempts returned a `500 Internal Server Error`. 
   changes:
     - |
-      To improve performance on large instances, HAProxy automatically scales its thread count based on available CPUs and uses higher connection limits for high-traffic backend services including GitHub Actions, database connections, job queues, and package registry. Administrators can override the thread count using `ghe-config haproxy-nbthread` if needed. 
+      To improve performance on large instances, HAProxy automatically scales its thread count based on available CPUs and uses higher connection limits for high-traffic backend services including GitHub Actions, database connections, job queues, and package registry. Administrators can override the thread count using `ghe-config core.haproxy-nbthread` if needed. 
     - |
       API consumers can update issues via the REST API (PATCH) using fine-grained permissions for closing and reopening issues, and for setting milestones. 
     - |


### PR DESCRIPTION
The HAProxy nbthread release note in 3.16.16, 3.17.13, 3.18.7, and 3.19.4 says `ghe-config haproxy-nbthread` but the correct command is `ghe-config core.haproxy-nbthread` (needs the `core.` prefix).

Without the prefix, admins running the command will get an error or set the wrong config key.