### PR TITLE
Update approve workflow instructions to reflect current UI  For the description, paste this:

### DIFF
--- a/data/reusables/actions/workflows/approve-workflow-runs.md
+++ b/data/reusables/actions/workflows/approve-workflow-runs.md
@@ -4,4 +4,4 @@ Maintainers with write access to a repository can use the following procedure to
 {% data reusables.repositories.choose-pr-review %}
 {% data reusables.repositories.changed-files %}
 1. {% data reusables.actions.workflows.inspect-proposed-changes %}
-1. If you are comfortable with running workflows on the pull request branch, return to the **{% octicon "comment-discussion" aria-hidden="true" aria-label="comment-discussion" %} Conversation** tab, and in the section "_n_ workflow(s) awaiting approval", click **Approve workflows to run**.
+1. If you are comfortable with running workflows on the pull request branch, click **Approve and run workflows** on the pull request.


### PR DESCRIPTION
## Summary
Updates the reusable workflow approval instructions to reflect the current GitHub UI.

## Changes made
- Removes the outdated instruction to return to the Conversation tab
- Replaces it with the current action: click **Approve and run workflows** on the pull request

## Related issue
Closes #43521