### PR TITLE
Fix broken cross-links in documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for investing your time in contributing to our project! Any contributi
 
 **📖 For comprehensive contribution guidance, please visit our official documentation at [docs.github.com/en/contributing](https://docs.github.com/en/contributing). This is our canonical source for all contribution processes and policies.**
 
-Read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
+Read our [Code of Conduct](/.github/CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
 
 This guide provides repository-specific information to supplement the official contribution documentation. For detailed processes, policies, and best practices, always refer to [docs.github.com/en/contributing](https://docs.github.com/en/contributing).
 


### PR DESCRIPTION
# Pull Request: Fix broken cross-links in documentation

## Description
This PR updates internal links within `CONTRIBUTING.md` to use **root-relative paths**. 

Previously, relative links (e.g., `./CODE_OF_CONDUCT.md`) broke when viewed via the GitHub repository's "Contributing" overview tab. This is because that tab renders content at the root level, causing relative paths to resolve incorrectly. 

By switching to root-relative paths (starting with `/`), these links now resolve correctly in both:
1.  **The Blob view** (file-specific context).
2.  **The Overview tab** (repository-root context).

This approach also maintains full compatibility with local editor previews (e.g., VS Code).

## Changes
- **File:** `.github/CONTRIBUTING.md`
- **Action:** Updated community health file cross-links to use absolute root paths (e.g., `/.github/CODE_OF_CONDUCT.md`).

## Verification
- [x] Links verified in local IDE/editor.
- [x] Links verified in GitHub Blob view.
- [x] Links verified via the repository "Contributing" overview tab.

---