### PR TITLE
llms.txt: link the parameterized API examples instead of bare endpoints

### DIFF
--- a/data/llms-txt/config-default.yml
+++ b/data/llms-txt/config-default.yml
@@ -11,9 +11,9 @@ how_to_use: |
   * [Versions API](https://docs.github.com/api/pagelist/versions): Lists all available documentation versions.
   * [Languages API](https://docs.github.com/api/pagelist/languages): Lists all available languages.
   * [Page List API](https://docs.github.com/api/pagelist/en/free-pro-team@latest): Returns every docs page path for a given language and version.
-  * [Article API](https://docs.github.com/api/article): Returns the full rendered content and context of any docs page as JSON. Example: `curl "https://docs.github.com/api/article?pathname=/en/get-started/start-your-journey/what-is-github"`
-  * [Article Body API](https://docs.github.com/api/article/body): Returns the full rendered content of any docs page as markdown. Example: `curl "https://docs.github.com/api/article/body?pathname=/en/get-started/start-your-journey/what-is-github"`
-  * [Search API](https://docs.github.com/api/search/v1): Search across all docs content. Example: `curl "https://docs.github.com/api/search/v1?query=actions&language=en&version=free-pro-team@latest"`
+  * [Article API](https://docs.github.com/api/article?pathname=/en/get-started/start-your-journey/what-is-github): Returns the full rendered content and context of any docs page as JSON. Example: `curl "https://docs.github.com/api/article?pathname=/en/get-started/start-your-journey/what-is-github"`
+  * [Article Body API](https://docs.github.com/api/article/body?pathname=/en/get-started/start-your-journey/what-is-github): Returns the full rendered content of any docs page as markdown. Example: `curl "https://docs.github.com/api/article/body?pathname=/en/get-started/start-your-journey/what-is-github"`
+  * [Search API](https://docs.github.com/api/search/v1?query=actions&language=en&version=free-pro-team@latest): Search across all docs content. Example: `curl "https://docs.github.com/api/search/v1?query=actions&language=en&version=free-pro-team@latest"`
   * [GitHub MCP server](https://github.com/github/github-mcp-server): For agents that connect via Model Context Protocol, the GitHub MCP server provides tools for working with GitHub itself: repositories, issues, pull requests, workflows, and code. It does not currently include docs search.
 
 pinned_section_heading: |


### PR DESCRIPTION
### Why:

Closes #45452

The three API entries in llms.txt's "How to use" section link the bare endpoints, which return HTTP 400 as linked. The working parameterized examples already exist in each entry's description, but agents that follow the href without parsing the description get a 400 instead of content.

### What's being changed:

In `data/llms-txt/config-default.yml`, the hrefs for the Article API, Article Body API, and Search API entries now point at the parameterized example URLs from their own descriptions. Descriptions and curl examples are unchanged, and the other entries (Versions, Languages, Page List) already work bare so they're untouched.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).