### PR TITLE
Modernize the Swift CI tutorial (current Swift versions, refreshed pins, cross-platform guidance)

### DIFF
--- a/content/actions/tutorials/build-and-test-code/swift.md
+++ b/content/actions/tutorials/build-and-test-code/swift.md
@@ -107,10 +107,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        swift: ["5.2", "5.3"]
+        swift: ["6.1", "6.2", "6.3"]
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
     steps:
-      - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+      - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
         with:
           swift-version: {% raw %}${{ matrix.swift }}{% endraw %}
       - uses: {% data reusables.actions.action-checkout %}
@@ -122,16 +122,16 @@ jobs:
 
 ### Using a single specific Swift version
 
-You can configure your job to use a single specific version of Swift, such as `5.3.3`.
+You can configure your job to use a single specific version of Swift, such as `6.3`.
 
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
 steps:
-  - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+  - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
     with:
-      swift-version: "5.3.3"
+      swift-version: "6.3"
   - name: Get swift version
-    run: swift --version # Swift 5.3.3
+    run: swift --version # Swift 6.3
 ```
 
 ## Building and testing your code
@@ -142,11 +142,283 @@ You can use the same commands that you use locally to build and test your code u
 {% data reusables.actions.actions-not-certified-by-github-comment %}
 steps:
   - uses: {% data reusables.actions.action-checkout %}
-  - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+  - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
     with:
-      swift-version: "5.3.3"
+      swift-version: "6.3"
   - name: Build
     run: swift build
   - name: Run tests
     run: swift test
+```
+
+## Building and testing on Linux with a container
+
+On {% data variables.product.prodname_dotcom %}-hosted Linux runners, you can run your job inside an official Swift container image, which already includes the Swift toolchain. This means you don't need a separate step to install Swift.
+
+Released Swift versions are published as the [`swift`](https://hub.docker.com/_/swift) official images on Docker Hub (for example, `swift:6.3` or `swift:6.3-noble`). To test against unreleased toolchains, use the nightly snapshot images published as [`swiftlang/swift`](https://hub.docker.com/r/swiftlang/swift) (for example, `swiftlang/swift:nightly-main` or `swiftlang/swift:nightly-6.2-noble`). For more information, see [Swift on Docker](https://www.swift.org/documentation/docker/) on Swift.org.
+
+```yaml copy
+name: Swift
+
+on: [push]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container: swift:6.3
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test
+```
+
+To test against a nightly toolchain, use a `swiftlang/swift` snapshot image instead.
+
+```yaml copy
+name: Swift
+
+on: [push]
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    container: swiftlang/swift:nightly-main
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test
+```
+
+## Building and testing for Apple platforms with Xcode
+
+To build and test for a specific Apple platform such as iOS, watchOS, tvOS, or visionOS, use `xcodebuild` on a macOS runner and select a simulator with the `-destination` option. {% data variables.product.prodname_dotcom %}-hosted macOS runners come with Xcode and Apple platform simulators preinstalled. To check which Xcode versions, platform SDKs, OS versions, and simulators are available on each macOS runner, see [AUTOTITLE](/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software).
+
+```yaml copy
+name: Swift
+
+on: [push]
+
+jobs:
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - name: Build and test for iOS
+        run: |
+          xcodebuild test \
+            -scheme MyPackage \
+            -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.5'
+```
+
+To target a different platform, change the `-destination` value. For example, use `platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)`, `platform=tvOS Simulator,name=Apple TV`, `platform=visionOS Simulator,name=Apple Vision Pro`, or `platform=macOS` for native macOS. To select a specific installed Xcode version, run `sudo xcode-select -s /Applications/Xcode_16.4.app` before building.
+
+If you target a platform whose simulator runtime is not preinstalled on the runner, the build fails until the runtime is available. Download it first with `xcodebuild -downloadPlatform iOS` (replacing `iOS` with the platform you need), or choose a simulator and OS version that the runner already provides.
+
+## Building and testing on Windows
+
+To build and test on Windows, install the Swift toolchain with the [`compnerd/gha-setup-swift`](https://github.com/compnerd/gha-setup-swift) action, then run `swift build` and `swift test`.
+
+```yaml copy
+
+{% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
+name: Swift
+
+on: [push]
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: compnerd/gha-setup-swift@eeda069c5bc95ac8a9ac5cea7d4f588ae5420ca5 # v0.4.0
+        with:
+          swift-version: swift-6.3-release
+          swift-build: 6.3-RELEASE
+      - uses: {% data reusables.actions.action-checkout %}
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test
+```
+
+## Building and testing on Android
+
+To build and test on Android, use the [`skiptools/swift-android-action`](https://github.com/skiptools/swift-android-action) action, which installs the Swift SDK for Android and can run your tests on an emulator.
+
+```yaml copy
+
+{% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
+name: Swift
+
+on: [push]
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - uses: skiptools/swift-android-action@2044b79660f201ccef8cbce62877e4ec5409f9c8 # v2.9.5
+        with:
+          swift-version: "6.3"
+          android-api-level: 28
+```
+
+## Building and testing across multiple platforms with one action
+
+If you want to build and test across several of the platforms above from a single workflow, you can use a community action that wraps the platform-specific setup. For example, the [`brightdigit/swift-build`](https://github.com/brightdigit/swift-build) action can target macOS, Linux, Windows, Apple devices (iOS, watchOS, tvOS, and visionOS), Android, and WebAssembly, selected with its `type` input. It uses `xcodebuild` for Apple platforms, [`compnerd/gha-setup-swift`](https://github.com/compnerd/gha-setup-swift) for Windows, and [`skiptools/swift-android-action`](https://github.com/skiptools/swift-android-action) for Android.
+
+```yaml copy
+
+{% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
+name: Swift
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - uses: brightdigit/swift-build@b0a63a89ea85b47a8b43dff122e12856ad661f33 # v1.5.7
+        with:
+          scheme: MyPackage
+```
+
+### Apple platforms
+
+To target a specific Apple platform, set the `type` input (`ios`, `watchos`, `tvos`, `visionos`, or `macos`) and, for simulator-based platforms, the `deviceName` and `osVersion`. To check which simulators and OS versions are preinstalled on each macOS runner, see [AUTOTITLE](/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software). If the simulator runtime you request is not already installed on the runner, set `download-platform: true` so the action downloads it before testing.
+
+```yaml copy
+
+{% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
+name: Swift
+
+on: [push]
+
+jobs:
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - uses: brightdigit/swift-build@b0a63a89ea85b47a8b43dff122e12856ad661f33 # v1.5.7
+        with:
+          scheme: MyPackage
+          type: ios
+          deviceName: iPhone 15
+          osVersion: "17.5"
+          download-platform: true
+```
+
+### Linux
+
+On Linux, run the action inside an official Swift container image.
+
+```yaml copy
+
+{% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
+name: Swift
+
+on: [push]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container: swift:6.3
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - uses: brightdigit/swift-build@b0a63a89ea85b47a8b43dff122e12856ad661f33 # v1.5.7
+        with:
+          scheme: MyPackage
+```
+
+### Windows
+
+```yaml copy
+
+{% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
+name: Swift
+
+on: [push]
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - uses: brightdigit/swift-build@b0a63a89ea85b47a8b43dff122e12856ad661f33 # v1.5.7
+        with:
+          windows-swift-version: swift-6.3-release
+          windows-swift-build: 6.3-RELEASE
+```
+
+### Android
+
+```yaml copy
+
+{% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
+name: Swift
+
+on: [push]
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - uses: brightdigit/swift-build@b0a63a89ea85b47a8b43dff122e12856ad661f33 # v1.5.7
+        with:
+          scheme: MyPackage
+          type: android
+          android-swift-version: "6.3"
+          android-api-level: "28"
+```
+
+### WebAssembly
+
+WebAssembly builds require Swift 6.2.3 or later. Run the action inside a Swift container image and set `type` to `wasm`.
+
+```yaml copy
+
+{% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
+name: Swift
+
+on: [push]
+
+jobs:
+  wasm:
+    runs-on: ubuntu-latest
+    container: swift:6.3-jammy
+    steps:
+      - uses: {% data reusables.actions.action-checkout %}
+      - uses: brightdigit/swift-build@b0a63a89ea85b47a8b43dff122e12856ad661f33 # v1.5.7
+        with:
+          scheme: MyPackage
+          type: wasm
 ```

--- a/content/actions/tutorials/build-and-test-code/swift.md
+++ b/content/actions/tutorials/build-and-test-code/swift.md
@@ -126,6 +126,9 @@ You can configure your job to use a single specific version of Swift, such as `6
 
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
 steps:
   - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
     with:
@@ -140,6 +143,9 @@ You can use the same commands that you use locally to build and test your code u
 
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
+
+{% data reusables.actions.actions-use-sha-pinning-comment %}
+
 steps:
   - uses: {% data reusables.actions.action-checkout %}
   - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
@@ -195,7 +201,7 @@ jobs:
 
 ## Building and testing for Apple platforms with Xcode
 
-To build and test for a specific Apple platform such as iOS, watchOS, tvOS, or visionOS, use `xcodebuild` on a macOS runner and select a simulator with the `-destination` option. {% data variables.product.prodname_dotcom %}-hosted macOS runners come with Xcode and Apple platform simulators preinstalled. To check which Xcode versions, platform SDKs, OS versions, and simulators are available on each macOS runner, see [AUTOTITLE](/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software).
+To build and test for a specific Apple platform such as iOS, watchOS, tvOS, or visionOS, use `xcodebuild` on a macOS runner and select a simulator with the `-destination` option. {% data variables.product.prodname_dotcom %}-hosted macOS runners come with Xcode and Apple platform simulators preinstalled. To check which Xcode versions, platform SDKs, OS versions, and simulators are available on each macOS runner, see [AUTOTITLE](/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software), or open the README for the macOS version you want in the [{% data variables.product.prodname_actions %} Runner Images repository](https://github.com/actions/runner-images/tree/main/images/macos). For the runner labels you can use with `runs-on` (for example, `macos-15`, `macos-14`, or `macos-13`), see [AUTOTITLE](/actions/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).
 
 ```yaml copy
 name: Swift
@@ -298,7 +304,7 @@ jobs:
 
 ### Apple platforms
 
-To target a specific Apple platform, set the `type` input (`ios`, `watchos`, `tvos`, `visionos`, or `macos`) and, for simulator-based platforms, the `deviceName` and `osVersion`. To check which simulators and OS versions are preinstalled on each macOS runner, see [AUTOTITLE](/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software). If the simulator runtime you request is not already installed on the runner, set `download-platform: true` so the action downloads it before testing.
+To target a specific Apple platform, set the `type` input (`ios`, `watchos`, `tvos`, `visionos`, or `macos`) and, for simulator-based platforms, the `deviceName` and `osVersion`. To check which simulators and OS versions are preinstalled on each macOS runner, see [AUTOTITLE](/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software), or open the README for the macOS version you want in the [{% data variables.product.prodname_actions %} Runner Images repository](https://github.com/actions/runner-images/tree/main/images/macos). If the simulator runtime you request is not already installed on the runner, set `download-platform: true` so the action downloads it before testing.
 
 ```yaml copy
 

--- a/content/actions/tutorials/build-and-test-code/swift.md
+++ b/content/actions/tutorials/build-and-test-code/swift.md
@@ -159,7 +159,7 @@ steps:
 
 ## Building and testing on Linux with a container
 
-On {% data variables.product.prodname_dotcom %}-hosted Linux runners, you can run your job inside an official Swift container image, which already includes the Swift toolchain. This means you don't need a separate step to install Swift.
+On {% data variables.product.prodname_dotcom %}-hosted Linux runners, you can run your job inside an official Swift container image, that includes the Swift toolchain. With these images, you don't need a separate step to install Swift.
 
 Released Swift versions are published as the [`swift`](https://hub.docker.com/_/swift) official images on Docker Hub (for example, `swift:6.3` or `swift:6.3-noble`). To test against unreleased toolchains, use the nightly snapshot images published as [`swiftlang/swift`](https://hub.docker.com/r/swiftlang/swift) (for example, `swiftlang/swift:nightly-main` or `swiftlang/swift:nightly-6.2-noble`). For more information, see [Swift on Docker](https://www.swift.org/documentation/docker/) on Swift.org.
 


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs/issues/44868

The "Building and testing Swift" tutorial had aged out of date — examples pinned Swift 5.2/5.3/5.3.3 and referenced `swift-actions/setup-swift` at a 2021 commit, and the page covered only Ubuntu/macOS `swift build` / `swift test`. This PR refreshes the tutorial and adds current cross-platform guidance.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

File: `content/actions/tutorials/build-and-test-code/swift.md`

- **Updated Swift versions** — matrix → `["6.1", "6.2", "6.3"]`, single version → `"6.3"` (current GA release).
- **Refreshed the `swift-actions/setup-swift` pin** from the 2021 commit to v2.4.0 (`7ca6abe…`), keeping the existing not-certified-by-GitHub notice and SHA-pinning reusables.
- **New section: Building and testing on Linux with a container** — uses the official [`swift`](https://hub.docker.com/_/swift) release images, and links the [`swiftlang/swift`](https://hub.docker.com/r/swiftlang/swift) nightly images, with a nightly example.
- **New section: Building and testing for Apple platforms with Xcode** — native `xcodebuild` + simulator `-destination` (no third-party action), notes how to check the runner's available Xcode/SDKs/simulators, and how to download a missing simulator runtime (`xcodebuild -downloadPlatform`).
- **New section: Building and testing on Windows** — uses [`compnerd/gha-setup-swift`](https://github.com/compnerd/gha-setup-swift) (`eeda069…`, v0.4.0).
- **New section: Building and testing on Android** — uses [`skiptools/swift-android-action`](https://github.com/skiptools/swift-android-action) (`2044b79…`, v2.9.5).
- **New section: Building and testing across multiple platforms with one action** — [`brightdigit/swift-build`](https://github.com/brightdigit/swift-build) (`b0a63a8…`, v1.5.7), shown as a wrapper over the platform setup above, with per-platform examples (Apple, Linux, Windows, Android, WebAssembly) and the `download-platform` input.

All third-party examples carry the page's standard `actions-not-certified-by-github-comment` notice and are SHA-pinned per `actions-use-sha-pinning-comment`.

### Disclosure

I'm the maintainer of [`brightdigit/swift-build`](https://github.com/brightdigit/swift-build). I've kept its mention neutral and placed it after the native/per-platform approaches (Xcode, `compnerd/gha-setup-swift`, `skiptools/swift-android-action`), in the same spirit the page already references `swift-actions/setup-swift`. If the team prefers a lighter touch, I'm glad to trim the multi-platform section down to a single neutral mention, or drop it entirely and keep just the version/pin/Linux modernization.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.

---

### Section outline after this change

- Introduction / Prerequisites / Using a Swift workflow template (unchanged)
- Specifying a Swift version → Using multiple Swift versions / Using a single specific Swift version (versions + pin refreshed)
- Building and testing your code (versions + pin refreshed)
- Building and testing on Linux with a container *(new)*
- Building and testing for Apple platforms with Xcode *(new)*
- Building and testing on Windows *(new)*
- Building and testing on Android *(new)*
- Building and testing across multiple platforms with one action *(new)* → Apple platforms / Linux / Windows / Android / WebAssembly
