### PR TITLE
Fix markdown error in attaching-files.md

### DIFF
--- a/content/get-started/writing-on-github/working-with-advanced-formatting/attaching-files.md
+++ b/content/get-started/writing-on-github/working-with-advanced-formatting/attaching-files.md
@@ -68,7 +68,7 @@ The following file types are supported for uploads in issue comments, pull reque
 ### Documents
 
 * PDFs (`.pdf`)
-* Microsoft Office documents (`.docx`, `.pptx`, `.xlsx`, `.xls`{% ifversion fpt or ghec or ghes > 3.18 %}` ,.xlsm`{% endif %})
+* Microsoft Office documents (`.docx`, `.pptx`, `.xlsx`, `.xls`{% ifversion fpt or ghec or ghes > 3.18 %}, `.xlsm`{% endif %})
 {%- ifversion fpt or ghec or ghes > 3.18 %}
 * OpenDocument formats (`.odt`, `.fodt`, `.ods`, `.fods`, `.odp`, `.fodp`, `.odg`, `.fodg`, `.odf`)
 * Rich text and word processing files (`.rtf`, `.doc`)


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: None

Fix a minor markdown rendering glitch in the "Attaching files" document. The misplaced backticks around `.xls` and `.xlsm` caused the inline code blocks to parse incorrectly on the live site.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fixed the backtick formatting for Microsoft Office file extensions in `content/get-started/writing-on-github/working-with-advanced-formatting/attaching-files.md`.

- Before: `... , .xls`` ,.xlsm`
- After: `... , .xls, .xlsm` (properly enclosed in backticks)

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
