### PR TITLE
Docs wrongly state GHC CLI supports prompt files

### DIFF
--- a/content/copilot/reference/customization-cheat-sheet.md
+++ b/content/copilot/reference/customization-cheat-sheet.md
@@ -54,7 +54,7 @@ This table shows which customization features are supported in each IDE and surf
 | Feature | {% data variables.product.prodname_vscode_shortname %} | {% data variables.product.prodname_vs %} | JetBrains IDEs | Eclipse | Xcode | {% data variables.product.prodname_dotcom %} .com | {% data variables.copilot.copilot_cli_short %} |
 |---------|:-------:|:-------------:|:---------:|:-------:|:-----:|:-------:|:---:|
 | Custom instructions | ✓ | ✓ | P | P | P | ✓ | ✓ |
-| Prompt files | ✓ | ✓ | P | ✗ | P | ✗ | ✓ |
+| Prompt files | ✓ | ✓ | P | ✗ | P | ✗ | ✗ |
 | {% data variables.copilot.custom_agents_caps_short %} | ✓ | ✗ | P | P | P | ✓ | ✓ |
 | {% data variables.copilot.subagents_caps_short %} | ✓ | ✗ | P | P | P | ✗ | ✓ |
 | Agent skills | ✓ | ✗ | P | ✗ | ✗ | ✓ | ✓ |


### PR DESCRIPTION
### Why:

The docs wrongly state that the GitHub Copilot CLI supports prompt files.
[In this issue, it is clearly stated that it does not](https://github.com/github/copilot-cli/issues/618#issuecomment-4005755203), nor will it ever be.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Prompt file supported - as-is `yes` - to-be `no` 

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
