### PR TITLE
Add agent finder section to MCP management concept

### DIFF
--- a/content/copilot/concepts/mcp-management.md
+++ b/content/copilot/concepts/mcp-management.md
@@ -47,6 +47,12 @@ MCP management features are supported as follows:
 > [!NOTE]
 > For Eclipse, JetBrains, and Xcode, MCP management features are supported in the pre-release versions of {% data variables.product.prodname_copilot_short %}.
 
+## Agent finder
+
+Agent finder is a discovery service that helps {% data variables.product.prodname_copilot_short %} find the right capabilities—such as MCP servers, tools, agents, and skills—for a task at runtime, instead of requiring every capability to be configured in advance. Like an MCP registry, it searches a registry you choose—a curated public catalog or your own private registry—and returns ranked matches that {% data variables.product.prodname_copilot_short %} can use on demand. Agent finder implements the open Agentic Resource Discovery (ARD) specification.
+
+You control what agent finder can surface through managed settings for {% data variables.product.prodname_copilot_short %}, and it never installs anything on its own.
+
 ## Next steps
 
 To create your own MCP registry, see [AUTOTITLE](/copilot/how-tos/administer-copilot/manage-mcp-usage/configure-mcp-registry).


### PR DESCRIPTION
_GitHub Copilot generated this pull request._

<details><summary>Prompt summary - submitted by @meagancojocar</summary>

> Restore the preserved "Agent finder" concept page work, then review and polish it against the docs style guide. Keep it minimal and non-prominent: this is a GA feature that needs some docs but isn't expected to be around long, so avoid a standalone page or navigation entry if the content can be folded into an existing page. Reference the release issue in the PR and give context on the release issue and the blog issue.

</details>

## What this does

Adds a short **Agent finder** section to the existing MCP management concept page (`content/copilot/concepts/mcp-management.md`) instead of creating a standalone, prominent concept page.

Agent finder is shipping as GA but is intended to stay low-profile, so rather than a dedicated page with its own navigation entry, the content is folded into the MCP management page—which already covers registry-based discovery and admin governance, the closest existing home. The section stays discoverable via search without adding a top-level concept.

## Context

* **Release issue:** towards github/docs-content#22969 — "[2026-06-17] GitHub AgentFinder: a standardized way to catalog, discover, and search AI capabilities". Auto-opened from the release issue github/releases#9618; stakeholder @meagancojocar; expected ship date 2026-06-17. Labeled `new-release` and `builder persona`.
* **Changelog / blog:** Announced in github/blog#9730 ("Agent finder: GitHub Copilot discovers the right tools for each task"). Agent finder implements the open **Agentic Resource Discovery (ARD)** specification, developed with partners Google, GoDaddy, Hugging Face, and Microsoft, and is timed to publish alongside Microsoft's ARD specification announcement.

## Notes

* No standalone page and no `content/copilot/concepts/index.md` navigation entry were added; the previously drafted standalone page was intentionally removed to keep the feature non-prominent.
* The content linter passes.

_Opened by GitHub Copilot on behalf of @meagancojocar._
