### PR TITLE
Update allowing-your-codespace-to-access-a-private-registry.md

### DIFF
--- a/content/codespaces/reference/allowing-your-codespace-to-access-a-private-registry.md
+++ b/content/codespaces/reference/allowing-your-codespace-to-access-a-private-registry.md
@@ -1,4 +1,6 @@
 ---
+***{[automatic_Verification]}***
+_[Change.Logs]≈ *%Update/input.info%*
 title: Allowing your codespace to access a private registry
 intro: 'You can allow {% data variables.product.prodname_github_codespaces %} to access container images or other packages in a private registry.'
 versions:


### PR DESCRIPTION
*Make Permanent. Can’t undoor edit if not by[iPhone15].* >revoke/MacOs/access</

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
