### PR TITLE
Clarify pending-invitation license billing excludes usage-based GHE

### DIFF
--- a/content/billing/reference/github-license-users.md
+++ b/content/billing/reference/github-license-users.md
@@ -51,7 +51,7 @@ category:
   * {% data variables.product.company_short %} counts each outside collaborator once, even if the user account has access to multiple repositories in your organization.
 * Dormant users who are a member or owner of at least one organization in the enterprise
 
-If your enterprise does not use {% data variables.product.prodname_emus %}, you will also be billed for each of the following accounts:
+If your enterprise does not use {% data variables.product.prodname_emus %} or usage-based billing, you will also be billed for each of the following accounts. Under usage-based billing, pending invitations do not consume a license. See [AUTOTITLE](/billing/concepts/enterprise-billing/usage-based-licenses).
 
 * Anyone with a pending invitation to become an organization owner or member
   * If the invited user already consumes an enterprise license, a pending organization invitation won't use an additional license—as long as the invitation is sent to their {% data variables.product.github %} username or a verified email address on their account. 


### PR DESCRIPTION
_GitHub Copilot generated this pull request._

<details><summary>Prompt summary - submitted by @lucyji1000</summary>

> Update the "People who consume a license" page so the pending-invitation billing statement is scoped correctly. Pending invitations consume licenses for volume/standard seat-based GHE but do not consume licenses under usage-based (metered) GHE. Resolve the ambiguity between the standard per-seat license page and the usage-based license page.

</details>

## What's changed

On the **Organizations on GitHub Enterprise Cloud** section, the statement introducing pending-invitation billing previously read:

> If your enterprise does not use Enterprise Managed Users, you will also be billed for each of the following accounts:

This omitted the usage-based (metered) billing exception. Under usage-based billing, pending invitations to join an organization **do not** consume a license (as documented on the [Usage-based billing for enterprise licenses](https://docs.github.com/en/enterprise-cloud@latest/billing/concepts/enterprise-billing/usage-based-licenses) page and the `metered-license-measures` reusable).

The statement is now scoped to enterprises that use **neither** Enterprise Managed Users **nor** usage-based billing, with an explicit note and a link to the usage-based licenses page.

## Why

This resolves an ambiguity between the standard per-seat license page (`github-license-users`) and the usage-based license page. Volume/standard seat-based GHE bills for pending invitations; metered GHE does not. The previous wording could mislead metered customers into believing pending invitations always consume a license.

Source: Confirmed by Lucy Ji in #licensing-and-copilot-access (July 28, 2026): "On metered GHE, pending invitations don't consume licenses. On volume GHE, they do."
