### PR TITLE
Reconcile contradictory Search code rate limit on the search REST page

### DIFF
--- a/content/rest/search/search.md
+++ b/content/rest/search/search.md
@@ -31,7 +31,7 @@ Unless another sort option is provided as a query parameter, results are sorted 
 {% data reusables.enterprise.rate_limit %}
 
 The REST API has a custom rate limit for searching. For authenticated requests, you can make up to
-30 requests per minute{% ifversion fpt or ghec %} for all search endpoints except for the [Search code](/rest/search/search#search-code) endpoint. The [Search code](/rest/search/search#search-code) endpoint requires you to authenticate and limits you to 9 requests per minute{% endif %}. For unauthenticated requests, the rate limit allows you to make up to 10 requests per minute.
+30 requests per minute{% ifversion fpt or ghec %} for all search endpoints except for the [Search code](/rest/search/search#search-code) endpoint. The [Search code](/rest/search/search#search-code) endpoint requires you to authenticate and limits you to 10 requests per minute{% endif %}. For unauthenticated requests, the rate limit allows you to make up to 10 requests per minute.
 
 For information about how to determine your current rate limit status, see [Rate Limit](/rest/rate-limit/rate-limit).
 


### PR DESCRIPTION
Fixes #43865.

The REST search docs page stated two different rate limits for `GET /search/code` on the same page. In the hand-written "About search" prose, the Search code endpoint was described as limited to 9 requests per minute, while the auto-generated "Search code" endpoint section (generated from the OpenAPI description) lists 10 requests per minute.

This aligns the hand-written prose to the auto-generated endpoint value (10 requests per minute), which is the source of truth, so the page is internally consistent. Only the prose above the autogeneration marker is changed; no generated content is touched, and no other numbers are altered.

Prepared with AI assistance.