### PR TITLE
[Open Source 2.0] Glossary - Update open source - change 'working materials' to 'source files'

### DIFF
--- a/data/glossaries/external.yml
+++ b/data/glossaries/external.yml
@@ -473,7 +473,7 @@
     Open source software is software that can be freely used, modified, and
     shared (in both modified and unmodified form) by anyone. Today the concept
     of "open source" is often extended beyond software, to represent a
-    philosophy of collaboration in which working materials are made available
+    philosophy of collaboration in which source files are made available
     online for anyone to fork, modify, discuss, and contribute to.
 - term: organization
   description: >-

--- a/data/glossaries/external.yml
+++ b/data/glossaries/external.yml
@@ -473,7 +473,7 @@
     Open source software is software that can be freely used, modified, and
     shared (in both modified and unmodified form) by anyone. Today the concept
     of "open source" is often extended beyond software, to represent a
-    philosophy of collaboration in which source files are made available
+    philosophy of collaboration in which source files of digital resources are made available
     online for anyone to fork, modify, discuss, and contribute to.
 - term: organization
   description: >-


### PR DESCRIPTION
[*Following the article « [Open source, not just software anymore](https://ben.balter.com/2014/01/27/open-collaboration/) » by @benbalter and <https://github.com/benbalter/benbalter.github.com/pull/98> which leads to the current state of the definition in your glossary.*]

### Why:

Hello, I propose an update to the definition of open source in the glossary, replacing 'working materials' to 'source files'. This is related to a citizen research I did on the meaning of open source, published in the preprint « *[Open Source 2.0: From Open Source Software to Open Source Resources?](https://doi.org/10.5281/zenodo.20237079)* ».

It supports the idea that open source is slowly derivating from source files in other openness movements (such as « [Open Source Educational Resources](https://arxiv.org/abs/2107.14330) » in extension to OER in open education).

This update could bring more consistency to the existing definition while being based on research.

> **Open Source Resource:** a digital resource made publicly available alongside its source files.