### PR TITLE
fixes the confusing wording in docs  making it more clear

### DIFF
--- a/content/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models.md
+++ b/content/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models.md
@@ -17,7 +17,7 @@ category:
 ---
 ## Fork and pull model
 
-In the fork and pull model, anyone can fork an existing ("upstream") repository to which they have read access and the owner of the upstream repository allows it. Be aware that a fork and its upstream share the same git data. This means that all content uploaded to a fork is accessible from the upstream and all other forks of that upstream. You do not need permission from the upstream repository to push to a fork of it you created. You can optionally allow anyone with push access to the upstream repository to make changes to your pull request branch. This model is popular with open-source projects as it reduces the amount of friction for new contributors and allows people to work independently without upfront coordination.
+In the fork and pull model, anyone can fork an existing ("upstream") repository to which they have read access and the owner of the upstream repository allows it. Be aware that a fork and its upstream share the same git data. This means that all content uploaded to a fork is accessible from the upstream and all other forks of that upstream. You do not need permission from the upstream repository to push to a fork that you created. You can optionally allow anyone with push access to the upstream repository to make changes to your pull request branch. This model is popular with open-source projects as it reduces the amount of friction for new contributors and allows people to work independently without upfront coordination.
 
 > [!TIP]
 > {% data reusables.open-source.open-source-guide-general %} {% data reusables.open-source.open-source-learning %}


### PR DESCRIPTION



Closes: #44811

https://github.com/github/docs/issues/44811


fixes issue of making the docs more clear stating "You do not need permission from the upstream repository to push to a fork **of it** you created." to "You do not need permission from the upstream repository to push to a fork **that** you created."


