### PR TITLE
Use dash in input parameter naming in workflow syntax example

### DIFF
--- a/content/actions/reference/workflows-and-actions/workflow-syntax.md
+++ b/content/actions/reference/workflows-and-actions/workflow-syntax.md
@@ -815,18 +815,18 @@ Input parameters defined for a Docker container must use `args`. For more inform
 
 ### Example of `jobs.<job_id>.steps[*].with`
 
-Defines the three input parameters (`first_name`, `middle_name`, and `last_name`) defined by the `hello_world` action. These input variables will be accessible to the `hello-world` action as `INPUT_FIRST_NAME`, `INPUT_MIDDLE_NAME`, and `INPUT_LAST_NAME` environment variables.
+Defines the three input parameters (`first-name`, `middle-name`, and `last-name`) defined by the `hello-world` action. These input variables will be accessible to the `hello-world` action as `INPUT_FIRST-NAME`, `INPUT_MIDDLE-NAME`, and `INPUT_LAST-NAME` environment variables.
 
 ```yaml
 jobs:
   my_first_job:
     steps:
       - name: My first step
-        uses: actions/hello_world@main
+        uses: actions/hello-world@main
         with:
-          first_name: Mona
-          middle_name: The
-          last_name: Octocat
+          first-name: Mona
+          middle-name: The
+          last-name: Octocat
 ```
 
 ## `jobs.<job_id>.steps[*].with.args`


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Existing actions customarily use dash rather than underscore in action names their inputs. The example should do the same to support consistent style.

### Check off the following:

- [X] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [X] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
