### PR TITLE
Note that hyphens are replaced as well as spaces in seeding of `INPUT_*` environment variables in `action.yaml` reference

### DIFF
--- a/content/actions/reference/workflows-and-actions/metadata-syntax.md
+++ b/content/actions/reference/workflows-and-actions/metadata-syntax.md
@@ -59,7 +59,7 @@ inputs:
     required: true
 ```
 
-When you specify an input, {% data variables.product.prodname_dotcom %} creates an environment variable for the input with the name `INPUT_<VARIABLE_NAME>`. The environment variable created converts input names to uppercase letters and replaces spaces with `_` characters.
+When you specify an input, {% data variables.product.prodname_dotcom %} creates an environment variable for the input with the name `INPUT_<VARIABLE_NAME>`. The environment variable created converts input names to uppercase letters and replaces spaces and hyphens with `_` characters.
 
 If the action is written using a [composite](/actions/tutorials/create-actions/create-a-composite-action), then it will not automatically get `INPUT_<VARIABLE_NAME>`. With composite actions you can use the [`inputs` context](/actions/reference/workflows-and-actions/contexts#inputs-context) to access action inputs.
 


### PR DESCRIPTION
### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
