### PR TITLE
Clarify authentication for enterprise audit log endpoints

### DIFF
--- a/content/rest/enterprise-admin/audit-log.md
+++ b/content/rest/enterprise-admin/audit-log.md
@@ -11,6 +11,7 @@ category:
   - Administer enterprises and billing
 ---
 
-{% data reusables.user-settings.enterprise-admin-api-classic-pat-only %}
+> [!NOTE]
+> These endpoints support authentication using a {% data variables.product.pat_v1 %} or an OAuth token with the `admin:enterprise` scope, for a user who is an enterprise administrator. {% data variables.product.prodname_github_app %} installation and user access tokens, and {% data variables.product.pat_v2_plural %}, are not supported.
 
 <!-- Content after this section is automatically generated -->


### PR DESCRIPTION
_GitHub Copilot generated this pull request._

## Summary

- Document support for OAuth tokens with the `admin:enterprise` scope.
- Clarify that GitHub App installation and user access tokens and fine-grained personal access tokens are unsupported.

## Testing

- `npm run lint-content -- --paths content/rest/enterprise-admin/audit-log.md`
- `CHANGED_FILES="content/rest/enterprise-admin/audit-log.md" npm run test -- src/content-render/tests/render-changed-and-deleted-files.ts`

Fixes github/audit-log#3795