### PR TITLE
Add Cerebras Systems Inc. to Subprocessor list

### DIFF
--- a/content/site-policy/privacy-policies/github-subprocessors.md
+++ b/content/site-policy/privacy-policies/github-subprocessors.md
@@ -28,6 +28,7 @@ If you have questions about this list, please contact us at <privacy@github.com>
 |-------------------------------|--------------------------------------------------------------------------------| ----------------------- | ------------------ |
 | Amazon Web Services Inc (AWS) | Cloud Hosted Infrastructure, Data Hosting, AI Inference and AI Services        | United States                                     | United States      |
 | Anthropic PBC                 | AI Inference and AI Services                                                   | United States                                     | United States      |
+| Cerebras Systems Inc.         | AI Inference and AI Services                                                   | United States                                     | United States      |
 | Cloudflare                    | Content delivery service                                                       | United States                                     | United States      |
 | Elasticsearch, Inc.           | Cloud Hosted Infrastructure                                                    | United States                                     | United States      |
 | Fastly                        | Content delivery service                                                       | United States                                     | United States      |


### PR DESCRIPTION
Adds Cerebras Systems Inc. to the Third Party Subprocessors table in the GitHub Subprocessor list.

| Field | Value |
|---|---|
| Name of Subprocessor | Cerebras Systems Inc. |
| Description of Processing | AI Inference and AI Services |
| Location of Processing | United States |
| Corporate Location | United States |

The row is inserted alphabetically between Anthropic PBC and Cloudflare.

Reference: github/product-and-privacy-legal#2144 (internal)