### PR TITLE
Document workflow run statuses and conclusions

### DIFF
--- a/content/actions/reference/workflows-and-actions/index.md
+++ b/content/actions/reference/workflows-and-actions/index.md
@@ -18,6 +18,7 @@ children:
   - /reusing-workflow-configurations
   - /metadata-syntax
   - /workflow-cancellation
+  - /workflow-run-statuses
   - /dockerfile-support
 contentType: reference
 ---

--- a/content/actions/reference/workflows-and-actions/workflow-run-statuses.md
+++ b/content/actions/reference/workflows-and-actions/workflow-run-statuses.md
@@ -1,0 +1,47 @@
+---
+title: Workflow run statuses and conclusions
+shortTitle: Workflow run statuses
+intro: Learn how status and conclusion values describe the lifecycle and result of a workflow run.
+versions:
+  fpt: '*'
+  ghes: '*'
+  ghec: '*'
+category:
+  - Manage and monitor workflow runs
+contentType: reference
+---
+
+A workflow run has a `status` while it moves through its lifecycle. After the run reaches a `completed` status, its `conclusion` describes the final result.
+
+The workflow run list endpoints in the REST API use the `status` query parameter to filter by either status or conclusion. For more information, see [AUTOTITLE](/rest/actions/workflow-runs).
+
+## Status values
+
+| Status | Description |
+| --- | --- |
+| `requested` | The workflow run was created but has not been queued. |
+| `queued` | The workflow run is queued. |
+| `pending` | The workflow run is at the front of the queue, but a concurrency limit has been reached. |
+| `waiting` | The workflow run is waiting for a deployment protection rule to be satisfied. |
+| `in_progress` | The workflow run is in progress. |
+| `completed` | The workflow run completed and has a conclusion. |
+
+Only {% data variables.product.prodname_actions %} can set the `requested`, `pending`, and `waiting` statuses.
+
+For more information about the conditions that cause `pending` and `waiting` statuses, see [AUTOTITLE](/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) and [AUTOTITLE](/actions/how-tos/deploy/configure-and-manage-deployments/review-deployments).
+
+## Conclusion values
+
+| Conclusion | Description |
+| --- | --- |
+| `action_required` | The workflow run completed and requires action. |
+| `cancelled` | The workflow run was cancelled before it completed. |
+| `failure` | The workflow run failed. |
+| `neutral` | The workflow run completed with a neutral result. |
+| `skipped` | The workflow run was skipped. |
+| `stale` | The workflow run was marked stale by {% data variables.product.github %}. |
+| `success` | The workflow run completed successfully. |
+| `timed_out` | The workflow run timed out. |
+| `startup_failure` | The workflow run failed during startup. |
+
+The `startup_failure` value can appear as a workflow run conclusion in webhook payloads. It is not an accepted value for the `status` query parameter in the REST API workflow run list endpoints.

--- a/content/actions/reference/workflows-and-actions/workflow-run-statuses.md
+++ b/content/actions/reference/workflows-and-actions/workflow-run-statuses.md
@@ -11,9 +11,13 @@ category:
 contentType: reference
 ---
 
-A workflow run has a `status` while it moves through its lifecycle. After the run reaches a `completed` status, its `conclusion` describes the final result.
+A workflow run has a `status` while it moves through its lifecycle. After the run reaches a `completed` status, its `conclusion` describes the final result. Until then, the `conclusion` value is `null`.
+
+A status is a snapshot of the workflow run's current state, not a history of transitions. For example, a sequence of `queued`, `in_progress`, `queued`, and `completed` values does not identify why the state changed. When investigating such a sequence, first compare `run_attempt`: a re-run keeps the workflow run ID and increments `run_attempt`. If the attempt did not change, inspect the workflow run logs and its related check runs for more evidence. For more information, see [AUTOTITLE](/actions/reference/workflows-and-actions/contexts#github-context) and [AUTOTITLE](/actions/how-tos/monitor-workflows/use-workflow-run-logs).
 
 The workflow run list endpoints in the REST API use the `status` query parameter to filter by either status or conclusion. For more information, see [AUTOTITLE](/rest/actions/workflow-runs).
+
+The values on this page apply only to workflow runs. Check suites, check runs, and commit statuses have their own status and conclusion values, and a value with the same name can have different meanings for different objects. For example, in the Checks API, `startup_failure` describes a check suite that failed during startup, while `stale` describes an incomplete check run that {% data variables.product.github %} marked stale. For more information, see [AUTOTITLE](/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks).
 
 ## Status values
 
@@ -44,4 +48,4 @@ For more information about the conditions that cause `pending` and `waiting` sta
 | `timed_out` | The workflow run timed out. |
 | `startup_failure` | The workflow run failed during startup. |
 
-The `startup_failure` value can appear as a workflow run conclusion in webhook payloads. It is not an accepted value for the `status` query parameter in the REST API workflow run list endpoints.
+The `startup_failure` value can appear as a workflow run conclusion in webhook payloads. It is not listed as an accepted value for the `status` query parameter in the REST API workflow run list endpoints.

--- a/content/rest/actions/workflow-runs.md
+++ b/content/rest/actions/workflow-runs.md
@@ -16,6 +16,6 @@ category:
 
 ## About workflow runs in {% data variables.product.prodname_actions %}
 
-You can use the REST API to view, re-run, cancel, and view logs for workflow runs in {% data variables.product.prodname_actions %}. {% data reusables.actions.about-workflow-runs %} For more information, see [AUTOTITLE](/actions/how-tos/manage-workflow-runs).
+You can use the REST API to view, re-run, cancel, and view logs for workflow runs in {% data variables.product.prodname_actions %}. {% data reusables.actions.about-workflow-runs %} For reference information about `status` and `conclusion` values, see [AUTOTITLE](/actions/reference/workflows-and-actions/workflow-run-statuses). For more information, see [AUTOTITLE](/actions/how-tos/manage-workflow-runs).
 
 <!-- Content after this section is automatically generated -->


### PR DESCRIPTION
_GitHub Copilot generated this pull request._

> [!NOTE]
> This pull request should have the `llm-generated` label. External contributors do not have permission to add labels to this repository.

### Why:

Closes: #34987

The issue is labeled `help wanted` and `SME reviewed`; the Actions SME requested a new reference article defining workflow run statuses and conclusions, linked from the REST API documentation.

### What's being changed:

* Adds a focused workflow run status and conclusion reference article.
* Adds the article to the workflows and actions reference navigation.
* Links to the article from the manually maintained introduction to the workflow runs REST API page.
* Separates the six `status` values from the nine `conclusion` values exposed by the current `workflow_run` webhook schema.
* Calls out that `startup_failure` is a webhook conclusion but is not listed among the accepted values for the workflow run list endpoints' `status` filter.

This builds on the useful direction in #44984 by @happysnaker. It preserves the existing frontmatter formatting requested in that pull request's review and removes speculative "typical use case" claims that are not established by the public schema.

Technical values were checked against the current workflow run REST endpoint documentation and the `workflow_run` webhook schema in this repository.

### Verification:

* `npm run lint-content -- --paths content/actions/reference/workflows-and-actions/index.md content/actions/reference/workflows-and-actions/workflow-run-statuses.md content/rest/actions/workflow-runs.md` ? no errors.
* `npm run build` ? passed.
* `CHANGED_FILES="content/actions/reference/workflows-and-actions/index.md content/actions/reference/workflows-and-actions/workflow-run-statuses.md content/rest/actions/workflow-runs.md" npm run test -- src/content-render/tests/render-changed-and-deleted-files.ts` ? 1 test file and 2 tests passed.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.

