### PR TITLE
docs(migrations): update ado2gh PAT scopes for mannequin retrieval

### DIFF
--- a/data/reusables/enterprise-migration-tool/github-pat-required-scopes.md
+++ b/data/reusables/enterprise-migration-tool/github-pat-required-scopes.md
@@ -9,3 +9,4 @@ Assigning the migrator role for repository migrations | `admin:org` | {% octicon
 Running a repository migration (destination organization) | `repo`, `admin:org`, `workflow` | `repo`, `read:org`, `workflow`
 Downloading a migration log | `repo`, `admin:org`, `workflow` | `repo`, `read:org`, `workflow`
 Reclaiming mannequins | `admin:org` | {% octicon "dash" aria-label="Not applicable" %}
+Generating mannequin CSV | `repo`, `admin:org`, `workflow` | `repo`, `read:org`, `workflow`


### PR DESCRIPTION
### Why:

Closes #45071

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updated the required Personal Access Token (PAT) scopes for the `ado2gh` CLI tool when retrieving or reclaiming mannequins. Relying strictly on `admin:org` triggers a `FORBIDDEN` permission error. The documentation has been updated to explicitly specify that `repo`, `admin:org`, and `workflow` scopes are required for this action to succeed.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.