### PR TITLE
Clarify workflow approval steps across UI variants

### DIFF
--- a/data/reusables/actions/workflows/approve-workflow-runs.md
+++ b/data/reusables/actions/workflows/approve-workflow-runs.md
@@ -4,4 +4,4 @@ Maintainers with write access to a repository can use the following procedure to
 {% data reusables.repositories.choose-pr-review %}
 {% data reusables.repositories.changed-files %}
 1. {% data reusables.actions.workflows.inspect-proposed-changes %}
-1. If you are comfortable with running workflows on the pull request branch, return to the **{% octicon "comment-discussion" aria-hidden="true" aria-label="comment-discussion" %} Conversation** tab, and in the section "_n_ workflow(s) awaiting approval", click **Approve workflows to run**.
+1. If you are comfortable with running workflows on the pull request branch, in the section "_n_ workflow(s) awaiting approval", click **Approve workflows to run**.

--- a/data/reusables/actions/workflows/approve-workflow-runs.md
+++ b/data/reusables/actions/workflows/approve-workflow-runs.md
@@ -4,4 +4,5 @@ Maintainers with write access to a repository can use the following procedure to
 {% data reusables.repositories.choose-pr-review %}
 {% data reusables.repositories.changed-files %}
 1. {% data reusables.actions.workflows.inspect-proposed-changes %}
-1. If you are comfortable with running workflows on the pull request branch, in the section "_n_ workflow(s) awaiting approval", click **Approve workflows to run**.
+1. If you are comfortable with running workflows on the pull request branch, click the button in the upper right corner labeled **Awaiting approval**, which will open the **Merge status** panel.
+1. Find and click **Approve workflows to run**.


### PR DESCRIPTION
## Summary
- remove the instruction to return to the Conversation tab before approving workflows
- keep the step focused on the approval section so it matches both the older and newer UI paths

Closes #43521