### PR TITLE
docs(pages): clarify when to create _config.yml

### DIFF
--- a/content/pages/quickstart.md
+++ b/content/pages/quickstart.md
@@ -38,9 +38,9 @@ In this guide, you'll create a user site at `<username>.github.io`.
 By default, the title of your site is `username.github.io`. You can change the title by editing the `_config.yml` file in your repository. You can also add a description for your site.
 
 1. Click the **Code** tab of your repository.
-1. In the file list, click `_config.yml` to open the file.
-1. Click {% octicon "pencil" aria-label="The edit icon" %} to edit the file.
-1. The `_config.yml` file already contains a line that specifies the theme for your site. Add a new line with `title:` followed by the title you want. Add a new line with `description:` followed by the description you want. For example:
+1. If the repository already contains a `_config.yml` file, click `_config.yml` to open it, then click {% octicon "pencil" aria-label="The edit icon" %} to edit the file.
+1. If the repository doesn't contain a `_config.yml` file, select the **Add file** dropdown menu, click **Create new file**, and name the file `_config.yml`.
+1. In `_config.yml`, add a line that specifies the theme for your site, then add a line with `title:` followed by the title you want and a line with `description:` followed by the description you want. For example:
 
    ```yaml
    theme: jekyll-theme-minimal


### PR DESCRIPTION
## Summary
- clarify that the Pages quickstart may not already contain a `_config.yml` file
- explain how to create `_config.yml` when it doesn't exist yet
- keep the example focused on adding `theme`, `title`, and `description`

Closes #44410
