### PR TITLE
Update GitHub Pages navigation instructions

### DIFF
--- a/data/reusables/pages/sidebar-pages.md
+++ b/data/reusables/pages/sidebar-pages.md
@@ -1,1 +1,1 @@
-1. In the "Code, planning, and automation" section of the sidebar, click **{% octicon "browser" aria-hidden="true" aria-label="browser" %} Pages**.
+1. In the{% ifversion fpt or ghec %} "Code, planning, and automation"{% elsif ghes %} "Code and automation"{% endif %} section of the sidebar, click **{% octicon "browser" aria-hidden="true" aria-label="browser" %} Pages**.

--- a/data/reusables/pages/sidebar-pages.md
+++ b/data/reusables/pages/sidebar-pages.md
@@ -1,1 +1,1 @@
-1. In the "Code and automation" section of the sidebar, click **{% octicon "browser" aria-hidden="true" aria-label="browser" %} Pages**.
+1. In the "Code, planning, and automation" section of the sidebar, click **{% octicon "browser" aria-hidden="true" aria-label="browser" %} Pages**.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

Updated the GitHub Pages instructions to reflect the current GitHub repository settings sidebar. Specifically, the instructions now refer to “Code, planning, and automation” instead of the outdated “Code and automation” section when navigating to Pages.

<img width="1753" height="777" alt="Code, planning, and automation" src="https://github.com/user-attachments/assets/339da659-7a51-4b68-8628-59d53eda270b" />


This update applies to the following documentation pages:

+ [Deleting a GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/deleting-a-github-pages-site?utm_source=chatgpt.com)
+ [Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site?utm_source=chatgpt.com)
+ [Securing your GitHub Pages site with HTTPS](https://docs.github.com/en/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https?utm_source=chatgpt.com)
+ Other related GitHub Pages documentation, as applicable.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
