### PR TITLE
Add merge queue note to Copilot setup steps example

### DIFF
--- a/content/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment.md
+++ b/content/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment.md
@@ -56,9 +56,13 @@ name: "Copilot Setup Steps"
 on:
   workflow_dispatch:
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
     paths:
       - .github/workflows/copilot-setup-steps.yml
   pull_request:
+    branches:
+      - main
     paths:
       - .github/workflows/copilot-setup-steps.yml
 

--- a/data/reusables/actions/workflows/approve-workflow-runs.md
+++ b/data/reusables/actions/workflows/approve-workflow-runs.md
@@ -4,4 +4,4 @@ Maintainers with write access to a repository can use the following procedure to
 {% data reusables.repositories.choose-pr-review %}
 {% data reusables.repositories.changed-files %}
 1. {% data reusables.actions.workflows.inspect-proposed-changes %}
-1. If you are comfortable with running workflows on the pull request branch, return to the **{% octicon "comment-discussion" aria-hidden="true" aria-label="comment-discussion" %} Conversation** tab, and in the section "_n_ workflow(s) awaiting approval", click **Approve workflows to run**.
+1. If you are comfortable with running workflows on the pull request branch, click **Approve and run workflows** on the pull request.


### PR DESCRIPTION
## Summary
Updates the copilot-setup-steps.yml example to avoid unnecessary runs in merge queues.

## Changes made
- added branches-ignore for gh-readonly-queue/**
- limited pull_request to main