### PR TITLE
Fix MCP management section link

### DIFF
--- a/content/copilot/concepts/agents/copilot-cli/about-copilot-cli.md
+++ b/content/copilot/concepts/agents/copilot-cli/about-copilot-cli.md
@@ -321,7 +321,7 @@ Alternatively, you can run {% data variables.copilot.copilot_cli_short %} in a v
 * **MCP servers in {% data variables.product.prodname_copilot_short %}**, which controls whether MCP servers can be used at all by {% data variables.product.prodname_copilot_short %}.
 * **MCP Registry URL**, which controls which MCP registry {% data variables.product.prodname_copilot_short %} will allow MCP servers to be used from.
 
-For more information about these policies, see [AUTOTITLE](/copilot/concepts/mcp-management#mcp-policy-settings).
+For more information about these policies, see [AUTOTITLE](/copilot/concepts/mcp-management#mcp-allowlists).
 
 ## Model usage
 


### PR DESCRIPTION

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Update the stale fragment after the target heading was renamed to MCP allowlists. This restores direct navigation from the Copilot CLI policy limitations section.

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

- content/copilot/concepts/agents/copilot-cli/about-copilot-cli.md
  - Replace the removed mcp-policy-settings fragment with mcp-allowlists.
<img width="1120" height="726" alt="Screen Recording 2026-08-12 at 10 17 29-compressed" src="https://github.com/user-attachments/assets/7b0b3052-7607-49de-a954-6ba854796b42" />

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
