### PR TITLE
Clarify ARC quickstart authentication guidance

### DIFF
--- a/content/actions/tutorials/use-actions-runner-controller/get-started.md
+++ b/content/actions/tutorials/use-actions-runner-controller/get-started.md
@@ -45,7 +45,7 @@ In order to use ARC, ensure you have the following.
 
     For additional Helm configuration options, see [`values.yaml`](https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set-controller/values.yaml) in the ARC documentation.
 
-1. To enable ARC to authenticate to {% data variables.product.company_short %}, generate a {% data variables.product.pat_v1 %}. For more information, see [AUTOTITLE](/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api#deploying-using-personal-access-token-classic-authentication).
+1. To complete this quickstart, generate a {% data variables.product.pat_v1 %} that ARC can use to authenticate to {% data variables.product.company_short %}. This quickstart uses a {% data variables.product.pat_generic %} to keep the initial setup short. If you are registering runners at the repository or organization level, we recommend authenticating with a {% data variables.product.prodname_github_app %} instead. Enterprise-level runners require {% data variables.product.pat_v1 %} authentication. For more information, see [AUTOTITLE](/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/authenticating-to-the-github-api).
 
 ## Configuring a runner scale set
 


### PR DESCRIPTION
### Why:

Closes: #37288

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The ARC quickstart now makes it clear that the PAT-based setup is a short path for completing the quickstart, not the recommended authentication approach for repository or organization runner scale sets. It points those users to GitHub App authentication and keeps the enterprise-level PAT classic requirement explicit.

Checks run:

- `git diff --check`
- `npm run lint-content -- --paths content/actions/tutorials/use-actions-runner-controller/get-started.md`

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
