### PR TITLE
Add permissions to workflow_run example

### DIFF
--- a/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
+++ b/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
@@ -1248,6 +1248,9 @@ on:
 jobs:
   download:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      issues: write
     steps:
       - name: 'Download artifact'
         uses: {% data reusables.actions.action-download-artifact %}


### PR DESCRIPTION
### Why:

Closes: #45520

The `workflow_run` "Use the data" example downloads an artifact and creates a pull request comment using `GITHUB_TOKEN`, but the example does not explicitly declare the permissions required for these operations.

Explicitly declaring the required permissions makes the example work with repositories that use restrictive default `GITHUB_TOKEN` permissions and follows the principle of least privilege.

### What's being changed:

This PR adds explicit job-level permissions to the `download` job in the `workflow_run` example:

```yaml
permissions:
  actions: read
  issues: write
```

- `actions: read` allows the workflow to access and download the artifact from the triggering workflow.
- `issues: write` allows the workflow to create the pull request comment.

No other behavior in the example is changed.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet the docs fundamentals that are required for all content.
- [ ] All CI checks are passing and the changes look good in the review environment.