### PR TITLE
maint: remove note that no-volume needs root

### DIFF
--- a/content/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets.md
+++ b/content/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets.md
@@ -624,9 +624,6 @@ containerMode:
   type: "kubernetes-novolume"
 ```
 
->[!NOTE]
->When using `kubernetes-novolume` mode, the container must run as `root` to support lifecycle hook operations.
-
 #### Troubleshooting Kubernetes mode
 
 When Kubernetes mode is enabled, workflows that are not configured with a container job will fail with an error similar to:


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Docs are misleading for github ARC regarding kubernetes novolume mode needing root. it is not required
Closes: https://github.com/github/docs/issues/44324

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

Removing note that says kubernetes no volume mode needs root to run

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
