### PR TITLE
docs: remove duplicated "the" typos in five articles

### DIFF
--- a/content/authentication/authenticating-with-single-sign-on/authorizing-an-app-for-single-sign-on.md
+++ b/content/authentication/authenticating-with-single-sign-on/authorizing-an-app-for-single-sign-on.md
@@ -28,7 +28,7 @@ If you sign into an app but it is unable to access an organization you belong to
 1. Under "Single sign-on", find the organization you need to authenticate to, and click **Sign in**.
    If your enterprise manages SSO for your organization, signing in to one organization in the enterprise works as an SSO session for all organizations in the enterprise.
 
-1. Try to sign into the the app again. When you are authorizing the app you will see the organizations you've signed into and be able to request or install the app for those organizations. 
+1. Try to sign into the app again. When you are authorizing the app you will see the organizations you've signed into and be able to request or install the app for those organizations. 
 
 For more information, see [AUTOTITLE](/apps/using-github-apps/installing-a-github-app-from-a-third-party), [AUTOTITLE](/apps/using-github-apps/installing-a-github-app-from-github-marketplace-for-your-organizations), and [AUTOTITLE](/apps/using-github-apps/requesting-a-github-app-from-your-organization-owner).
 

--- a/content/code-security/reference/code-scanning/codeql/codeql-cli/codeql-query-packs.md
+++ b/content/code-security/reference/code-scanning/codeql/codeql-cli/codeql-query-packs.md
@@ -14,7 +14,7 @@ category:
 
 ## {% data variables.product.prodname_codeql %} pack compatibility
 
-When a query pack is published, it includes pre-compiled representations of all the queries in it to increase analysis speed. However, if the version of {% data variables.product.prodname_codeql %} that performs the analysis is over 6 months newer than the the version that ran `codeql pack publish`, it may be necessary to compile the queries from source during analysis, slowing the process significantly.
+When a query pack is published, it includes pre-compiled representations of all the queries in it to increase analysis speed. However, if the version of {% data variables.product.prodname_codeql %} that performs the analysis is over 6 months newer than the version that ran `codeql pack publish`, it may be necessary to compile the queries from source during analysis, slowing the process significantly.
 
 A pack published by the _latest_ public release of {% data variables.product.prodname_codeql %} will be useable by the version of {% data variables.product.prodname_codeql %} that is used by {% data variables.product.prodname_code_scanning %} and {% data variables.product.prodname_actions %}, even though that is often a slightly older release.
 

--- a/content/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-access/disable-for-organizations.md
+++ b/content/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-access/disable-for-organizations.md
@@ -23,7 +23,7 @@ When you disable {% data variables.product.prodname_copilot %} for organizations
 {% data reusables.enterprise-accounts.copilot-licensing %}
 1. Next to "Organization access", choose whether to disable {% data variables.product.prodname_copilot_short %} for all organizations or allow for specific organizations.
 
-   ![Screenshot of the the "Organization access" section, with the dropdown menu highlighted.](/assets/images/help/copilot/organization-access-menu.png)
+   ![Screenshot of the "Organization access" section, with the dropdown menu highlighted.](/assets/images/help/copilot/organization-access-menu.png)
 
 1. If you selected **Allow for specific organizations**:
 

--- a/content/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-access/grant-access.md
+++ b/content/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-access/grant-access.md
@@ -53,7 +53,7 @@ If your enterprise has a {% data variables.copilot.copilot_enterprise_short %} p
 {% data reusables.enterprise-accounts.copilot-licensing %}
 1. Next to "Organization access", choose whether to enable {% data variables.product.prodname_copilot_short %} for all organizations or allow for specific organizations.
 
-   ![Screenshot of the the "Organization access" section, with the dropdown menu highlighted.](/assets/images/help/copilot/organization-access-menu.png)
+   ![Screenshot of the "Organization access" section, with the dropdown menu highlighted.](/assets/images/help/copilot/organization-access-menu.png)
 
 1. If you selected **Allow for specific organizations**:
     1. Click the **{% octicon "organization" aria-hidden="true" aria-label="organization" %} Organizations** tab.

--- a/content/migrations/elm/migrated-data-reference.md
+++ b/content/migrations/elm/migrated-data-reference.md
@@ -154,4 +154,4 @@ The following are exported during initial backfill only and are **not** updated 
 
 References **within the source repository**, such as user mentions or links to issues and pull requests in the same repository, are rewritten so that they will still point to the correct resources after migration.
 
-References to **different repositories** (such as a link to an issue in the the `repo-2` repository from a pull request in `repo-1`) are **not** migrated and will point to the exact same destination after migration. This applies even if the referenced repository has already been migrated or is being migrated concurrently.
+References to **different repositories** (such as a link to an issue in the `repo-2` repository from a pull request in `repo-1`) are **not** migrated and will point to the exact same destination after migration. This applies even if the referenced repository has already been migrated or is being migrated concurrently.


### PR DESCRIPTION
## Summary

Fix duplicated word typos (`the the`) in five documentation articles.

## Problem

Several pages contain duplicated articles (`the the`), which reads unprofessional and can confuse readers.

## Fix

Replace `the the` → `the` in:

- `content/authentication/.../authorizing-an-app-for-single-sign-on.md`
- `content/code-security/.../codeql-query-packs.md`
- `content/copilot/.../grant-access.md`
- `content/copilot/.../disable-for-organizations.md`
- `content/migrations/elm/migrated-data-reference.md`

## Testing

- `rg 'the the ' content --glob '*.md'` — no matches in changed files
- Docs-only change; no runtime impact