### PR TITLE
docs: propose note about custom runner group UI visibility

### DIFF
--- a/content/actions/how-tos/manage-runners/self-hosted-runners/manage-access.md
+++ b/content/actions/how-tos/manage-runners/self-hosted-runners/manage-access.md
@@ -56,6 +56,12 @@ For runner groups in an enterprise, you can change what organizations in the ent
 
 For runner groups in an organization, you can change what repositories in the organization can access a runner group.
 
+{% note %}
+
+**Note:** Some users have reported that organization-level runners assigned to custom runner groups don't appear on the legacy **Settings > Actions > Runners** page for individual repositories, even when the group has valid repository access configured. If a runner you expect to see is missing there, check the repository's **Actions > Runners** management page, which reflects custom group membership more reliably.
+
+{% endnote %}
+
 {% data reusables.actions.runner-groups-org-navigation %}
 {% data reusables.actions.changing-repository-access-for-a-runner-group %}
 


### PR DESCRIPTION
Adds a note clarifying that organization runners in custom groups may not render in legacy repository settings, despite retaining full routing access, to prevent user confusion.

**Draft** — Proposing this note pending confirmation on Issue #45132. Leaving this as a draft and open to wording changes from the docs team once the behavior is reviewed.

Why:
Several users independently reported in a Community Discussion that org-level runners assigned to custom runner groups stop appearing on the legacy repository Settings > Actions > Runners page — even with correct repository access configured — while continuing to route and execute jobs normally. This note aims to prevent users from assuming their runner group permissions are misconfigured.

Related discussion: https://github.com/orgs/community/discussions/201615
Related issue: #45132

Closes: N/A — not intended to auto-close; see related issue above

What's being changed (if available, include any code snippets, screenshots, or gifs):
Adds a {% note %} callout under "Changing which repositories can access a runner group" in content/actions/how-tos/manage-runners/self-hosted-runners/manage-access.md.

Check off the following:
- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet the docs fundamentals that are required for all content.
- [ ] All CI checks are passing and the changes look good in the review environment.