### PR TITLE
Remove unnecessary Community Exchange link

### DIFF
--- a/content/education/about-github-education/github-education-for-students/about-github-community-exchange.md
+++ b/content/education/about-github-education/github-education-for-students/about-github-community-exchange.md
@@ -29,6 +29,4 @@ For more information, see [AUTOTITLE](/education/contribute-with-github-communit
 
 {% data reusables.education.access-github-community-exchange %}
 
-## Further reading
 
-* [AUTOTITLE](/education/contribute-with-github-community-exchange/getting-started-with-github-community-exchange)


### PR DESCRIPTION
Resolves #44615

Removed the circular "Further reading" link from the About GitHub Community Exchange article.