### PR TITLE
Fix grammar: remove misused 'set up' noun in Copilot Spaces prerequisites

### DIFF
--- a/content/copilot/how-tos/provide-context/use-copilot-spaces/use-copilot-spaces.md
+++ b/content/copilot/how-tos/provide-context/use-copilot-spaces/use-copilot-spaces.md
@@ -31,7 +31,7 @@ Once you've accessed space context from your IDE:
 To use {% data variables.copilot.copilot_spaces_short %} in your IDE, you need to:
 
 * Set up the remote {% data variables.product.github %} MCP server for your IDE. For more information, see [AUTOTITLE](/copilot/how-tos/provide-context/use-mcp/set-up-the-github-mcp-server) and [Remote {% data variables.product.github %} MCP Server](https://github.com/github/github-mcp-server/blob/main/docs/remote-server.md) in the {% data variables.product.github %} MCP server documentation.
-* Configure the set up of the remote {% data variables.product.github %} MCP server so that the {% data variables.copilot.copilot_spaces_short %} toolset is enabled.
+* Configure the remote {% data variables.product.github %} MCP server so that the {% data variables.copilot.copilot_spaces_short %} toolset is enabled.
 
   The {% data variables.copilot.copilot_spaces_short %} toolset is not included in the default configuration, so you must explicitly enable it using the `X-MCP-Toolsets` header. The following example configuration enables both the default tools and {% data variables.copilot.copilot_spaces_short %}:
 


### PR DESCRIPTION
## Why:

On `/copilot/how-tos/provide-context/use-copilot-spaces/use-copilot-spaces`, the prerequisites list reads:

> Configure **the set up of** the remote GitHub MCP server so that the Copilot Spaces toolset is enabled.

"Set up" is a verb phrase; the noun form is "setup". The wrapper phrase is also redundant — the configuration *is* the setup. Removing "the set up of" makes the sentence grammatically correct and more concise, and matches the style of the first bullet immediately above it ("Set up the remote GitHub MCP server for your IDE").

## What is being changed:

Single-line copy fix in `content/copilot/how-tos/provide-context/use-copilot-spaces/use-copilot-spaces.md`:

- Before: Configure the set up of the remote GitHub MCP server so that the Copilot Spaces toolset is enabled.
- After:  Configure the remote GitHub MCP server so that the Copilot Spaces toolset is enabled.

No links, structure, or technical instructions changed.

## Check off the following:

- [x] Pure copy fix; rendered output differs only in the edited sentence.
- [x] I have completed the self-review checklist.
