### PR TITLE
Update API Center URL instructions for allowlist policy

### DIFF
--- a/content/copilot/how-tos/administer-copilot/manage-mcp-usage/configure-mcp-registry.md
+++ b/content/copilot/how-tos/administer-copilot/manage-mcp-usage/configure-mcp-registry.md
@@ -70,7 +70,7 @@ Azure API Center provides a fully managed MCP registry with automatic CORS confi
 1. To complete the initial setup for your registry, see [Register and discover remote MCP servers in your API inventory](https://learn.microsoft.com/azure/api-center/register-discover-mcp-server) in the Azure documentation.
 1. If you want your developers to have access to local MCP servers, include those servers in your registry with the correct server ID. For more information, see [AUTOTITLE](/copilot/reference/mcp-allowlist-enforcement).
 1. To ensure {% data variables.product.prodname_copilot %} can fetch your registry, in the visibility settings of your API Center, allow anonymous access.
-1. Copy your API Center endpoint URL. In the next article, you will use this URL to make your registry available across your company.
+1. Copy your API Center endpoint URL. In the next article, you will use this URL to make your registry available across your company. When using the API Center URL in allowlist policy, you'll need to append it with `/workspaces/default`, e.g. `sampleapicenter.data.westeurope.azure-apicenter.ms/workspaces/default`.
 
 ### Pricing and limits
 


### PR DESCRIPTION
Added information about appending '/workspaces/default' to API Center URL for allowlist policy.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: N/A

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs): Information added regarding how the URL should be changed for API Center to work with Github Copilot.

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
