### PR TITLE
Update `profile.org_settings` reusable with current steps

### DIFF
--- a/data/reusables/profile/org_settings.md
+++ b/data/reusables/profile/org_settings.md
@@ -1,1 +1,2 @@
-1. Next to the organization, click **Settings**.
+1. Select an organization by clicking on it.
+{% data reusables.organizations.org_settings %}


### PR DESCRIPTION


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #43573

Can no longer access organization settings directly from profile organizations page - must first navigate to the organization page then access settings via the navbar there.

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->
- Amend the `profile.org_settings` reusable with the current steps required to go from the profile orgs tab to the org settings page

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
