### PR TITLE
fix(copilot-cli): wrap GITHUB_TOKEN expression in raw tags

### DIFF
--- a/content/copilot/how-tos/copilot-cli/use-copilot-cli-in-actions.md
+++ b/content/copilot/how-tos/copilot-cli/use-copilot-cli-in-actions.md
@@ -55,7 +55,7 @@ jobs:
       - name: Run Copilot
         run: copilot --yolo -p "Summarize the changes in this commit"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: {% raw %}${{ github.token }}{% endraw %}
 ```
 
 Key details about this example:


### PR DESCRIPTION
Before (rendered): `GITHUB_TOKEN: $` (check https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli-in-actions)
<img width="767" height="458" alt="image" src="https://github.com/user-attachments/assets/18b82c15-cbbc-4723-a42c-fe9df6056bab" />

After (rendered): `GITHUB_TOKEN: ${{ github.token }}`

Docs-only change, no content or behavior changes beyond the fix.

### Check off the following:
- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.