### PR TITLE
Enhance content on installation access tokens for GitHub Apps

### DIFF
--- a/content/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app.md
+++ b/content/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app.md
@@ -12,7 +12,13 @@ category:
 
 ## About installation access tokens
 
-In order to authenticate as an app installation, you must generate an installation access token. For more information about authenticating as an app installation, see [Authenticating as a GitHub App installation](/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation).
+In order to authenticate as an app installation, you must generate an installation access token. Installation access tokens are short-lived tokens whose scope is inherited from their associated Github App. These permissions can be further pared down per use case. 
+
+When you use an installation access token, it acts on behalf of the associated Github App. In other words, it is not tied to a user (as is the case with [personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens)).  
+
+For more information regarding installation access tokens and about authenticating as an app installation, see [Authenticating as a GitHub App installation](/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation).
+
+Installation access tokens are short-lived tokens whose scope is inherited from their associated Github App. These permissions can be further pared down per use case. 
 
 > [!NOTE]
 > Instead of generating an installation access token, you can use {% data variables.product.company_short %}'s Octokit SDKs to authenticate as an app. The SDK will take care of generating an installation access token for you and will regenerate the token once it expires. For more information about authenticating as an app installation, see [Authenticating as a GitHub App installation](/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation).


### PR DESCRIPTION
Expanded the explanation of installation access tokens, emphasizing their short-lived nature and scope inheritance from the associated GitHub App.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: TBD

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->
See above. The section "About installation access tokens" should explain what these tokens are and characteristics regarding them. The way the page is currently set up does not give much information as to what installation access tokens actually are--it just says they're needed to auth a Github App. While that's true, this doesn't explain their benefits. I'd argue that their benefits could even be further embellished upon than what I wrote.

Most of the information in the added text was pulled from the page [Authenticating as a GitHub App installation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation#generating-an-installation-access-token)

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
