### PR TITLE
docs(actions): use GiB for runner capacity tables

### DIFF
--- a/content/actions/reference/runners/larger-runners.md
+++ b/content/actions/reference/runners/larger-runners.md
@@ -29,16 +29,16 @@ You can choose from several specifications for {% data variables.actions.hosted_
 
 | CPU | Memory (RAM)  | Storage (SSD) | Architecture | Operating system (OS) |
 | --- | ------------- | ------------- | ------------ | --------------------- |
-| 5   | 14 GB         | 14 GB         | arm64 (M2)   | macOS                 |
-| 12  | 30 GB         | 14 GB         | x64 (Intel)  | macOS                 |
-| 2   | 8 GB          | 75 GB         | x64, arm64   | Ubuntu                |
-| 4   | 16 GB         | 150 GB        | x64, arm64   | Ubuntu, Windows       |
-| 8   | 32 GB         | 300 GB        | x64, arm64   | Ubuntu, Windows       |
-| 16  | 64 GB         | 600 GB        | x64, arm64   | Ubuntu, Windows       |
-| 32  | 128 GB        | 1200 GB       | x64, arm64   | Ubuntu, Windows       |
-| 64  | 208 GB        | 2040 GB       | arm64        | Ubuntu, Windows       |
-| 64  | 256 GB        | 2040 GB       | x64          | Ubuntu, Windows       |
-| 96 | 384 GB         | 2040 GB       | x64          | Ubuntu, Windows        |
+| 5   | 14 GiB         | 14 GiB         | arm64 (M2)   | macOS                 |
+| 12  | 30 GiB         | 14 GiB         | x64 (Intel)  | macOS                 |
+| 2   | 8 GiB          | 75 GiB         | x64, arm64   | Ubuntu                |
+| 4   | 16 GiB         | 150 GiB        | x64, arm64   | Ubuntu, Windows       |
+| 8   | 32 GiB         | 300 GiB        | x64, arm64   | Ubuntu, Windows       |
+| 16  | 64 GiB         | 600 GiB        | x64, arm64   | Ubuntu, Windows       |
+| 32  | 128 GiB        | 1200 GiB       | x64, arm64   | Ubuntu, Windows       |
+| 64  | 208 GiB        | 2040 GiB       | arm64        | Ubuntu, Windows       |
+| 64  | 256 GiB        | 2040 GiB       | x64          | Ubuntu, Windows       |
+| 96 | 384 GiB         | 2040 GiB       | x64          | Ubuntu, Windows        |
 
 > [!NOTE] The 4-vCPU Windows runner only works with the Windows Server 2025 or the Base Windows 11 Desktop image.
 
@@ -46,7 +46,7 @@ You can choose from several specifications for {% data variables.actions.hosted_
 
 | CPU | GPU | GPU card | Memory (RAM) | GPU memory (VRAM) | Storage (SSD) | Operating system (OS) |
 | --- | --- | -------- | ------------ | ----------------- | ------------- | --------------------- |
-| 4   | 1   | Tesla T4 | 28 GB        | 16 GB             | 176 GB        | Ubuntu, Windows       |
+| 4   | 1   | Tesla T4 | 28 GiB        | 16 GiB             | 176 GiB        | Ubuntu, Windows       |
 
 ## Runner images
 

--- a/data/reusables/actions/larger-runners-table.md
+++ b/data/reusables/actions/larger-runners-table.md
@@ -1,4 +1,4 @@
 | Runner Size | Architecture| Processor (CPU)| Memory (RAM)  | Storage (SSD) | Workflow label                                                                                                                                   |
 | ------------| ------------| -------------- | ------------- | ------------- |--------------------------------------------------------------------------------------------------------------------------------------------------|
-| Large       | Intel       | 12             | 30 GB         | 14 GB         | <code>macos-latest-large</code>, <code>macos-14-large</code>, <code>macos-15-large</code> (latest), <code>macos-26-large</code> |
-| XLarge      | arm64 (M2)  | 5 (+ 8 GPU hardware acceleration) | 14 GB         | 14 GB         | <code>macos-latest-xlarge</code>, <code>macos-14-xlarge</code>, <code>macos-15-xlarge</code> (latest), <code>macos-26-xlarge</code> |
+| Large       | Intel       | 12             | 30 GiB         | 14 GiB         | <code>macos-latest-large</code>, <code>macos-14-large</code>, <code>macos-15-large</code> (latest), <code>macos-26-large</code> |
+| XLarge      | arm64 (M2)  | 5 (+ 8 GPU hardware acceleration) | 14 GiB         | 14 GiB         | <code>macos-latest-xlarge</code>, <code>macos-14-xlarge</code>, <code>macos-15-xlarge</code> (latest), <code>macos-26-xlarge</code> |

--- a/data/reusables/actions/single-cpu-table-row.md
+++ b/data/reusables/actions/single-cpu-table-row.md
@@ -1,8 +1,8 @@
     <tr>
       <td>Linux</td>
       <td>1</td>
-      <td>5 GB</td>
-      <td>14 GB</td>
+      <td>5 GiB</td>
+      <td>14 GiB</td>
       <td> x64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md">ubuntu-slim</a></code>

--- a/data/reusables/actions/supported-github-runners.md
+++ b/data/reusables/actions/supported-github-runners.md
@@ -18,8 +18,8 @@ For public repositories, jobs using the workflow labels shown in the table below
     <tr>
       <td>Linux</td>
       <td>4</td>
-      <td>16 GB</td>
-      <td>14 GB</td>
+      <td>16 GiB</td>
+      <td>14 GiB</td>
       <td> x64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md">ubuntu-latest</a></code>,
@@ -31,8 +31,8 @@ For public repositories, jobs using the workflow labels shown in the table below
     <tr>
       <td>Windows</td>
       <td>4</td>
-      <td>16 GB</td>
-      <td>14 GB</td>
+      <td>16 GiB</td>
+      <td>14 GiB</td>
       <td> x64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md">windows-latest</a></code>,
@@ -44,8 +44,8 @@ For public repositories, jobs using the workflow labels shown in the table below
     <tr>
       <td>Linux</td>
       <td>4</td>
-      <td>16 GB</td>
-      <td>14 GB</td>
+      <td>16 GiB</td>
+      <td>14 GiB</td>
       <td> arm64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md">ubuntu-24.04-arm</a></code>,
@@ -56,8 +56,8 @@ For public repositories, jobs using the workflow labels shown in the table below
     <tr>
       <td>Windows</td>
       <td>4</td>
-      <td>16 GB</td>
-      <td>14 GB</td>
+      <td>16 GiB</td>
+      <td>14 GiB</td>
       <td>arm64</td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/windows/Windows11-Arm64-Readme.md">windows-11-arm</a></code>,
@@ -67,8 +67,8 @@ For public repositories, jobs using the workflow labels shown in the table below
     <tr>
       <td>macOS</td>
       <td>4</td>
-      <td>14 GB</td>
-      <td>14 GB</td>
+      <td>14 GiB</td>
+      <td>14 GiB</td>
       <td> Intel </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md">macos-15-intel</a></code>,
@@ -78,8 +78,8 @@ For public repositories, jobs using the workflow labels shown in the table below
     <tr>
       <td>macOS</td>
       <td>3 (M1)</td>
-      <td>7 GB</td>
-      <td>14 GB</td>
+      <td>7 GiB</td>
+      <td>14 GiB</td>
       <td> arm64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md">macos-latest</a></code>,
@@ -112,8 +112,8 @@ For {% ifversion ghec %}internal and{% endif %} private repositories, jobs using
     <tr>
       <td>Linux</td>
       <td>2</td>
-      <td>8 GB</td>
-      <td>14 GB</td>
+      <td>8 GiB</td>
+      <td>14 GiB</td>
       <td> x64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md">ubuntu-latest</a></code>,
@@ -125,8 +125,8 @@ For {% ifversion ghec %}internal and{% endif %} private repositories, jobs using
     <tr>
       <td>Windows</td>
       <td>2</td>
-      <td>8 GB</td>
-      <td>14 GB</td>
+      <td>8 GiB</td>
+      <td>14 GiB</td>
       <td> x64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md">windows-latest</a></code>,
@@ -137,8 +137,8 @@ For {% ifversion ghec %}internal and{% endif %} private repositories, jobs using
     <tr>
       <td>Linux</td>
       <td>2</td>
-      <td>8 GB</td>
-      <td>14 GB</td>
+      <td>8 GiB</td>
+      <td>14 GiB</td>
       <td> arm64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Arm64-Readme.md">ubuntu-24.04-arm</a></code>,
@@ -149,8 +149,8 @@ For {% ifversion ghec %}internal and{% endif %} private repositories, jobs using
     <tr>
       <td>Windows</td>
       <td>2</td>
-      <td>8 GB</td>
-      <td>14 GB</td>
+      <td>8 GiB</td>
+      <td>14 GiB</td>
       <td> arm64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/windows/Windows11-Arm64-Readme.md">windows-11-arm</a></code>,
@@ -160,8 +160,8 @@ For {% ifversion ghec %}internal and{% endif %} private repositories, jobs using
     <tr>
       <td>macOS</td>
       <td>4</td>
-      <td>14 GB</td>
-      <td>14 GB</td>
+      <td>14 GiB</td>
+      <td>14 GiB</td>
       <td> Intel </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md">macos-15-intel</a></code>,
@@ -171,8 +171,8 @@ For {% ifversion ghec %}internal and{% endif %} private repositories, jobs using
     <tr>
       <td>macOS</td>
       <td>3 (M1)</td>
-      <td>7 GB</td>
-      <td>14 GB</td>
+      <td>7 GiB</td>
+      <td>14 GiB</td>
       <td> arm64 </td>
       <td>
         <code><a href="https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md">macos-latest</a></code>,


### PR DESCRIPTION
## Summary
- use `GiB` instead of `GB` in GitHub-hosted runner capacity tables where the values describe binary-sized memory and storage resources
- update the shared reusable tables so the terminology stays consistent across the runner reference docs
- align the larger runners reference with the same unit terminology

Closes #44033
