### PR TITLE
Update codeNavigation status for C, C++, and Scala

### DIFF
--- a/data/tables/supported-code-languages.yml
+++ b/data/tables/supported-code-languages.yml
@@ -41,7 +41,7 @@ features:
 languages:
   C:
     copilot: 'supported'
-    codeNavigation: 'not-supported'
+    codeNavigation: 'supported'
     codeScanning: 'supported'
     depGraph: 'not-supported'
     depUpdates: 'not-supported'
@@ -49,7 +49,7 @@ languages:
     packages: 'not-supported'
   C++:
     copilot: 'supported'
-    codeNavigation: 'not-supported'
+    codeNavigation: 'supported'
     codeScanning: 'supported'
     depGraph: 'not-supported'
     depUpdates: 'not-supported'
@@ -129,7 +129,7 @@ languages:
     packages: 'not-supported'
   Scala:
     copilot: 'supported'
-    codeNavigation: 'not-supported'
+    codeNavigation: 'supported'
     codeScanning: 'third-party [^1]'
     depGraph: 'Maven'
     depUpdates: 'Maven, Gradle'


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

The [github-language-support article's](https://docs.github.com/en/get-started/learning-about-github/github-language-support) "Code navigation" column marked C, C++, and Scala as not supported (✗), but the [navigating-code-on-github](https://docs.github.com/en/repositories/working-with-files/using-files/navigating-code-on-github) article  lists C, C++, and Scala  languages supported code navigation feature. This was an inconsistency between the two articles.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Updated data/tables/supported-code-languages.yml to mark codeNavigation as supported for:

* C
* C++
* Scala

This corrects the table in content/get-started/learning-about-github/github-language-support.md so it matches the list of supported languages documented on the code navigation page.

Verified code navigation works for all three languages using a small test repo (code-navigation):

**C** — `add` function definition + reference resolved

<img width="1917" height="676" alt="c language" src="https://github.com/user-attachments/assets/0017b6d5-c59f-4cef-b553-5ab92bf4bb26" />


**C++** — `Calculator::add` definition + reference resolved

<img width="1917" height="647" alt="c++" src="https://github.com/user-attachments/assets/1548ec34-7433-4f2b-8033-fd24b37ab2c9" />

**Scala** — `Calculator` class definition + reference resolved:

<img width="1907" height="642" alt="scala" src="https://github.com/user-attachments/assets/8cc23b81-ba09-4407-9e4f-522e6d588925" />



### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
