### PR TITLE
Update 'Policy' to 'Security policy', to reflect wording visible in UI

### DIFF
--- a/content/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/adding-a-security-policy-to-your-repository.md
+++ b/content/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/adding-a-security-policy-to-your-repository.md
@@ -18,7 +18,7 @@ category:
 
 {% data reusables.repositories.navigate-to-repo %}
 {% data reusables.repositories.sidebar-security %}
-1. In the left sidebar, under "Reporting", click **{% octicon "law" aria-hidden="true" aria-label="law" %} Policy**.
+1. In the left sidebar, under "Reporting", click **{% octicon "law" aria-hidden="true" aria-label="law" %} Security policy**.
 1. Click **Start setup**.
 1. In the new `SECURITY.md` file, add information about supported versions of your project and how to report a vulnerability.
 {% data reusables.files.write_commit_message %}


### PR DESCRIPTION
See what is visible in the UI (left sidebar, under Reporting):

<img width="2468" height="1291" alt="580627745-0141a27b-6def-4341-88c2-6f7dcb2f045b" src="https://github.com/user-attachments/assets/0a24fc2c-53e6-4392-9616-72f60227aa4a" />


### Why:

Reduce confusion.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updated wording to match UI.

### Check off the following:

- [v] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [v] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [?] All CI checks are passing and the changes look good in the review environment.
