### PR TITLE
Fix sidebar icon toggle logic for desktop and mobile views

### DIFF
--- a/src/frame/components/page-header/DocsSecondaryBar.tsx
+++ b/src/frame/components/page-header/DocsSecondaryBar.tsx
@@ -39,7 +39,7 @@ export const DocsSecondaryBar = () => {
               className={cx(styles.desktopOnly, 'color-fg-muted')}
               variant="invisible"
               size="small"
-              icon={collapsed ? SidebarExpandIcon : SidebarCollapseIcon}
+              icon={collapsed ? SidebarCollapseIcon : SidebarExpandIcon}
               aria-label={collapsed ? t('expand_sidebar') : t('collapse_sidebar')}
               aria-expanded={!collapsed}
               onClick={toggleCollapsed}
@@ -50,7 +50,7 @@ export const DocsSecondaryBar = () => {
               className={cx(styles.mobileOnly, 'color-fg-muted')}
               variant="invisible"
               size="small"
-              icon={mobileNavOpen ? SidebarCollapseIcon : SidebarExpandIcon}
+              icon={mobileNavOpen ? SidebarExpandIcon : SidebarCollapseIcon}
               aria-label={mobileNavOpen ? t('collapse_sidebar') : t('expand_sidebar')}
               aria-expanded={mobileNavOpen}
               onClick={toggleMobileNav}


### PR DESCRIPTION
### Why:
The collapse and expand icons on the sidebar are swapped.
Closes: #45210

### What's being changed (if available, include any code snippets, screenshots, or gifs):
The collapse and expand icons for the sidbar are swapped.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
