### PR TITLE
document cloud agent managed settings

### DIFF
--- a/content/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-agents/configure-enterprise-managed-settings.md
+++ b/content/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-agents/configure-enterprise-managed-settings.md
@@ -22,10 +22,11 @@ Supported clients are:
 * {% data variables.copilot.copilot_cli_short %}
 * {% data variables.product.prodname_vscode_shortname %}
 * The {% data variables.copilot.github_copilot_app %}
+* {% data variables.copilot.copilot_cloud_agent %}
 
-These settings apply enterprise-wide, with no organization-level override. For each supported key, the `{% data variables.copilot.managed_setting_file %}` value takes precedence over any file-based configuration a user sets in their client.
+These settings apply enterprise-wide, with no organization-level override. For each supported key, the `{% data variables.copilot.managed_setting_file %}` value takes precedence over other configuration sources available to that client.
 
-Managed settings are loaded locally when the client starts, even if the device has no network connection. This means controls such as disabled bypass mode and restricted plugin configuration still apply before sign in or any server round trip, and remain active when users switch accounts.
+Local clients load managed settings when they start, even if the device has no network connection. This means controls such as disabled bypass mode and restricted plugin configuration still apply before sign in or any server round trip, and remain active when users switch accounts. {% data variables.copilot.copilot_cloud_agent %} applies server-managed settings when a task is assigned.
 
 ## Defining settings
 
@@ -35,7 +36,9 @@ For detailed information on the available properties and syntax, see [AUTOTITLE]
 
 There are multiple ways to deploy enterprise managed settings. Use the following guidelines to choose the right method for you. For any method, pilot on a small device group before broad deployment.
 
-* **Server-managed**: Default for most enterprises and best for review workflows and audit history
+{% data variables.copilot.copilot_cloud_agent %} only supports server-managed settings. MDM-managed and file-based settings apply to local clients.
+
+* **Server-managed**: Required for {% data variables.copilot.copilot_cloud_agent %}, and the default for most enterprises
 * **MDM-managed**: Best when IT teams need device-group targeting through existing MDM tooling on macOS and Windows
 * **File-based**: Available on all platforms, and useful when server-managed and MDM-managed deployment are not available, including developer environments such as containers and {% data variables.product.prodname_codespaces %}
 
@@ -47,7 +50,7 @@ There are additional considerations if you use a dedicated enterprise for {% dat
 1. In the repository, create or update `copilot/{% data variables.copilot.managed_setting_file %}`.
 1. Add your enterprise policy keys and values in JSON format.
 1. Commit and push your changes to the default branch.
-1. Confirm that enterprise users are running a supported client. Updated settings are applied automatically within about an hour, or immediately after the client restarts or the user signs in again.
+1. Confirm that enterprise users are running a supported client. Local clients apply updated settings automatically within about an hour, or immediately after the client restarts or the user signs in again. {% data variables.copilot.copilot_cloud_agent %} applies updated settings on the next task assignment.
 
 ## Deploying MDM-managed settings
 
@@ -69,7 +72,7 @@ There are additional considerations if you use a dedicated enterprise for {% dat
 
 ## Verifying the configuration has applied
 
-Once the configuration is committed, users on a supported client see the specified settings within about an hour, since clients periodically check the server for updated configuration. Restarting the client or signing in again applies the latest settings immediately.
+Once the configuration is committed, users on a supported local client see the specified settings within about an hour, since clients periodically check the server for updated configuration. Restarting the client or signing in again applies the latest settings immediately. {% data variables.copilot.copilot_cloud_agent %} applies updated server-managed settings on the next task assignment.
 
 If a user does not see these settings, ensure they receive access to {% data variables.product.prodname_copilot_short %} through your enterprise or one of its organizations. If a user receives a license from multiple billing entities, ensure they have selected your enterprise in the "Usage billed to" dropdown in their [personal {% data variables.product.prodname_copilot_short %} settings](https://github.com/settings/copilot/features).
 
@@ -85,7 +88,7 @@ Server-managed settings require an organization and a `.github-private` reposito
 1. Add settings to the repository in a `copilot/{% data variables.copilot.managed_setting_file %}` file.
 1. Set that organization as the source of governance for your enterprise's AI standards. See [AUTOTITLE](/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-agents/create-github-private-repo#selecting-your-repository-as-your-source-of-governance).
 
-From that point on, any user on your enterprise's {% data variables.product.prodname_copilot_short %} plan using {% data variables.copilot.copilot_cli_short %} or {% data variables.product.prodname_vscode_shortname %} is governed by those settings, whether or not they have access to the `.github-private` repository.
+From that point on, any user on your enterprise's {% data variables.product.prodname_copilot_short %} plan using a supported client is governed by those settings, whether or not they have access to the `.github-private` repository.
 
 The main limitation of this method is the {% data variables.product.prodname_enterprise %} license requirement to create the organization and repository.
 

--- a/content/copilot/reference/enterprise-managed-settings-reference.md
+++ b/content/copilot/reference/enterprise-managed-settings-reference.md
@@ -26,14 +26,14 @@ When multiple settings sources are present, settings earlier in this list take p
 
 {% rowheaders %}
 
-| Key | Purpose | {% data variables.copilot.copilot_cli_short %} | {% data variables.product.prodname_vscode_shortname %} | {% data variables.copilot.github_copilot_app %} |
-| --- | --- | --- | --- | --- |
-| `permissions.disableBypassPermissionsMode` | Disables bypass or YOLO-style allow-all behavior | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
-| `permissions.model` | Sets auto model selection as the default for new conversations | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
-| `enabledPlugins` | Enables or disables specific plugins by key | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
-| `extraKnownMarketplaces` | Adds plugin marketplaces that users can access | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
-| `strictKnownMarketplaces` | Restricts plugin installation to explicitly listed marketplaces | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
-| `telemetry` | Configures OpenTelemetry export, routing {% data variables.product.prodname_copilot_short %} usage data to a collector of your choice | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} |
+| Key | Purpose | {% data variables.copilot.copilot_cli_short %} | {% data variables.product.prodname_vscode_shortname %} | {% data variables.copilot.github_copilot_app %} | {% data variables.copilot.copilot_cloud_agent %} |
+| --- | --- | --- | --- | --- | --- |
+| `permissions.disableBypassPermissionsMode` | Disables bypass or YOLO-style allow-all behavior | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} |
+| `permissions.model` | Sets auto model selection as the default for new conversations | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} |
+| `enabledPlugins` | Enables or disables specific plugins by key | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
+| `extraKnownMarketplaces` | Adds plugin marketplaces that users can access | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
+| `strictKnownMarketplaces` | Restricts plugin installation to explicitly listed marketplaces | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} |
+| `telemetry` | Configures OpenTelemetry export, routing {% data variables.product.prodname_copilot_short %} usage data to a collector of your choice | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} | {% octicon "x" aria-label="Not supported" %} |
 
 {% endrowheaders %}
 


### PR DESCRIPTION
### Why:

Closes: N/A

The [[27 July 2026 changelog announcement](https://github.blog/changelog/2026-07-27-enterprise-managed-settings-now-apply-to-the-github-copilot-app/)](https://github.blog/changelog/2026-07-27-enterprise-managed-settings-now-apply-to-the-github-copilot-app/) confirms that the Copilot cloud agent now observes enterprise-managed plugin and marketplace controls.

The enterprise-managed settings documentation was updated for the GitHub Copilot app, but it does not show the cloud agent in the supported-client list or settings matrix. The deployment and refresh guidance also describes only locally installed clients.

### What's being changed:

This PR:

* Adds the Copilot cloud agent to the list of supported clients.
* Adds a cloud-agent column to the managed settings support matrix.
* Records support for:

  * `enabledPlugins`
  * `extraKnownMarketplaces`
  * `strictKnownMarketplaces`
* Records that `permissions.disableBypassPermissionsMode`, `permissions.model`, and `telemetry` are not supported by the cloud agent.
* Clarifies that the cloud agent only uses server-managed settings.
* Clarifies that updated settings apply to the cloud agent on the next task assignment.
* Separates local-client loading and refresh behaviour from cloud-agent behaviour.
* Replaces stale wording that referred only to Copilot CLI and Visual Studio Code with the broader supported-client scope.

The GitHub Docs content linter completed with no errors.

### Check off the following:

* [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
* [x] The changes in this PR meet [[the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals)](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
* [ ] All CI checks are passing and the changes look good in the review environment.