### PR TITLE
Remove shortcut for opening Copilot suggestions pane

### DIFF
--- a/content/copilot/reference/keyboard-shortcuts.md
+++ b/content/copilot/reference/keyboard-shortcuts.md
@@ -24,7 +24,6 @@ You can use the default keyboard shortcuts for inline suggestions in your JetBra
 |Show next inline suggestion|<kbd>Option (⌥) or Alt</kbd>+<kbd>]</kbd>|
 |Show previous inline suggestion|<kbd>Option (⌥) or Alt</kbd>+<kbd>[</kbd>|
 |Trigger inline suggestion|<kbd>Option (⌥)</kbd>+<kbd>\\</kbd>|
-|Open {% data variables.product.prodname_copilot %} (additional suggestions in separate pane)|<kbd>Option (⌥) or Alt</kbd>+<kbd>Return</kbd> |
 
 ## Keyboard shortcuts for Windows
 
@@ -35,7 +34,6 @@ You can use the default keyboard shortcuts for inline suggestions in your JetBra
 |Show next inline suggestion|<kbd>Alt</kbd>+<kbd>]</kbd>|
 |Show previous inline suggestion|<kbd>Alt</kbd>+<kbd>[</kbd>|
 |Trigger inline suggestion|<kbd>Alt</kbd>+<kbd>\\</kbd>|
-|Open {% data variables.product.prodname_copilot %} (additional suggestions in separate pane)|<kbd>Alt</kbd>+<kbd>Enter</kbd> |
 
 ## Keyboard shortcuts for Linux
 
@@ -46,7 +44,6 @@ You can use the default keyboard shortcuts for inline suggestions in your JetBra
 |Show next inline suggestion|<kbd>Alt</kbd>+<kbd>]</kbd>|
 |Show previous inline suggestion|<kbd>Alt</kbd>+<kbd>[</kbd>|
 |Trigger inline suggestion|<kbd>Alt</kbd>+<kbd>\\</kbd>|
-|Open {% data variables.product.prodname_copilot %} (additional suggestions in separate pane)|<kbd>Alt</kbd>+<kbd>Enter</kbd> |
 
 {% endjetbrains %}
 
@@ -74,7 +71,6 @@ You can use the default keyboard shortcuts for {% data variables.product.prodnam
 |Show next inline suggestion| <kbd>Option (⌥)</kbd>+<kbd>]</kbd><br> |editor.action.inlineSuggest.showNext|
 |Show previous inline suggestion| <kbd>Option (⌥)</kbd>+<kbd>[</kbd><br> |editor.action.inlineSuggest.showPrevious|
 |Trigger inline suggestion| <kbd>Option (⌥)</kbd>+<kbd>\\</kbd><br> |editor.action.inlineSuggest.trigger|
-|Open {% data variables.product.prodname_copilot %} (additional suggestions in separate pane)|<kbd>Ctrl</kbd>+<kbd>Return</kbd>|github.copilot.generate|
 |Toggle {% data variables.product.prodname_copilot %} on/off|_No default shortcut_|github.copilot.toggleCopilot|
 
 ## Keyboard shortcuts for Windows
@@ -86,7 +82,6 @@ You can use the default keyboard shortcuts for {% data variables.product.prodnam
 |Show next inline suggestion|<kbd>Alt</kbd>+<kbd>]</kbd> |editor.action.inlineSuggest.showNext|
 |Show previous inline suggestion|<kbd>Alt</kbd>+<kbd>[</kbd>|editor.action.inlineSuggest.showPrevious|
 |Trigger inline suggestion|<kbd>Alt</kbd>+<kbd>\\</kbd>|editor.action.inlineSuggest.trigger|
-|Open {% data variables.product.prodname_copilot %} (additional suggestions in separate pane)|<kbd>Ctrl</kbd>+<kbd>Enter</kbd>|github.copilot.generate|
 |Toggle {% data variables.product.prodname_copilot %} on/off|_No default shortcut_|github.copilot.toggleCopilot|
 
 ## Keyboard shortcuts for Linux
@@ -98,7 +93,6 @@ You can use the default keyboard shortcuts for {% data variables.product.prodnam
 |Show next inline suggestion|<kbd>Alt</kbd>+<kbd>]</kbd> |editor.action.inlineSuggest.showNext|
 |Show previous inline suggestion|<kbd>Alt</kbd>+<kbd>[</kbd>|editor.action.inlineSuggest.showPrevious|
 |Trigger inline suggestion|<kbd>Alt</kbd>+<kbd>\\</kbd>|editor.action.inlineSuggest.trigger|
-|Open {% data variables.product.prodname_copilot %} (additional suggestions in separate pane)|<kbd>Ctrl</kbd>+<kbd>Enter</kbd>|github.copilot.generate|
 |Toggle {% data variables.product.prodname_copilot %} on/off|_No default shortcut_|github.copilot.toggleCopilot|
 
 {% endvscode %}


### PR DESCRIPTION
Removed the 'Open Copilot (additional suggestions in separate pane)' shortcut for macOS, Windows, and Linux.

This feature has been removed from all copilot extensions some time ago.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
