### PR TITLE
Fix budget types

### DIFF
--- a/content/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises.md
+++ b/content/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises.md
@@ -74,13 +74,11 @@ Additional usage budgets are set in US dollars, and usage is shown in {% data va
 You can set budgets at four levels to control {% data variables.product.prodname_ai_credits %} spend:
 
 * **Enterprise-level budgets** track spending for all organizations, repositories, and cost centers under the enterprise.
-* **Organization-level budgets** track spending for all repositories in the organization.
 * **Cost-center-level budgets** track spending for a single cost center.
 * **User-level budgets** track spending for individual users. A $0 user-level budget means no access at all.
-
+* **Individual-level Budget** track spending for power users. Overwrites user-level budgets. 
 You can use budgets to get alerts as you approach limits, and to enforce hard stops on usage. For example, if you want to allow some additional usage but keep it in check, you could set a user-level budget slightly above the included amount.
 
-For more information on setting budgets, see [AUTOTITLE](/billing/how-tos/set-up-budgets).
 
 ## Next steps
 


### PR DESCRIPTION
- Removed organization-level budgets. This type of budget does not exist per GH newly published course: https://share.articulate.com/pmpueguUReJvPTq-7f_aY#/lessons/OGJRPBujjCiFDnCdRGCUJW3kXqt6tBsa
- Added individual-level budget option for power users.
- removed the link to how to create budgets. Those instructions are not updated for usage-based billing yet and thus incorrect and misleading.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
