### PR TITLE
Fix incorrect input name for upload-code-coverage action

### DIFF
--- a/content/code-security/how-tos/maintain-quality-code/set-up-code-coverage.md
+++ b/content/code-security/how-tos/maintain-quality-code/set-up-code-coverage.md
@@ -52,7 +52,7 @@ After your tests generate a Cobertura XML report, upload it to {% data variables
      if: {% raw %}github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository{% endraw %}
      uses: actions/upload-code-coverage@v1
      with:
-       report: COVERAGE-FILE-PATH.xml
+       file: COVERAGE-FILE-PATH.xml
        language: LANGUAGE
        label: LABEL
    ```
@@ -112,7 +112,7 @@ jobs:
         if: {% raw %}github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository{% endraw %}
         uses: actions/upload-code-coverage@v1
         with:
-          report: coverage.xml
+          file: coverage.xml
           language: Python
           label: code-coverage/pytest
 ```


### PR DESCRIPTION
### Why:

The `actions/upload-code-coverage@v1` action defines its input as `file:`, but the docs incorrectly show `report:`. Anyone copy-pasting the example gets a silently broken workflow since composite actions ignore unrecognized `with:` keys.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Two occurrences of `report:` changed to `file:` in the code coverage setup guide (Step 2 snippet and full workflow example), matching the [actual action.yml](https://github.com/actions/upload-code-coverage/blob/main/action.yml).

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.