### PR TITLE
Update pnpm version support in dependabot options

### DIFF
--- a/content/code-security/reference/supply-chain-security/dependabot-options-reference.md
+++ b/content/code-security/reference/supply-chain-security/dependabot-options-reference.md
@@ -572,7 +572,7 @@ Package manager | YAML value      | Supported versions |
 | pip         | `pip`            | 24.2             |
 | pip-compile | `pip`            | 7.5.3            |
 | pipenv      | `pip`            | <= 2024.4.1      |
-| pnpm   | `npm`            | v7, v8 <br>v9, v10 (version updates only)    |
+| pnpm   | `npm`            | v7, v8, v9, v10   |
 | poetry      | `pip`    | v2    |
 | {% ifversion dependabot-pre-commit-support %} |
 | pre-commit | `pre-commit` | Not applicable |


### PR DESCRIPTION
According to [this discussion](https://github.com/dependabot/dependabot-core/issues/11246) and [this page](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#supported-ecosystems-and-repositories), pnpm v10 is supported for both version and security updates, but the dependabot-options-reference says that v9 and v10 only have version updates.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/44030

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
A single line change to update the package support table in the dependabot reference docs.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
