### PR TITLE
Update note on action description requirement

### DIFF
--- a/content/actions/reference/workflows-and-actions/metadata-syntax.md
+++ b/content/actions/reference/workflows-and-actions/metadata-syntax.md
@@ -34,7 +34,7 @@ category:
 ## `description`
 
 **Required** A short description of the action.
-
+Note: This is not required for composite actions.
 ## `inputs`
 
 **Optional** Input parameters allow you to specify data that the action expects to use during runtime. {% data variables.product.prodname_dotcom %} stores input parameters as environment variables. We recommend using lowercase input ids.


### PR DESCRIPTION
Clarified that the description is not required for composite actions.

As a proof of concept, I deleted my 'description' key from my composite action and called it, with everything still working.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/43910

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

Per the issue linked above:

"For composite actions, the `description` key is not strictly required for the composite action to function correctly (see Additional Information [in the issue] for proof).

Instead of 'Required' this should either have an addendum like in the pull request (that is, that `description` is not required for composite actions, or change Required to optional. In either case, it is probably worth it to state that a `description` key is highly recommended."

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
