### PR TITLE
Fix duplicate criteria for active committers

### DIFF
--- a/content/billing/concepts/product-billing/github-code-quality.md
+++ b/content/billing/concepts/product-billing/github-code-quality.md
@@ -37,7 +37,6 @@ For more information about how {% data variables.product.prodname_ai_credits_sho
 * Your license usage is calculated based on the number of unique, active committers to repositories with {% data variables.product.prodname_code_quality_short %} enabled. 
 * Each **active committer** uses **one {% data variables.product.prodname_code_quality_short %} license**. 
 * A committer is considered active if one of their commits has been pushed to the repository within the last 90 days, regardless of when it was originally authored.
-* A committer is considered active if one of their commits has been pushed to the repository within the last 90 days, regardless of when it was originally authored.
 
 To understand your license usage, and which licenses you can free up, it helps to distinguish between active and unique committers. You can see the number of licenses you're using on the **Licensing** page for your organization or enterprise, shown as **"Consumed licenses"**:
 * **Active committers** are committers who contributed to at least one repository and have a {% data variables.product.prodname_team %} or {% data variables.product.prodname_enterprise %} license with your organization or enterprise. This includes members, enterprise-managed users, external collaborators, and people with a pending invitation to join your organization or enterprise.


### PR DESCRIPTION
Removed duplicate definition of 'active committer' criteria.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
