### PR TITLE
docs: update deprecated Azure AD terminology to Microsoft Entra ID

### DIFF
--- a/content/billing/how-tos/set-up-payment/connect-azure-sub.md
+++ b/content/billing/how-tos/set-up-payment/connect-azure-sub.md
@@ -30,7 +30,7 @@ You can pay for metered usage of {% data variables.product.github %} features th
 
 * You must know your Azure subscription ID. See [Get subscription and tenant IDs in the Azure portal](https://learn.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id) in the Microsoft Docs.
 
-* You must be logged into Azure as a user who is able to provide tenant-wide admin consent or arrange to work with an Azure AD global administrator to configure an admin consent workflow. See [AUTOTITLE](/billing/concepts/azure-subscriptions).
+* You must be logged into Azure as a user who is able to provide tenant-wide admin consent or arrange to work with a Microsoft Entra Global Administrator to configure an admin consent workflow. See [AUTOTITLE](/billing/concepts/azure-subscriptions).
 
 ## Connecting your Azure subscription to an organization or enterprise account
 


### PR DESCRIPTION
## Summary

Replace deprecated "Azure AD" terminology with the current  "Microsoft Entra" branding per Microsoft's official rename  (July 2023).

## Changes

| Location | Before | After |
|---|---|---|
| `billing/concepts/azure-subscriptions.md` | an **Azure AD** global administrator | a **Microsoft Entra** Global Administrator |

## Why

- Microsoft officially renamed Azure Active Directory to  **Microsoft Entra ID** in July 2023.
- The role name **Global Administrator** remains unchanged;  only the product prefix requires updating.

## References

- [Microsoft Entra rename announcement](https://learn.microsoft.com/en-us/entra/fundamentals/new-name)
- [Microsoft Entra built-in roles – Global Administrator](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference#global-administrator)

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
