### PR TITLE
docs: add rate-limiting section to REST API getting-started guide

### DIFF
--- a/content/rest/using-the-rest-api/getting-started-with-the-rest-api.md
+++ b/content/rest/using-the-rest-api/getting-started-with-the-rest-api.md
@@ -702,7 +702,7 @@ You can then expand these templates using something like the [uri_template](http
 
 ## Rate limiting
 
-The {% data variables.product.github %} REST API limits the number of requests you can make within a given time period. For more information about rate limits and how to check your current rate limit status, see "[AUTOTITLE](/rest/using-the-rest-api/rate-limits-for-the-rest-api)."
+The {% data variables.product.github %} REST API limits the number of requests you can make within a given time period. For more information about rate limits and how to check your current rate limit status, see [AUTOTITLE](/rest/using-the-rest-api/rate-limits-for-the-rest-api).
 
 ## Next steps
 

--- a/content/rest/using-the-rest-api/getting-started-with-the-rest-api.md
+++ b/content/rest/using-the-rest-api/getting-started-with-the-rest-api.md
@@ -700,6 +700,10 @@ You can then expand these templates using something like the [uri_template](http
 => "/notifications?all=1&participating=1"
 ```
 
+## Rate limiting
+
+The {% data variables.product.github %} REST API limits the number of requests you can make within a given time period. For more information about rate limits and how to check your current rate limit status, see "[AUTOTITLE](/rest/using-the-rest-api/rate-limits-for-the-rest-api)."
+
 ## Next steps
 
 This article demonstrated how to list and create issues in a repository. For more practice, try to comment on an issue, edit the title of an issue, or close an issue. For more information, see the ["Create an issue comment" endpoint](/rest/issues/comments#create-an-issue-comment) and the ["Update an issue" endpoint](/rest/issues/issues#update-an-issue).


### PR DESCRIPTION
## What's changing?

Adds a `## Rate limiting` section to the REST API getting-started guide, before the existing `## Next steps` section.

## Why?

Closes #43557

GitHub's backend links to `#rate-limiting` in this article (e.g. from API error responses), but the anchor did not exist in the document. The new section creates the expected anchor and directs readers to the dedicated rate limits reference page.

## Type of change

- [x] New or updated content