### PR TITLE
Clarify "do not create an organization" warning for Copilot Business standalone setup

### DIFF
--- a/content/copilot/how-tos/copilot-on-github/set-up-copilot/enable-copilot/set-up-a-dedicated-enterprise-for-copilot-business.md
+++ b/content/copilot/how-tos/copilot-on-github/set-up-copilot/enable-copilot/set-up-a-dedicated-enterprise-for-copilot-business.md
@@ -29,7 +29,14 @@ Start a trial of {% data variables.product.prodname_ghe_cloud %} to create your 
 
 <a href="https://github.com/account/enterprises/new?ref_product=ghec&ref_type=trial&ref_style=button&ref_plan=enterprise" target="_blank" class="btn btn-primary mt-3 mr-3 no-underline"><span>Set up a trial of {% data variables.product.prodname_ghe_cloud %}</span> {% octicon "link-external" height:16 aria-label="link-external" %}</a>
 
-Do not create any organizations during setup. Adding users to organizations assigns {% data variables.product.prodname_enterprise %} licenses, while adding users directly to the enterprise keeps your setup limited to {% data variables.copilot.copilot_business_short %}.
+> [!WARNING]
+> **Do not create an organization during setup.** This enterprise account exists only as a billing and identity container for {% data variables.copilot.copilot_business_short %} licenses - it should have **0 seats of {% data variables.product.prodname_enterprise %}** when you are done.
+>
+> Creating an organization, or adding users to an organization later, will assign {% data variables.product.prodname_enterprise %} licenses and bill your account for {% data variables.product.prodname_enterprise %} - which you do not need for {% data variables.copilot.copilot_business_short %}.
+>
+> Instead, add users **directly to the enterprise** (see the next section). They will receive {% data variables.copilot.copilot_business_short %} licenses without any {% data variables.product.prodname_enterprise %} cost.
+
+This setup is also the recommended path for customers whose code lives outside of {% data variables.product.github %} (for example, on Azure DevOps) and who only want {% data variables.copilot.copilot_business_short %} in the IDE.
 
 ## Add users to your enterprise
 


### PR DESCRIPTION
## Why

Customers setting up a dedicated enterprise account for Copilot Business standalone (no GitHub Enterprise) are repeatedly creating an organization during the trial flow because the warning in the current article is a single, unbolded paragraph buried under the trial button. This results in surprise GitHub Enterprise license assignments and billing, which then has to be walked back via Support.

## What changed

1. Promotes the "do not create an organization" warning to a proper `[!WARNING]` callout so it visually stands out from the surrounding setup instructions.
2. Adds explicit consequence language ("will bill your account for GitHub Enterprise - which you do not need for Copilot Business") so readers understand the cost impact, not just the policy.
3. States the goal-state explicitly: **0 seats of GitHub Enterprise** when setup is complete. This matches language Sales uses with customers and gives readers a self-check.
4. Tells the reader what to do instead (add users directly to the enterprise).
5. Adds one line noting this path is correct for ADO-only / non-GitHub-hosted code customers, which is the most common Copilot Business standalone scenario from the field.

## Signal from the field

Multiple Digital Sales reps and SDRs have flagged this in internal channels when customers ask why they are being billed for GitHub Enterprise they did not intend to buy. There is an internal text expander maintained by Sales that calls this step out as its own bold heading - this PR brings the public docs closer to that internal guidance.

## Preview

Before: one short paragraph easily scrolled past.
After: a `[!WARNING]` callout with bolded directive, consequence, goal-state, and the corrective action.