### PR TITLE
docs(actions): add SHA pinning notes to OIDC examples

### DIFF
--- a/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws.md
+++ b/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws.md
@@ -141,6 +141,7 @@ The `aws-actions/configure-aws-credentials` action receives a JWT from the {% da
 # Sample workflow to access AWS resources when workflow is tied to branch
 # The workflow creates a static website using Amazon S3
 {% data reusables.actions.actions-not-certified-by-github-comment %}
+{% data reusables.actions.actions-use-sha-pinning-comment %}
 name: AWS example workflow
 on:
   push

--- a/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-azure.md
+++ b/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-azure.md
@@ -81,6 +81,7 @@ The following example exchanges an OIDC ID token with Azure to receive an access
 
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
+{% data reusables.actions.actions-use-sha-pinning-comment %}
 name: Run Azure Login with OIDC
 on: [push]
 

--- a/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-google-cloud-platform.md
+++ b/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-google-cloud-platform.md
@@ -82,6 +82,7 @@ This action exchanges a {% data variables.product.prodname_dotcom %} OIDC token 
 
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
+{% data reusables.actions.actions-use-sha-pinning-comment %}
 name: List services in GCP
 on:
   pull_request:

--- a/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-hashicorp-vault.md
+++ b/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-hashicorp-vault.md
@@ -129,6 +129,7 @@ This example demonstrates how to create a job that requests a secret from HashiC
 
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
+{% data reusables.actions.actions-use-sha-pinning-comment %}
 jobs:
   retrieve-secret:
     runs-on: ubuntu-latest
@@ -163,6 +164,7 @@ By default, the Vault server will automatically revoke access tokens when their 
 
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
+{% data reusables.actions.actions-use-sha-pinning-comment %}
 jobs:
   retrieve-secret:
     runs-on: ubuntu-latest

--- a/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-pypi.md
+++ b/content/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-pypi.md
@@ -56,6 +56,7 @@ The following example uses the `pypa/gh-action-pypi-publish` action to exchange 
 
 ```yaml copy
 {% data reusables.actions.actions-not-certified-by-github-comment %}
+{% data reusables.actions.actions-use-sha-pinning-comment %}
 jobs:
   release-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add the SHA pinning comment reusable to OIDC workflow examples that already use full commit SHAs for third-party actions
- keep the existing third-party action notice and example structure unchanged
- make the guidance consistent across the Google Cloud Platform, AWS, Azure, HashiCorp Vault, and PyPI OIDC pages

Closes #34316