### PR TITLE
Update ubuntu-slim reference to include link

### DIFF
--- a/data/reusables/actions/single-cpu-table-row.md
+++ b/data/reusables/actions/single-cpu-table-row.md
@@ -5,6 +5,6 @@
       <td>14 GB</td>
       <td> x64 </td>
       <td>
-        <code>ubuntu-slim</code>
+        <code><a href="https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md">ubuntu-slim</a></code>
       </td>
     </tr>


### PR DESCRIPTION
Just like Ubuntu 22.04 includes a link to the readme, the `ubuntu-slim` one should contain a link as well, for consistency, and accessibility.

For reference, the link on the main branch for Ubuntu 22.04: https://github.com/github/docs/blob/28dc5b5f28d02983b56cece2e8ed93d6653d2a38/data/reusables/actions/supported-github-runners.md#L27 

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
