### PR TITLE
Note Ruby incompability with Jekyll for GitHub Pages

### DIFF
--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md
@@ -54,7 +54,7 @@ Before you can use Jekyll to test a site, you must:
    >
    >   To fix the error, try running `bundle add webrick`, then re-running `bundle exec jekyll serve`.
    >
-   >   You might get other errors (related to missing gems and methods) if you've installed Ruby 3.2 or later. It is recommended to install Ruby 3.1.x or earlier instead due to compatibility issues with the `github-pages` gem.
+   >   If you've installed Ruby 3.2 or later, you may see other errors related to missing gems and methods, due to compatibility issues with the `github-pages` gem. In this event, you should install Ruby 3.1.x or earlier instead.
    >
    > * If your `_config.yml` file's `baseurl` field contains your GitHub repository's link, you can use the following command when building locally to ignore that value and serve the site on `localhost:4000/`:
    >

--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md
@@ -54,6 +54,8 @@ Before you can use Jekyll to test a site, you must:
    >
    >   To fix the error, try running `bundle add webrick`, then re-running `bundle exec jekyll serve`.
    >
+   >   You might get other errors (related to missing gems and deprecated methods) if you've installed Ruby 3.2 or later. It is recommended to install Ruby 3.1.x or earlier instead due to compatibility issues with the `github-pages` gem.
+   >
    > * If your `_config.yml` file's `baseurl` field contains your GitHub repository's link, you can use the following command when building locally to ignore that value and serve the site on `localhost:4000/`:
    >
    >   ```shell

--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md
@@ -54,7 +54,7 @@ Before you can use Jekyll to test a site, you must:
    >
    >   To fix the error, try running `bundle add webrick`, then re-running `bundle exec jekyll serve`.
    >
-   >   You might get other errors (related to missing gems and deprecated methods) if you've installed Ruby 3.2 or later. It is recommended to install Ruby 3.1.x or earlier instead due to compatibility issues with the `github-pages` gem.
+   >   You might get other errors (related to missing gems methods) if you've installed Ruby 3.2 or later. It is recommended to install Ruby 3.1.x or earlier instead due to compatibility issues with the `github-pages` gem.
    >
    > * If your `_config.yml` file's `baseurl` field contains your GitHub repository's link, you can use the following command when building locally to ignore that value and serve the site on `localhost:4000/`:
    >

--- a/content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md
+++ b/content/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll.md
@@ -54,7 +54,7 @@ Before you can use Jekyll to test a site, you must:
    >
    >   To fix the error, try running `bundle add webrick`, then re-running `bundle exec jekyll serve`.
    >
-   >   You might get other errors (related to missing gems methods) if you've installed Ruby 3.2 or later. It is recommended to install Ruby 3.1.x or earlier instead due to compatibility issues with the `github-pages` gem.
+   >   You might get other errors (related to missing gems and methods) if you've installed Ruby 3.2 or later. It is recommended to install Ruby 3.1.x or earlier instead due to compatibility issues with the `github-pages` gem.
    >
    > * If your `_config.yml` file's `baseurl` field contains your GitHub repository's link, you can use the following command when building locally to ignore that value and serve the site on `localhost:4000/`:
    >


### PR DESCRIPTION
### Why:

Closes: #44808

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Added a note for the user to install an earlier version of Ruby like 3.1.x if they are using Ruby 3.2 or later to test their GitHub Pages site locally with Jekyll due to errors produced by `bundle exec jekyll serve` described in the related issue.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
