### PR TITLE
Correct collaborator permission levels for personal-account repositories

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/repository-access-and-collaboration/permission-levels-for-a-personal-account-repository.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/repository-access-and-collaboration/permission-levels-for-a-personal-account-repository.md
@@ -1,6 +1,6 @@
 ---
 title: Permission levels for a personal account repository
-intro: 'A repository owned by a personal account has two permission levels: the repository owner and collaborators.'
+intro: 'A repository owned by a personal account has a single owner, and collaborators can be granted read, write, or admin access.'
 redirect_from:
   - /articles/permission-levels-for-a-user-account-repository
   - /github/setting-up-and-managing-your-github-user-account/permission-levels-for-a-user-account-repository
@@ -69,10 +69,10 @@ Repositories owned by personal accounts have a single owner who has full control
 
 {% endif %}
 
-Collaborators on a personal repository can pull (read) the contents of the repository and push (write) changes to the repository.
+Collaborators on a personal repository can be granted one of three access levels: read, write, or admin. The triage and maintain roles are only available on repositories owned by an organization.
 
 > [!NOTE]
-> In a private repository, repository owners can only grant write access to collaborators. Collaborators can't have read-only access to repositories owned by a personal account.
+> The triage and maintain roles are not available for repositories owned by a personal account. If you need those roles, or team-based access management, consider transferring the repository to an organization.
 
 Collaborators can also perform the following actions.
 


### PR DESCRIPTION
## Why

  Three statements in this article do not match the behaviour of the REST API. I verified each against the live API (`X-GitHub-Api-Version: 2026-03-10`).

  `PUT /repos/{owner}/{repo}/collaborators/{username}` on a **private repository owned by a personal account**:

  | requested | HTTP | recorded permission |
  |---|---|---|
  | `pull` | 201 | `read` |
  | `triage` | 422 | Validation Failed |
  | `push` | 201 | `write` |
  | `maintain` | 422 | Validation Failed |
  | `admin` | 201 | `admin` |

  Control run, same script and token, against a **private repository owned by an organization** — all five values accepted and recorded as requested.

  So personal-account repositories do support read, write and admin for collaborators. Only `triage` and `maintain` are organization-only, and the API rejects those explicitly with a `422` rather than silently substituting another level.

  Enforcement was confirmed independently: a collaborator granted `pull` on a private personal-account repository has `git push` rejected by the server and cannot access repository settings, while a collaborator granted `admin` can.

  ## Scope of this change

  - Verified on GitHub.com only (`fpt` / `ghec`). This article is also versioned for `ghes`, which I could not test. Happy to wrap the change in `{% ifversion fpt or ghec %}` if a maintainer confirms GHES behaves differently.
  - I deliberately did **not** touch the "Owner access" table. If admin can be granted to a collaborator, some entries there may also need revisiting, but I have not tested which, so I left it alone rather than guess.

  Refs #45537

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
