### PR TITLE
Clarify rate limit error message and actions

### DIFF
--- a/content/copilot/how-tos/troubleshoot-copilot/troubleshoot-common-issues.md
+++ b/content/copilot/how-tos/troubleshoot-copilot/troubleshoot-common-issues.md
@@ -71,7 +71,7 @@ Most people see rate limiting for select models, due to limited capacity.
 
 Service-level request rate limits ensure high service quality for all {% data variables.product.prodname_copilot_short %}  users and should not affect typical or even deeply engaged {% data variables.product.prodname_copilot_short %} usage. We are aware of some use cases that are affected by it. {% data variables.product.github %} is iterating on {% data variables.product.prodname_copilot_short %}’s rate-limiting heuristics to ensure it doesn’t block legitimate use cases.
 
-If you are rate limited, the error message will contain the suggested retry time for a successful request. For more information about alternative actions you can take while your limit resets, see [AUTOTITLE](/copilot/concepts/usage-limits#what-to-do-if-you-hit-a-limit).
+If you are rate limited, the error message will read: "You've hit your session rate limit. Please upgrade your plan or wait a moment for your limit to reset.". For more information about alternative actions you can take while your limit resets, see [AUTOTITLE](/copilot/concepts/usage-limits#what-to-do-if-you-hit-a-limit).
 
 In case you experience repeated rate limiting in {% data variables.product.prodname_copilot_short %} contact {% data variables.contact.contact_support_page %}.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: [https://github.com/github/docs/issues/43998](https://github.com/github/docs/issues/43998)

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

Updated the rate limit error message for clarity and added guidance on what to do if rate limited. Applies to behavior of GitHub Copilot Chat v0.45.1 in:
VS Code
Version: 1.117.0 (system setup)
Commit: 10c8e557c8b9f9ed0a87f61f1c9a44bde731c409
Date: 2026-04-21T16:12:14-07:00
Electron: 39.8.7
ElectronBuildId: 13841579
Chromium: 142.0.7444.265
Node.js: 22.22.1
V8: 14.2.231.22-electron.0
OS: Windows_NT x64 10.0.26200

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
