### PR TITLE
Document on.merge_group branches and branches-ignore filters (#32879)

### DIFF
--- a/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
+++ b/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
@@ -394,6 +394,28 @@ on:
     types: [checks_requested]
 ```
 
+
+You can use the `branches` and `branches-ignore` filters with `merge_group` to only run a workflow when the merge group targets specific branches. For more information, see [AUTOTITLE](/actions/reference/workflows-and-actions/workflow-syntax#onpull_requestpull_request_targetbranchesbranches-ignore).
+
+For example, you can run a workflow only when the merge group targets the `main` branch.
+
+```yaml
+on:
+  merge_group:
+    branches: [ "main" ]
+    types: [checks_requested]
+```
+
+You can also use `branches-ignore` to skip a specific branch.
+
+```yaml
+on:
+  merge_group:
+    branches-ignore: [ "main" ]
+    types: [checks_requested]
+```
+
+
 ## `milestone`
 
 | Webhook event payload | Activity types | `GITHUB_SHA` | `GITHUB_REF` |

--- a/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
+++ b/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
@@ -394,7 +394,6 @@ on:
     types: [checks_requested]
 ```
 
-
 You can use the `branches` and `branches-ignore` filters with `merge_group` to only run a workflow when the merge group targets specific branches. For more information, see [AUTOTITLE](/actions/reference/workflows-and-actions/workflow-syntax#onpull_requestpull_request_targetbranchesbranches-ignore).
 
 For example, you can run a workflow only when the merge group targets the `main` branch.
@@ -414,7 +413,6 @@ on:
     branches-ignore: [ "main" ]
     types: [checks_requested]
 ```
-
 
 ## `milestone`
 
@@ -1300,5 +1298,3 @@ jobs:
               body: 'Thank you for the PR!'
             });
 ```
-
-


### PR DESCRIPTION
Resolves #32879 by documenting the `branches` and `branches-ignore` filters for the `merge_group` event.

Both filters are supported for `merge_group` — the GitHub Actions team confirmed `branches-ignore` support directly in the issue thread (validated with a `branches-ignore: ["main"]` workflow). `branches` has been supported since the merge queue beta (Aug 2022).

This adds a short note plus two YAML examples (include and exclude) to the end of the `## merge_group` section of `events-that-trigger-workflows.md`, mirroring the existing `branches`/`branches-ignore` documentation style used for `pull_request`.

Note: this is an English-only content addition; localized files remain behind English, which is the allowed direction for the localization sync check.