### PR TITLE
Title: Improve clarity of intro paragraph on REST API Guides page Body: The intro paragraph on /rest/guides reuses the word "results"  with two different meanings in the same sentence, making it harder  to read. Proposing a small copy edit for clarity.

### DIFF
--- a/content/rest/guides/index.md
+++ b/content/rest/guides/index.md
@@ -20,7 +20,6 @@ children:
   - /using-the-rest-api-to-interact-with-checks
   - /encrypting-secrets-for-the-rest-api
 ---
-This section of the documentation is intended to get you up-and-running with
-real-world {% data variables.product.github %} API applications. We'll go over everything you need to know, from authentication to results manipulation to integrating results with other apps.
-Every tutorial will include a project, and each project will be saved and documented in our public
+These guides walk you through building real-world applications with the {% data variables.product.github %} API, covering everything from authentication to processing and displaying the data you retrieve.
+Each guide includes a complete project, documented and available in the public
 [platform-samples](https://github.com/github/platform-samples) repository.


### PR DESCRIPTION
### Why:


### What's being changed (if available, include any code snippets, screenshots, or gifs):

Reworded the intro paragraph on the REST API Guides index page 
(`content/rest/guides/index.md`) to remove a repeated use of the 
word "results" and improve overall readability. Split one long 
sentence into two shorter ones for scannability. No changes to 
front matter, links, or the guides list.

**Before:**
> This section of the documentation is intended to get you 
> up-and-running with real-world GitHub API applications. We'll 
> go over everything you need to know, from authentication to 
> results manipulation to integrating results with other apps.

**After:**
> These guides walk you through building real-world applications 
> with the GitHub API, covering everything from authentication to 
> processing and displaying the data you retrieve.
> 
> Each guide includes a complete project, documented and available 
> in the public platform-samples repository.