### PR TITLE
Add a direct link fallback for notifications

### DIFF
--- a/data/reusables/notifications/access_notifications.md
+++ b/data/reusables/notifications/access_notifications.md
@@ -1,3 +1,3 @@
-1. In the upper-right corner of any page, click {% octicon "inbox" aria-label="You have (no) unread notifications" %}.
+1. In the upper-right corner of any page, click {% octicon "inbox" aria-label="You have (no) unread notifications" %}. If the icon is not displayed, go directly to the [notifications page](https://github.com/notifications).
 
    ![Screenshot of the right corner of the header of GitHub. An inbox icon has a blue dot, indicating that there are unread notifications.](/assets/images/help/notifications/notifications-general-existence-indicator.png)


### PR DESCRIPTION
### Why:

Closes #45464

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Adds a direct link to the Notifications page as a fallback when the inbox icon is not displayed. The reusable is used by several notification-management procedures, so this keeps those paths accessible without changing their existing icon-based instructions.

Validation:

- `npm run lint-content -- --paths data/reusables/notifications/access_notifications.md`
- `NODE_ENV=development npm run test -- src/content-render/tests/render-changed-and-deleted-files.ts` (Node 24.19.0; 1 test file and 2 tests passed)

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.