### PR TITLE
Clarify that content exclusion requires Copilot Business or Enterprise plan

### DIFF
--- a/content/copilot/concepts/context/content-exclusion.md
+++ b/content/copilot/concepts/context/content-exclusion.md
@@ -26,6 +26,8 @@ You can use content exclusion to configure {% data variables.product.prodname_co
 
 Repository administrators, organization owners, and enterprise owners can configure content exclusion.
 
+Content exclusion requires a {% data variables.copilot.copilot_business_short %} or {% data variables.copilot.copilot_enterprise_short %} plan. This feature is not available for {% data variables.product.prodname_copilot_short %} plans assigned to personal accounts (such as {% data variables.copilot.copilot_free_short %}, {% data variables.copilot.copilot_pro_short %}, or {% data variables.copilot.copilot_pro_plus_short %}). Repositories must belong to an organization with an eligible plan for the content exclusion settings to appear.
+
 {% data reusables.copilot.content-exclusions-scope %}
 
 ### Availability of content exclusion

--- a/content/copilot/how-tos/configure-content-exclusion/exclude-content-from-copilot.md
+++ b/content/copilot/how-tos/configure-content-exclusion/exclude-content-from-copilot.md
@@ -31,6 +31,9 @@ category:
 You can use your repository settings to specify content in your repository that {% data variables.product.prodname_copilot %} should ignore.
 
 > [!NOTE]
+> Content exclusion settings are only available for repositories owned by an organization with a {% data variables.copilot.copilot_business_short %} or {% data variables.copilot.copilot_enterprise_short %} plan. If your repository is owned by a personal account, the **{% data variables.product.prodname_copilot_short %}** option will not appear in your repository settings. To configure content exclusion, the repository must belong to an organization that has a {% data variables.copilot.copilot_business_short %} or {% data variables.copilot.copilot_enterprise_short %} subscription.
+
+> [!NOTE]
 > {% data variables.copilot.copilot_cli %}, {% data variables.copilot.copilot_cloud_agent %}, and Agent mode in {% data variables.copilot.copilot_chat_short %} in IDEs, do not support content exclusion. For more information about these {% data variables.product.prodname_copilot_short %} features, see [AUTOTITLE](/copilot/concepts/agents/about-copilot-cli), [AUTOTITLE](/copilot/concepts/agents/cloud-agent/about-cloud-agent), and [AUTOTITLE](/copilot/how-tos/chat-with-copilot/chat-in-ide).
 
 {% data reusables.repositories.navigate-to-repo %}


### PR DESCRIPTION
## Why

The [Excluding content from GitHub Copilot](https://docs.github.com/en/copilot/how-tos/configure-content-exclusion/exclude-content-from-copilot) how-to page and the [Content exclusion concepts](https://docs.github.com/en/copilot/concepts/context/content-exclusion) page do not explicitly state that repository-level content exclusion settings require the repository to belong to an **organization** with a **Copilot Business or Enterprise** plan.

While the page has a `product` frontmatter gate that renders a banner, the banner is easy to miss. The repository configuration section begins with *"You can use your repository settings…"* without clarifying that the Copilot option will not appear for repositories owned by personal accounts (even with Copilot Pro or Pro+).

This leads to confusion when users follow the instructions and cannot find the settings.

## What

**How-to page** (`exclude-content-from-copilot.md`):
- Adds a `> [!NOTE]` callout in the "Configuring content exclusion for your repository" section explicitly stating the plan and organization ownership requirement, and that personal-account repos will not show the Copilot settings option.

**Concepts page** (`content-exclusion.md`):
- Expands the "Who can configure content exclusion" section to explicitly list the plan requirement (Copilot Business or Enterprise) and clarify that personal-account plans (Copilot Free, Pro, Pro+) are not eligible.

## Validation

- All `{% data variables %}` references verified against `data/variables/copilot.yml`
- Changes follow existing doc conventions (NOTE callouts, variable references)
- No structural or formatting changes to surrounding content