### PR TITLE
Update Ubuntu 20.04 base OS support wording in system overview

### DIFF
--- a/content/admin/overview/system-overview.md
+++ b/content/admin/overview/system-overview.md
@@ -81,7 +81,7 @@ For more information, see [AUTOTITLE](/admin/configuration/configuring-your-ente
 
 {% data variables.product.prodname_ghe_server %} is provided as an appliance, and many of the operating system packages are modified compared to the usual Ubuntu distribution. We do not support modifying the underlying operating system for this reason (including operating system upgrades), which is aligned with the [{% data variables.product.prodname_ghe_server %} license and support agreement](https://enterprise.github.com/license), under section 11.3 Exclusions.
 
-Currently, the base operating system for {% data variables.product.prodname_ghe_server %} is Ubuntu 20 (Focal Fossa). Although Ubuntu 20 (Focal Fossa) will reach the end of standard support by May 2025, we will be able to use extended security maintenance and get security support beyond 2025.
+Currently, the base operating system for {% data variables.product.prodname_ghe_server %} is Ubuntu 20 (Focal Fossa). Although Ubuntu 20 (Focal Fossa) reached the end of standard support in May 2025, we use Expanded Security Maintenance (ESM), which provides security support through May 2030.
 
 Regular patch updates are released on the {% data variables.product.prodname_ghe_server %} [releases](https://enterprise.github.com/releases) page, and the [release notes](/admin/release-notes) page provides more information. These patches typically contain upstream vendor and project security patches after they've been tested and quality approved by our engineering team. There can be a slight time delay from when the upstream update is released to when it's tested and bundled in an upcoming {% data variables.product.prodname_ghe_server %} patch release.
 


### PR DESCRIPTION
### What is being changed

This updates the "Operating system, software, and patches" section of the GitHub Enterprise Server system overview. The current sentence about the Ubuntu 20 (Focal Fossa) base operating system was written before Ubuntu 20.04 reached the end of standard support, so it still reads in the future tense, uses the phrase "extended security maintenance" instead of the correct product name, and states no end date.

Old:

> Although Ubuntu 20 (Focal Fossa) will reach the end of standard support by May 2025, we will be able to use extended security maintenance and get security support beyond 2025.

New:

> Although Ubuntu 20 (Focal Fossa) reached the end of standard support in May 2025, we use Expanded Security Maintenance (ESM), which provides security support through May 2030.

### Why

* Ubuntu 20.04 LTS reached the end of standard security maintenance on 2025-05-31.
* Canonical's [Ubuntu release cycle](https://ubuntu.com/about/release-cycle) lists Expanded Security Maintenance for Ubuntu 20.04 running through May 2030.
* [Expanded Security Maintenance (ESM)](https://ubuntu.com/security/esm) is the correct Canonical product name (the previous wording said "extended").

### Versioning

Every currently supported documentation version (3.17 through 3.21) was released after May 2025, so the corrected wording applies to all built versions and no `ifversion` conditional is needed. Deprecated versions are archived separately and are unaffected.
