### PR TITLE
Clarify Dependabot is exempt from IP allow list enforcement

### DIFF
--- a/data/reusables/dependabot/ip-allow-list-dependabot.md
+++ b/data/reusables/dependabot/ip-allow-list-dependabot.md
@@ -1,0 +1,7 @@
+{% data variables.product.prodname_dependabot %} is a first-party {% data variables.product.github %} App whose repository access is exempt from IP allow list restrictions. This means {% data variables.product.prodname_dependabot %} can read dependency files and create pull requests regardless of your IP allow list configuration, even when running on standard {% data variables.product.github %}-hosted runners.
+
+If your {% data variables.product.prodname_dependabot %} workflows require predictable, static IP addresses for other reasons (for example, to access private registries behind a firewall), you should set up a self-hosted runner or enable {% data variables.product.prodname_dependabot %} for use with {% data variables.actions.hosted_runners %}. See [AUTOTITLE](/actions/concepts/runners/about-self-hosted-runners) and [AUTOTITLE](/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners#enabling-or-disabling-dependabot-on-larger-runners).
+
+Additionally, to learn more about setting up {% data variables.actions.hosted_runners %} with a static IP address configured, see [AUTOTITLE](/actions/concepts/runners/about-larger-runners).
+
+To allow your self-hosted runners or {% data variables.actions.hosted_runners %} to communicate with {% data variables.product.github %}, add the IP address or IP address range of your runners to the IP allow list that you have configured for your enterprise.


### PR DESCRIPTION
## Summary

Updates the Dependabot IP allow list documentation to accurately reflect that Dependabot is a first-party GitHub App whose repository access is **exempt from IP allow list restrictions**.

## Why

The current docs state that customers "must set up a self-hosted runner or enable Dependabot for use with larger runners" when using IP allow lists. This is inaccurate for Dependabot's core operations:

- Dependabot is a privileged first-party app with explicit `ip_allowlist_exempt: true` capability
- Its repository access (reading dependency files, creating PRs) bypasses IP allow list enforcement by design
- Customers have observed this working and are confused because the docs say otherwise ([internal ref](https://github.com/github/enterprise-primitives/issues/5258))

## Changes

Rewrites `data/reusables/dependabot/ip-allow-list-dependabot.md` to:

1. **State clearly** that Dependabot's repository access is exempt from IP allow lists
2. **Remove misleading "must" language** about requiring self-hosted/larger runners for basic Dependabot functionality
3. **Keep runner guidance** for other use cases where static IPs are needed (e.g., accessing private package registries behind firewalls)

## What this does NOT cover

The interaction between `GITHUB_TOKEN` in Dependabot workflow steps and IP allow list enforcement is nuanced and not fully documented here. The Actions app has a different exemption scope (`ip_allowlist_exempt_for_internal_apis` only). This PR focuses solely on clarifying Dependabot's own access, which is unambiguously exempt.

## Affected pages

This reusable appears on:
- [Restricting network traffic to your enterprise with an IP allow list](https://docs.github.com/en/enterprise-cloud@latest/admin/configuring-settings/hardening-security-for-your-enterprise/restricting-network-traffic-to-your-enterprise-with-an-ip-allow-list#using-dependabot-with-an-ip-allow-list)