### PR TITLE
Fix translation pipeline corrupting HTML tags and bold headings in non-English pages

### DIFF
--- a/src/languages/lib/correct-translation-content.ts
+++ b/src/languages/lib/correct-translation-content.ts
@@ -884,6 +884,34 @@ export function correctTranslatedContentStrings(
     }
   }
 
+  // Unescape HTML entity-encoded tags (`&lt;tag&gt;` → `<tag>`) that Crowdin
+  // introduces when the English source uses inline raw HTML — e.g.
+  // `<code><a href="...">label</a></code>` inside table `<td>` cells.
+  // Without this fix, those tags render as literal `<code>` text on translated
+  // pages rather than as styled code elements.
+  // Only unescape tag names present as raw HTML in the English source to avoid
+  // incorrectly expanding intentional `&lt;` entity sequences.
+  if (englishContent && content.includes('&lt;')) {
+    const englishTagNames = new Set(
+      [...englishContent.matchAll(/<([a-z][a-z0-9]*)/gi)].map((m) => m[1].toLowerCase()),
+    )
+    if (englishTagNames.size > 0) {
+      content = content.replace(
+        /&lt;(\/?[a-z][a-z0-9]*)(\s[^<>]*?)?&gt;/gi,
+        (match, tag: string, attrs = '') => {
+          const baseName = tag.replace(/^\//, '').toLowerCase()
+          return englishTagNames.has(baseName) ? `<${tag}${attrs}>` : match
+        },
+      )
+    }
+  }
+
+  // Remove bare code-fence wrapping from bold heading lines. Translation pipelines
+  // sometimes wrap `**heading**` lines in bare (no-language) fenced code blocks,
+  // causing them to render as code instead of bold text. Strip the fences and
+  // restore the heading as plain Markdown.
+  content = content.replace(/^```\s*\n(\*\*[^\n]+\*\*)\s*\n```/gm, '$1')
+
   // Collapsed Markdown table rows — restore linebreaks between `|` cells.
   content = content.replaceAll(' | | ', ' |\n| ')
 

--- a/src/languages/tests/correct-translation-content.ts
+++ b/src/languages/tests/correct-translation-content.ts
@@ -1355,6 +1355,80 @@ describe('correctTranslatedContentStrings', () => {
       expect(fix('{{%raw %}', 'es')).toBe('{% raw %}')
       expect(fix('{{% raw %}', 'es')).toBe('{% raw %}')
     })
+
+    test('unescapes entity-encoded HTML tags when English source has matching raw HTML', () => {
+      const english =
+        '<td><code><a href="https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md">ubuntu-latest</a></code></td>'
+
+      expect(fix('&lt;code&gt;ubuntu-latest&lt;/code&gt;', 'ko', english)).toBe(
+        '<code>ubuntu-latest</code>',
+      )
+      expect(
+        fix('&lt;a href="https://example.com"&gt;ubuntu-latest&lt;/a&gt;', 'ko', english),
+      ).toBe('<a href="https://example.com">ubuntu-latest</a>')
+      expect(
+        fix(
+          '&lt;code&gt;&lt;a href="https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md"&gt;ubuntu-latest&lt;/a&gt;&lt;/code&gt;',
+          'ko',
+          english,
+        ),
+      ).toBe(
+        '<code><a href="https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md">ubuntu-latest</a></code>',
+      )
+    })
+
+    test('does not unescape entity-encoded tags absent from English source', () => {
+      const english = '<p>Simple paragraph without code elements</p>'
+      const input = '&lt;code&gt;text&lt;/code&gt;'
+      expect(fix(input, 'ko', english)).toBe(input)
+    })
+
+    test('does not unescape entity-encoded tags when no English content provided', () => {
+      const input = '&lt;code&gt;ubuntu-latest&lt;/code&gt;'
+      expect(fix(input, 'ko')).toBe(input)
+    })
+
+    test('removes bare code-fence wrapping from bold heading lines', () => {
+      const input = '```\n**다음은 작업을 다운로드하는 데 필요합니다.**\n```'
+      expect(fix(input, 'ko')).toBe('**다음은 작업을 다운로드하는 데 필요합니다.**')
+    })
+
+    test('removes bare code-fence wrapping from bold headings between real code blocks', () => {
+      const input = [
+        '```shell copy',
+        'github.com',
+        'api.github.com',
+        '```',
+        '',
+        '```',
+        '**다음은 작업을 다운로드하는 데 필요합니다.**',
+        '```',
+        '',
+        '```shell copy',
+        'codeload.github.com',
+        '```',
+      ].join('\n')
+
+      const expected = [
+        '```shell copy',
+        'github.com',
+        'api.github.com',
+        '```',
+        '',
+        '**다음은 작업을 다운로드하는 데 필요합니다.**',
+        '',
+        '```shell copy',
+        'codeload.github.com',
+        '```',
+      ].join('\n')
+
+      expect(fix(input, 'ko')).toBe(expected)
+    })
+
+    test('does not strip language-specified code fences with bold content', () => {
+      const input = '```shell\n**not a heading**\n```'
+      expect(fix(input, 'ko')).toBe(input)
+    })
   })
 
   // ─── EDGE CASES ────────────────────────────────────────────────────


### PR DESCRIPTION
### Why:

Closes: #43888

### What's being changed:

Two rendering bugs affect all non-English translations caused by the Crowdin translation pipeline corrupting content in `src/languages/lib/correct-translation-content.ts`.

**Bug 1: Raw HTML tags visible in tables**

Inline HTML elements such as `<code><a href="...">ubuntu-latest</a></code>` inside table `<td>` cells are displayed as literal text instead of being rendered as styled code elements. Crowdin entity-encodes angle brackets, turning `<code>` into `&lt;code&gt;`, which the correction pipeline was not unescaping.

**Bug 2: Bold headings rendered inside code blocks**

Bold heading lines (e.g. `**Needed for downloading actions:**`) between code blocks are wrapped in bare code fences by the translation pipeline, causing them to render as code blocks instead of formatted headings.

**Fix:**

1. Unescape entity-encoded HTML tags (`&lt;code&gt;` → `<code>`) when the same tag name appears as raw HTML in the English source, to avoid incorrectly expanding intentional `&lt;` entities.
2. Strip bare code-fence wrapping from lines that contain only a bold heading (`**...**`).

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.