### PR TITLE
Document API insights data visibility timing

### DIFF
--- a/content/organizations/managing-programmatic-access-to-your-organization/viewing-api-insights-in-your-organization.md
+++ b/content/organizations/managing-programmatic-access-to-your-organization/viewing-api-insights-in-your-organization.md
@@ -26,6 +26,8 @@ Organization owners can create custom organization roles to allow people to view
 
 The time period selection feature allows you to view API insights over predefined periods or a custom period, as detailed in the following table. By default, data is presented in Coordinated Universal Time (UTC). You can change the data displayed from UTC to your browser's time zone in the "Period" drop down menu at the top-right of the page.
 
+Under normal conditions, you can expect API data to appear within 4–6 hours after making a request. During incidents or periods of unusually high volume, it may take longer to show up.
+
 {% rowheaders %}
 
 | Period          | Description                                                                                                |


### PR DESCRIPTION
_GitHub Copilot generated this pull request._

### Why:

Towards github/api-platform#9650

API Insights data can take several hours to become visible. Documenting that delay sets clear expectations for people investigating recent API activity.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adds the approved expected data visibility timing to the authored API Insights UI guide, including the possibility of longer delays during incidents or unusually high volume.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.