### PR TITLE
Use modern `providers.gradleProperty` APIs for GitHub Packages Gradle credential examples

### DIFF
--- a/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
@@ -37,7 +37,7 @@ category:
 
 {% data reusables.package_registry.required-scopes %}
 
-You can authenticate to {% data variables.product.prodname_registry %} with Gradle using either Gradle Groovy or Kotlin DSL by editing your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file (or _settings.gradle_/_settings.gradle.kts_ if you use [Centralizing Repository Declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html)) to include your {% data variables.product.pat_v1 %}. You can also configure Gradle Groovy and Kotlin DSL to recognize a single package or multiple packages in a repository.
+You can authenticate to {% data variables.product.prodname_registry %} with Gradle using either Gradle Groovy or Kotlin DSL by editing your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) (or _settings.gradle_/_settings.gradle.kts_ if you centralize repository declarations in the settings script to use published packages) to include your {% data variables.product.pat_v1 %}. You can also configure Gradle Groovy and Kotlin DSL to recognize a single package or multiple packages in a repository.
 
 {% ifversion ghes %}
 Replace REGISTRY_URL with the URL for your instance's Maven registry. If your instance has subdomain isolation enabled, use `maven.HOSTNAME`. If your instance has subdomain isolation disabled, use `HOSTNAME/_registry/maven`. In either case, replace HOSTNAME with the host name of your {% data variables.product.prodname_ghe_server %} instance.
@@ -190,7 +190,7 @@ To use a published package from {% data variables.product.prodname_registry %}, 
    }
    ```
 
-1. Add the repository to your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file, or to your _settings.gradle_ file (Gradle Groovy) or _settings.gradle.kts_ file (Kotlin DSL) in the `dependencyResolutionManagement` block if you use [Centralizing Repository Declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html).
+1. Add the repository to your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file, or to your _settings.gradle_ file (Gradle Groovy) or _settings.gradle.kts_ file (Kotlin DSL) in the `dependencyResolutionManagement` block if you centralize repository declarations in the settings script. For more information, see [Centralizing Repository Declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html) in the Gradle documentation.
 
    Example using Gradle Groovy:
 

--- a/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
@@ -60,8 +60,8 @@ publishing {
             name = "GitHubPackages"
             url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
             credentials {
-                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
-                password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
+                username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+                password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
             }
         }
     }
@@ -87,8 +87,8 @@ subprojects {
                 name = "GitHubPackages"
                 url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
                 credentials {
-                    username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
-                    password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
+                    username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+                    password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
                 }
             }
         }
@@ -113,8 +113,8 @@ publishing {
             name = "GitHubPackages"
             url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
             credentials {
-                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
-                password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
+                username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+                password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
             }
         }
     }
@@ -140,8 +140,8 @@ subprojects {
                 name = "GitHubPackages"
                 url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
                 credentials {
-                    username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
-                    password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
+                    username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+                    password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
                 }
             }
         }
@@ -199,8 +199,8 @@ To use a published package from {% data variables.product.prodname_registry %}, 
        maven {
            url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
            credentials {
-               username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
-               password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
+               username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+               password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
            }
       }
    }
@@ -213,8 +213,8 @@ To use a published package from {% data variables.product.prodname_registry %}, 
        maven {
            url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
            credentials {
-               username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
-               password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
+               username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+               password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
            }
        }
    }

--- a/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
@@ -37,7 +37,7 @@ category:
 
 {% data reusables.package_registry.required-scopes %}
 
-You can authenticate to {% data variables.product.prodname_registry %} with Gradle using either Gradle Groovy or Kotlin DSL by editing your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file to include your {% data variables.product.pat_v1 %}. You can also configure Gradle Groovy and Kotlin DSL to recognize a single package or multiple packages in a repository.
+You can authenticate to {% data variables.product.prodname_registry %} with Gradle using either Gradle Groovy or Kotlin DSL. To publish packages, edit your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) to include your {% data variables.product.pat_v1 %}. To use packages as dependencies, declare the repository and credentials in your _settings.gradle_ file (Gradle Groovy) or _settings.gradle.kts_ file (Kotlin DSL). You can also configure Gradle Groovy and Kotlin DSL to recognize a single package or multiple packages in a repository.
 
 {% ifversion ghes %}
 Replace REGISTRY_URL with the URL for your instance's Maven registry. If your instance has subdomain isolation enabled, use `maven.HOSTNAME`. If your instance has subdomain isolation disabled, use `HOSTNAME/_registry/maven`. In either case, replace HOSTNAME with the host name of your {% data variables.product.prodname_ghe_server %} instance.
@@ -169,7 +169,7 @@ subprojects {
 
 ## Using a published package
 
-To use a published package from {% data variables.product.prodname_registry %}, add the package as a dependency and add the repository to your project. For more information, see [Declaring dependencies](https://docs.gradle.org/current/userguide/declaring_dependencies.html) in the Gradle documentation.
+To use a published package from {% data variables.product.prodname_registry %}, add the package as a dependency and declare the repository in your project. Gradle recommends declaring repositories in your settings script with `dependencyResolutionManagement`. For more information, see [Declaring dependencies](https://docs.gradle.org/current/userguide/declaring_dependencies.html) and [Centralizing repository declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html) in the Gradle documentation.
 
 {% data reusables.package_registry.authenticate-step %}
 1. Add the package dependencies to your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file.
@@ -190,31 +190,35 @@ To use a published package from {% data variables.product.prodname_registry %}, 
    }
    ```
 
-1. Add the repository to your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file.
+1. Add the repository to your _settings.gradle_ file (Gradle Groovy) or _settings.gradle.kts_ file (Kotlin DSL) using a `dependencyResolutionManagement` block.
 
    Example using Gradle Groovy:
 
    ```shell
-   repositories {
-       maven {
-           url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
-           credentials {
-               username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
-               password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
+   dependencyResolutionManagement {
+       repositories {
+           maven {
+               url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
+               credentials {
+                   username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+                   password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
+               }
            }
-      }
+       }
    }
    ```
 
    Example using Kotlin DSL:
 
    ```shell
-   repositories {
-       maven {
-           url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
-           credentials {
-               username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
-               password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
+   dependencyResolutionManagement {
+       repositories {
+           maven {
+               url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
+               credentials {
+                   username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+                   password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
+               }
            }
        }
    }

--- a/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
@@ -60,8 +60,8 @@ publishing {
             name = "GitHubPackages"
             url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
             credentials {
-                username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
-                password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
+                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
+                password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
             }
         }
     }
@@ -87,8 +87,8 @@ subprojects {
                 name = "GitHubPackages"
                 url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
                 credentials {
-                    username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
-                    password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
+                    username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
+                    password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
                 }
             }
         }
@@ -113,8 +113,8 @@ publishing {
             name = "GitHubPackages"
             url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
             credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-                password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
+                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
+                password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
             }
         }
     }
@@ -140,8 +140,8 @@ subprojects {
                 name = "GitHubPackages"
                 url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
                 credentials {
-                    username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-                    password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
+                    username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
+                    password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
                 }
             }
         }
@@ -199,8 +199,8 @@ To use a published package from {% data variables.product.prodname_registry %}, 
        maven {
            url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
            credentials {
-               username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
-               password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
+               username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
+               password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
            }
       }
    }
@@ -213,8 +213,8 @@ To use a published package from {% data variables.product.prodname_registry %}, 
        maven {
            url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
            credentials {
-               username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-               password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
+               username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
+               password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("TOKEN")
            }
        }
    }

--- a/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
@@ -190,7 +190,7 @@ To use a published package from {% data variables.product.prodname_registry %}, 
    }
    ```
 
-1. Add the repository to your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file, or to your _settings.gradle_ file (Gradle Groovy) or _settings.gradle.kts_ file (Kotlin DSL) in the `dependencyResolutionManagement` block if you [Centralizing Repository Declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html).
+1. Add the repository to your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file, or to your _settings.gradle_ file (Gradle Groovy) or _settings.gradle.kts_ file (Kotlin DSL) in the `dependencyResolutionManagement` block if you use [Centralizing Repository Declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html).
 
    Example using Gradle Groovy:
 

--- a/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
+++ b/content/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry.md
@@ -37,7 +37,7 @@ category:
 
 {% data reusables.package_registry.required-scopes %}
 
-You can authenticate to {% data variables.product.prodname_registry %} with Gradle using either Gradle Groovy or Kotlin DSL. To publish packages, edit your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) to include your {% data variables.product.pat_v1 %}. To use packages as dependencies, declare the repository and credentials in your _settings.gradle_ file (Gradle Groovy) or _settings.gradle.kts_ file (Kotlin DSL). You can also configure Gradle Groovy and Kotlin DSL to recognize a single package or multiple packages in a repository.
+You can authenticate to {% data variables.product.prodname_registry %} with Gradle using either Gradle Groovy or Kotlin DSL by editing your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file (or _settings.gradle_/_settings.gradle.kts_ if you use [Centralizing Repository Declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html)) to include your {% data variables.product.pat_v1 %}. You can also configure Gradle Groovy and Kotlin DSL to recognize a single package or multiple packages in a repository.
 
 {% ifversion ghes %}
 Replace REGISTRY_URL with the URL for your instance's Maven registry. If your instance has subdomain isolation enabled, use `maven.HOSTNAME`. If your instance has subdomain isolation disabled, use `HOSTNAME/_registry/maven`. In either case, replace HOSTNAME with the host name of your {% data variables.product.prodname_ghe_server %} instance.
@@ -169,10 +169,10 @@ subprojects {
 
 ## Using a published package
 
-To use a published package from {% data variables.product.prodname_registry %}, add the package as a dependency and declare the repository in your project. Gradle recommends declaring repositories in your settings script with `dependencyResolutionManagement`. For more information, see [Declaring dependencies](https://docs.gradle.org/current/userguide/declaring_dependencies.html) and [Centralizing repository declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html) in the Gradle documentation.
+To use a published package from {% data variables.product.prodname_registry %}, add the package as a dependency and add the repository to your project. For more information, see [Declaring dependencies](https://docs.gradle.org/current/userguide/declaring_dependencies.html) and [Centralizing Repository Declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html) in the Gradle documentation.
 
 {% data reusables.package_registry.authenticate-step %}
-1. Add the package dependencies to your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file.
+1. Add the package dependencies to your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL).
 
    Example using Gradle Groovy:
 
@@ -190,19 +190,17 @@ To use a published package from {% data variables.product.prodname_registry %}, 
    }
    ```
 
-1. Add the repository to your _settings.gradle_ file (Gradle Groovy) or _settings.gradle.kts_ file (Kotlin DSL) using a `dependencyResolutionManagement` block.
+1. Add the repository to your _build.gradle_ file (Gradle Groovy) or _build.gradle.kts_ file (Kotlin DSL) file, or to your _settings.gradle_ file (Gradle Groovy) or _settings.gradle.kts_ file (Kotlin DSL) in the `dependencyResolutionManagement` block if you [Centralizing Repository Declarations](https://docs.gradle.org/current/userguide/centralizing_repositories.html).
 
    Example using Gradle Groovy:
 
    ```shell
-   dependencyResolutionManagement {
-       repositories {
-           maven {
-               url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
-               credentials {
-                   username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
-                   password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
-               }
+   repositories {
+       maven {
+           url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
+           credentials {
+               username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+               password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
            }
        }
    }
@@ -211,14 +209,12 @@ To use a published package from {% data variables.product.prodname_registry %}, 
    Example using Kotlin DSL:
 
    ```shell
-   dependencyResolutionManagement {
-       repositories {
-           maven {
-               url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
-               credentials {
-                   username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
-                   password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
-               }
+   repositories {
+       maven {
+           url = uri("https://{% ifversion fpt or ghec %}maven.pkg.github.com{% else %}REGISTRY_URL{% endif %}/OWNER/REPOSITORY")
+           credentials {
+               username = providers.gradleProperty("gpr.user").getOrNull() ?: System.getenv("USERNAME")
+               password = providers.gradleProperty("gpr.key").getOrNull() ?: System.getenv("TOKEN")
            }
        }
    }


### PR DESCRIPTION
### Why:

Gradle recommends newer APIs such `providers.gradleProperty()` for project properties supplied through build-level sources (`gradle.properties`, `-P`, `ORG_GRADLE_PROJECT_*`). For GitHub Packages credentials, this matches how users typically configure `gpr.user` and `gpr.key`, while avoiding the broader `findProperty` lookup (extra properties, name collisions with tasks/extensions, etc.). `providers.gradleProperty` can also be used in the settings script.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

`project.findProperty(...)` to `providers.gradleProperty(...).getOrNull()` in `working-with-the-gradle-registry.md`.

Fix typos of the repeating "file" words in the sentences "_build.gradle.kts_ file (Kotlin DSL) file" BTW.

Fix an indentation issue of a closing bracket in the code BTW.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
