### PR TITLE
Fixing typo - the docs variable is also populating the 'for example' string

### DIFF
--- a/content/copilot/how-tos/copilot-cli/set-up-copilot-cli/configure-copilot-cli.md
+++ b/content/copilot/how-tos/copilot-cli/set-up-copilot-cli/configure-copilot-cli.md
@@ -66,7 +66,7 @@ In this section, you can learn how to:
 
 ### Allowing a tool for the first time
 
-The first time that {% data variables.product.prodname_copilot_short %} needs to use a tool that may require approval—for example, {% data reusables.cli.tools-needing-approval %}—it will ask you whether you want to allow it to run. Whether you’re prompted can depend on the tool and how it’s being used (such as the arguments provided or whether the tool has been previously approved).
+The first time that {% data variables.product.prodname_copilot_short %} needs to use a tool that may require approval—{% data reusables.cli.tools-needing-approval %}—it will ask you whether you want to allow it to run. Whether you’re prompted can depend on the tool and how it’s being used (such as the arguments provided or whether the tool has been previously approved).
 
 1. Prompt {% data variables.product.prodname_copilot_short %} to perform a task that requires a tool. For example:
 


### PR DESCRIPTION
### Why:
To improve the readability - fixing typo: 'for example' is written two times.
The data variable already contain that string.

### What's being changed:

<img width="844" height="180" alt="image" src="https://github.com/user-attachments/assets/795def91-5a9a-4424-a5c6-3ee54128c5b5" />

https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/configure-copilot-cli#allowing-a-tool-for-the-first-time
