### PR TITLE
Update ARC quickstart authentication guidance

### DIFF
--- a/content/actions/tutorials/use-actions-runner-controller/get-started.md
+++ b/content/actions/tutorials/use-actions-runner-controller/get-started.md
@@ -45,7 +45,7 @@ In order to use ARC, ensure you have the following.
 
     For additional Helm configuration options, see [`values.yaml`](https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set-controller/values.yaml) in the ARC documentation.
 
-1. To enable ARC to authenticate to {% data variables.product.company_short %}, generate a {% data variables.product.pat_v1 %}. For more information, see [AUTOTITLE](/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api#authenticating-arc-with-a-personal-access-token-classic).
+1. To enable ARC to authenticate to {% data variables.product.company_short %}, choose an authentication method for your runner scale set. If you are registering runners at the repository or organization level, we recommend authenticating with a {% data variables.product.prodname_github_app %}. Runner scale sets registered at the enterprise level require {% data variables.product.pat_v1 %} authentication. For more information, see [AUTOTITLE](/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api).
 
 ## Configuring a runner scale set
 
@@ -56,10 +56,11 @@ In order to use ARC, ensure you have the following.
     * Update the `INSTALLATION_NAME` value carefully. You will use the installation name as the value of `runs-on` in your workflows. For more information, see [AUTOTITLE](/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idruns-on).
     * Update the `NAMESPACE` value to the location you want the runner pods to be created.
     * Set `GITHUB_CONFIG_URL` to the URL of your repository, organization, or enterprise. This is the entity that the runners will belong to.
+    * This example uses a {% data variables.product.pat_v1 %} to keep the initial setup short. For repository or organization runner scale sets, use a {% data variables.product.prodname_github_app %} in production environments when possible.
     {% ifversion fpt %}
-    * Set `GITHUB_PAT` to a {% data variables.product.company_short %} {% data variables.product.pat_generic %} with the `repo` and `admin:org` scopes for repository and organization runners.
+    * Set `GITHUB_PAT` to a {% data variables.product.company_short %} {% data variables.product.pat_v1 %} with the `repo` and `admin:org` scopes for repository and organization runners.
     {% else %}
-    * Set `GITHUB_PAT` to a {% data variables.product.company_short %} {% data variables.product.pat_generic %} with the `repo` and `manage_runners:org` scopes for repository and organization runners, and the `manage_runners:enterprise` scope for enterprise runners.
+    * Set `GITHUB_PAT` to a {% data variables.product.company_short %} {% data variables.product.pat_v1 %} with the `repo` and `manage_runners:org` scopes for repository and organization runners, and the `manage_runners:enterprise` scope for enterprise runners.
     {% endif %}
     * This example command installs the latest version of the Helm chart. To install a specific version, you can pass the `--version` argument with the version of the chart you wish to install. You can find the list of releases in the [GitHub Container Registry](https://github.com/actions/actions-runner-controller/pkgs/container/actions-runner-controller-charts%2Fgha-runner-scale-set).
 


### PR DESCRIPTION
## What changed

Updates the ARC quickstart to recommend GitHub App authentication for runner scale sets registered at the repository or organization level, while keeping the short setup example based on a classic PAT.

Also clarifies that runner scale sets registered at the enterprise level require classic PAT authentication, and aligns the `GITHUB_PAT` setup bullets with that token type.

## Why

This addresses github/docs#37288 by nudging readers toward the more production-ready GitHub App authentication path where it is supported, while avoiding ambiguity for enterprise-level runner scale sets.

## Testing

- Ran `npm run lint-content -- --paths content/actions/tutorials/use-actions-runner-controller/get-started.md`
- Pre-commit hook also ran `npm run lint-content -- --precommit --paths C:/_Dev/Code/open-sources/docs/content/actions/tutorials/use-actions-runner-controller/get-started.md`

Closes github/docs#37288

AI-assisted-by: Codex