### PR TITLE
Document per-repo .mcp.json for Copilot CLI

### DIFF
--- a/content/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers.md
+++ b/content/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers.md
@@ -138,6 +138,50 @@ The following example shows a configuration file with a local server and a remot
 
 For more information on MCP server configuration, see [AUTOTITLE](/copilot/how-tos/use-copilot-agents/cloud-agent/extend-cloud-agent-with-mcp#writing-a-json-configuration-for-mcp-servers).
 
+### Adding per-repository MCP servers
+
+You can configure MCP servers for a specific project by adding a JSON file to the repository. This is useful when you want servers to be available only when working in that project, or when you want to share an MCP setup with collaborators by committing it to the repository.
+
+{% data variables.copilot.copilot_cli_short %} looks for project-level configuration in the following locations:
+
+| Path | Recommended use |
+|------|-----------------|
+| `.mcp.json` (in any directory from your working directory up to the repository root) | Local or per-checkout configuration; commonly placed at the project root |
+| `.github/mcp.json` | Shared configuration that is committed to the repository |
+
+When you start {% data variables.copilot.copilot_cli_short %} inside a Git repository, the CLI walks from your current working directory up to the repository root, loading MCP configuration files along the way. If both `.mcp.json` and `.github/mcp.json` exist in the same directory, `.mcp.json` takes precedence. When server names conflict, definitions in files closer to your working directory take precedence. Project-level definitions also take precedence over those in `~/.copilot/mcp-config.json`. For more information on relative trust, see [AUTOTITLE](/copilot/reference/copilot-cli-reference/cli-command-reference#mcp-server-trust-levels).
+
+Project-level files can use either the `mcpServers` top-level object shown in `~/.copilot/mcp-config.json`, or the bare top-level format where each key is an MCP server name. For example, this configuration uses the `mcpServers` object:
+
+```json copy
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "local",
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+The same server can also be configured with the bare top-level format:
+
+```json copy
+{
+  "playwright": {
+    "type": "local",
+    "command": "npx",
+    "args": ["@playwright/mcp@latest"]
+  }
+}
+```
+
+> [!NOTE]
+> * Project-level MCP servers are loaded only after you confirm folder trust on first launch. They are silently skipped in untrusted directories. For more information on folder trust, see [AUTOTITLE](/copilot/concepts/agents/about-copilot-cli#trusted-directories).
+> * In prompt mode (`copilot -p`), project-level MCP servers are not loaded by default. To enable them, set the `GITHUB_COPILOT_PROMPT_MODE_WORKSPACE_MCP` environment variable to `true`. For more information, see [AUTOTITLE](/copilot/reference/copilot-cli-reference/cli-command-reference#environment-variables).
+> * {% data variables.product.prodname_vscode_shortname %}'s `.vscode/mcp.json` is not read by {% data variables.copilot.copilot_cli_short %}. It uses the unsupported top-level key `servers`. To migrate an existing `.vscode/mcp.json` to a format the CLI accepts, see [AUTOTITLE](/copilot/reference/copilot-cli-reference/cli-command-reference#migrating-from-vscodemcpjson).
+
 ### Searching and installing from the registry
 
 > [!NOTE]
@@ -156,7 +200,6 @@ If your organization has configured a custom MCP registry URL, `/mcp search` con
 1. A keyboard-navigable list of matching servers is displayed. Use the arrow keys to browse the results.
 1. Select a server to open its configuration form. The form is pre-populated with the server's configuration from the registry. Fill in any required fields, such as API keys or tokens.
 1. Press <kbd>Ctrl</kbd>+<kbd>S</kbd> to save. The server is added to your `mcp-config.json` and started immediately.
-
 
 ## Managing MCP servers
 


### PR DESCRIPTION
## Why:

Closes #44234

The Copilot CLI MCP how-to (`add-mcp-servers.md`) only documents the user-level `~/.copilot/mcp-config.json` and the interactive `/mcp add` flow. The CLI also reads per-repository configuration from `.mcp.json` and `.github/mcp.json`, but neither this how-to nor the "Add an MCP server" section of `use-copilot-cli.md` mentions those files at all. The relevant trust and prompt-mode behaviours live only in the reference pages and are not linked from the how-to.

This has produced several related bug reports in `github/copilot-cli` whose root cause is partly documentation — see #44234 for the list.

## What's being changed:

Adds a new `### Adding per-repository MCP servers` subsection to `content/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers.md` covering:

- The `.mcp.json` (project root) and `.github/mcp.json` file locations, with their recommended uses.
- Lookup behaviour: the CLI walks from the current working directory up to the Git repository root, loading every `.mcp.json` it finds; closer-to-cwd wins on name conflicts; project-level definitions take precedence over `~/.copilot/mcp-config.json`.
- A minimal JSON example pointing back at the existing format.
- A note that workspace MCP servers are loaded only after folder trust is confirmed.
- A note that in prompt mode (`copilot -p`) workspace MCP servers are not loaded by default, and require setting `GITHUB_COPILOT_PROMPT_MODE_WORKSPACE_MCP=true`. This connects the env var (already in the reference) back to `.mcp.json` for the first time.
- A clarification that `.vscode/mcp.json` is not read, pointing to the existing migration recipe.

All claims were verified against Copilot CLI v1.0.44-2 (the bundled JS) and confirmed by running `copilot mcp list` and `copilot -p` in both modes.

## Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all info.](https://github.com/github/docs/blob/main/contributing/content-style-guide.md)
- [ ] All CI checks are passing and the changes look good in a preview environment.
- [x] [Documentation accessibility guidelines](https://github.com/github/docs/blob/main/contributing/accessibility-guidelines.md) have been followed.
