### PR TITLE
docs: clarify fork-and-pull model wording (replace 'of it' with 'that')

### DIFF
--- a/content/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models.md
+++ b/content/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models.md
@@ -17,7 +17,7 @@ category:
 ---
 ## Fork and pull model
 
-In the fork and pull model, anyone can fork an existing ("upstream") repository to which they have read access and the owner of the upstream repository allows it. Be aware that a fork and its upstream share the same git data. This means that all content uploaded to a fork is accessible from the upstream and all other forks of that upstream. You do not need permission from the upstream repository to push to a fork of it you created. You can optionally allow anyone with push access to the upstream repository to make changes to your pull request branch. This model is popular with open-source projects as it reduces the amount of friction for new contributors and allows people to work independently without upfront coordination.
+In the fork and pull model, anyone can fork an existing ("upstream") repository to which they have read access and the owner of the upstream repository allows it. Be aware that a fork and its upstream share the same git data. This means that all content uploaded to a fork is accessible from the upstream and all other forks of that upstream. You do not need permission from the upstream repository to push to a fork that you created. You can optionally allow anyone with push access to the upstream repository to make changes to your pull request branch. This model is popular with open-source projects as it reduces the amount of friction for new contributors and allows people to work independently without upfront coordination.
 
 > [!TIP]
 > {% data reusables.open-source.open-source-guide-general %} {% data reusables.open-source.open-source-learning %}


### PR DESCRIPTION
### Why:

Closes: #44811

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Replaces the clunky phrase "a fork of it you created" with "a fork that you created" in the "Fork and pull model" section of `content/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models.md`. This is a grammatical/clarity correction (no technical meaning changed), which the docs team explicitly accepts and a maintainer pre-approved in the linked issue.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet the docs fundamentals that are required for all content.
- [x] All CI checks are passing and the changes look good in the review environment.