### PR TITLE
Clarify Dependabot cooldown wording in tutorial

### DIFF
--- a/content/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates.md
+++ b/content/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates.md
@@ -60,7 +60,7 @@ See also [schedule](/code-security/dependabot/working-with-dependabot/dependabot
 
 ### Setting up a cooldown period for dependency updates
 
-You can use  `cooldown` with a combination of options to control when {% data variables.product.prodname_dependabot %} creates pull requests for **version updates**.
+You can use `cooldown` with a combination of options to define a **cooldown period** for dependency updates. The `cooldown` option is only available for _version_ updates, not _security_ updates.
 
 The example `dependabot.yml` file below shows a cooldown period being applied to the dependencies `requests`, `numpy`, and those prefixed with `pandas` or `django`, but not to the dependency called `pandas` (exact match), which is excluded via the **exclude** list.
 


### PR DESCRIPTION
## Summary
- align the tutorial wording for `cooldown` with the Dependabot options reference
- clarify that `cooldown` defines a cooldown period for dependency updates
- state explicitly that `cooldown` applies to version updates, not security updates

Closes #43708.

## Validation
- `npm run lint-content -- --paths content/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates.md`