### PR TITLE
docs: document that Actions variables are accessible in Dependabot workflows

### DIFF
--- a/content/code-security/reference/supply-chain-security/dependabot-on-actions.md
+++ b/content/code-security/reference/supply-chain-security/dependabot-on-actions.md
@@ -19,6 +19,7 @@ For workflows initiated by {% data variables.product.prodname_dependabot %} (`gi
 
 * `GITHUB_TOKEN` has read-only permissions by default.
 * Secrets are populated from {% data variables.product.prodname_dependabot %} secrets. {% data variables.product.prodname_actions %} secrets are not available.
+* Actions variables (`vars` context) are accessible.
 
 For workflows initiated by {% data variables.product.prodname_dependabot %} (`github.actor == 'dependabot[bot]'`) using the `pull_request_target` event, if the base ref of the pull request was created by {% data variables.product.prodname_dependabot %} (`github.event.pull_request.user.login == 'dependabot[bot]'`), the `GITHUB_TOKEN` will be read-only and secrets are not available.
 


### PR DESCRIPTION
### Why:
Closes: https://github.com/github/docs/issues/43950

### What's being changed:
Added a bullet point to the "Restrictions when Dependabot triggers events" section documenting that Actions variables (`vars` context) are accessible in Dependabot-triggered workflows.

Tested in: https://github.com/gokcedemir/dependabot-variables-test
- Workflow log showed `Secret source: Dependabot`
- `vars.TEST_VAR` was successfully accessed with its value

Related community discussion: https://github.com/orgs/community/discussions/44088

### Check off the following:
- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet the docs fundamentals that are required for all content.
- [ ] All CI checks are passing and the changes look good in the review environment.