### PR TITLE
docs(rest): note when commit comments may be disabled

### DIFF
--- a/content/rest/commits/comments.md
+++ b/content/rest/commits/comments.md
@@ -14,6 +14,6 @@ category:
 
 ## About commit comments
 
-You can create, edit, and view commit comments using the REST API. A commit comment is a comment made on a specific commit. For more information, see [AUTOTITLE](/rest/guides/working-with-comments#commit-comments).
+You can create, edit, and view commit comments using the REST API. A commit comment is a comment made on a specific commit. {% ifversion fpt or ghec or ghes > 3.21 %}For repositories that belong to organizations, commit comments can be disabled at the organization or repository level. If commit comments are disabled, people cannot create new commit comments, and requests to create a commit comment may return `403 Forbidden`. For more information, see [AUTOTITLE](/organizations/managing-organization-settings/managing-commit-comments-for-your-organization). {% endif %}For more information, see [AUTOTITLE](/rest/guides/working-with-comments#commit-comments).
 
 <!-- Content after this section is automatically generated -->

--- a/content/rest/guides/working-with-comments.md
+++ b/content/rest/guides/working-with-comments.md
@@ -94,6 +94,10 @@ deal specifically with the way a particular change was implemented within a file
 The last type of comments occur specifically on individual commits. For this reason,
 they make use of [the endpoint to manage commit comments](/rest/commits#get-a-commit-comment).
 
+{% ifversion fpt or ghec or ghes > 3.21 %}
+For repositories that belong to organizations, commit comments can be disabled at the organization or repository level. If commit comments are disabled, people cannot create new commit comments, and requests to create a commit comment may return `403 Forbidden`. For more information, see [AUTOTITLE](/organizations/managing-organization-settings/managing-commit-comments-for-your-organization).
+{% endif %}
+
 To retrieve the comments on a commit, you'll want to use the SHA1 of the commit.
 In other words, you won't use any identifier related to the Pull Request. Here's an example:
 


### PR DESCRIPTION
## Summary

Adds a note to the commit comments REST docs that commit comments may be disabled for organization-owned repositories.

## What changed

- updates the REST guide for working with comments
- updates the REST commit comments overview page
- notes that creating commit comments may return `403 Forbidden` when commit comments are disabled
- links to the organization setting docs for managing commit comments

Closes #43937
