### PR TITLE
Add GitHub Copilot app to surface documentation

### DIFF
--- a/content/copilot/get-started/quickstart.md
+++ b/content/copilot/get-started/quickstart.md
@@ -24,6 +24,8 @@ category:
 
 ## Introduction
 
+To get started with the {% data variables.copilot.github_copilot_app %}, see [AUTOTITLE](/copilot/how-tos/github-copilot-app/getting-started).
+
 <!-- --------------------- -->
 <!-- Web browser -->
 <!-- --------------------- -->

--- a/content/copilot/get-started/what-is-github-copilot.md
+++ b/content/copilot/get-started/what-is-github-copilot.md
@@ -50,6 +50,7 @@ Use {% data variables.product.prodname_copilot_short %} in the following places:
 * {% data variables.product.prodname_mobile %}, as a chat interface
 * {% data variables.product.prodname_windows_terminal %} Canary, through the Terminal Chat interface
 * The command line, through the {% data variables.product.prodname_cli %}
+* The {% data variables.copilot.github_copilot_app %}, a desktop application for agent-driven development. See [AUTOTITLE](/copilot/concepts/agents/github-copilot-app).
 * The {% data variables.product.github %} website
 
 See [AUTOTITLE](/copilot/get-started/features).

--- a/content/copilot/how-tos/set-up/index.md
+++ b/content/copilot/how-tos/set-up/index.md
@@ -13,3 +13,4 @@ redirect_from:
 contentType: how-tos
 ---
 
+To set up the {% data variables.copilot.github_copilot_app %} and create your first agent session, see [AUTOTITLE](/copilot/how-tos/github-copilot-app/getting-started).

--- a/content/copilot/how-tos/set-up/set-up-for-self.md
+++ b/content/copilot/how-tos/set-up/set-up-for-self.md
@@ -14,6 +14,8 @@ category:
   - Configure Copilot
 ---
 
+To set up the {% data variables.copilot.github_copilot_app %} and create your first agent session, see [AUTOTITLE](/copilot/how-tos/github-copilot-app/getting-started).
+
 ## 1. Get access to {% data variables.product.prodname_copilot %}
 
 There are a few ways that you can get access to {% data variables.product.prodname_copilot %}:


### PR DESCRIPTION
## Summary

- Add the GitHub Copilot app to the supported surfaces overview
- Link the general quickstart to the dedicated app quickstart without changing environment tabs
- Add app getting-started pointers to the setup hub and individual setup guide

## Testing

- `npm run lint-content -- --paths content/copilot/get-started/what-is-github-copilot.md content/copilot/get-started/quickstart.md content/copilot/how-tos/set-up/index.md content/copilot/how-tos/set-up/set-up-for-self.md`
- `CHANGED_FILES="content/copilot/get-started/what-is-github-copilot.md content/copilot/get-started/quickstart.md content/copilot/how-tos/set-up/index.md content/copilot/how-tos/set-up/set-up-for-self.md" npm run test -- src/content-render/tests/render-changed-and-deleted-files.ts`