### PR TITLE
Add note about sponsorship cancellation when switching enterprise plan

### DIFF
--- a/content/organizations/managing-organization-settings/upgrading-to-the-github-customer-agreement.md
+++ b/content/organizations/managing-organization-settings/upgrading-to-the-github-customer-agreement.md
@@ -24,6 +24,9 @@ You can upgrade to the {% data variables.product.company_short %} Customer Agree
 1. In the text field, type the name of the company, non-profit, or group that owns the organization account. This is the entity that will enter into an agreement with {% data variables.product.prodname_dotcom %}.
 1. To agree to the {% data variables.product.company_short %} Customer Agreement on behalf of your entity, click **Accept terms**.
 
+> [!NOTE]
+> When you upgrade or switch your enterprise plan, your existing payment method is not carried forward. If you do not add a new payment method before your next billing cycle, active paid subscriptions—including {% data variables.product.prodname_sponsors %} sponsorships—are automatically cancelled. To avoid disruption, add a payment method immediately after upgrading. For more information, see "[AUTOTITLE](/billing/how-tos/set-up-payment/manage-payment-info)" and "[AUTOTITLE](/billing/concepts/third-party-payments/github-sponsors)."
+
 ## Further reading
 
 * [AUTOTITLE](/free-pro-team@latest/site-policy/github-terms/github-terms-of-service)


### PR DESCRIPTION
## Summary

Adds a note to the [Upgrading to the GitHub Customer Agreement](https://docs.github.com/en/organizations/managing-organization-settings/upgrading-to-the-github-customer-agreement) page warning that existing payment methods are not carried forward when switching enterprise plans, and that active sponsorships will be cancelled if a new payment method is not added.

## Why

This addresses repeated incidents where organizations lost active GitHub Sponsors sponsorships after upgrading their enterprise plan without realizing their payment method would not carry over.

Closes github/docs-content#22561