### PR TITLE
Mod instructions r/t enabling debug runner logging: orgs

### DIFF
--- a/content/actions/how-tos/monitor-workflows/enable-debug-logging.md
+++ b/content/actions/how-tos/monitor-workflows/enable-debug-logging.md
@@ -36,14 +36,14 @@ Runner diagnostic logging provides additional log files that contain information
 * The runner process log, which includes information about coordinating and setting up runners to execute jobs.
 * The worker process log, which logs the execution of a job.
 
-1. To enable runner diagnostic logging, set the following secret or variable in the repository that contains the workflow: `ACTIONS_RUNNER_DEBUG` to `true`. If both the secret and variable are set, the value of the secret takes precedence over the variable.
+1. To enable runner diagnostic logging, set the following secret or variable in the repository (or at organizational-level) that contains the workflow: `ACTIONS_RUNNER_DEBUG` to `true`. If both the secret and variable are set, the value of the secret takes precedence over the variable.
 1. To download runner diagnostic logs, download the log archive of the workflow run. The runner diagnostic logs are contained in the `runner-diagnostic-logs` folder. For more information on downloading logs, see [AUTOTITLE](/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#downloading-logs).
 
 ## Enabling step debug logging
 
 Step debug logging increases the verbosity of a job's logs during and after a job's execution.
 
-1. To enable step debug logging, set the following secret or variable in the repository that contains the workflow: `ACTIONS_STEP_DEBUG` to `true`. If both the secret and variable are set, the value of the secret takes precedence over the variable.
+1. To enable step debug logging, set the following secret or variable in the repository (or at organizational-level) that contains the workflow: `ACTIONS_STEP_DEBUG` to `true`. If both the secret and variable are set, the value of the secret takes precedence over the variable.
 1. After setting the secret or variable, more debug events are shown in the step logs. For more information, see [AUTOTITLE](/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#viewing-logs-to-diagnose-failures).
 
 You can also use the `runner.debug` context to conditionally run steps only when debug logging is enabled. For more information, see [AUTOTITLE](/actions/reference/workflows-and-actions/contexts#runner-context).


### PR DESCRIPTION

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: Issue # TBD

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adds to the documentation regarding enabling runner diagnostic logging for Github Actions. (link below)
https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging#enabling-runner-diagnostic-logging
<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

Clarifies that the secret or variable can be set at the organization-level for enabling runner and step debug logging. As in, you can set ACTIONS_RUNNER_DEBUG to true at organization-level and it will work as expected. I'm not married to the wording by any means, but it should be explicit this works at __both__ repo and org levels; the current wording makes it sounds like ACTIONS_RUNNER_DEBUG must be set at repo-level

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
