### PR TITLE
Add required permissions to the workflow_run example

### DIFF
--- a/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
+++ b/content/actions/reference/workflows-and-actions/events-that-trigger-workflows.md
@@ -1248,6 +1248,9 @@ on:
 jobs:
   download:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      issues: write
     steps:
       - name: 'Download artifact'
         uses: {% data reusables.actions.action-download-artifact %}


### PR DESCRIPTION
### Why:

Closes: #45520

The `workflow_run` "Use the data" example downloads an artifact from the triggering run and then posts a comment with `github.rest.issues.createComment`, and it declares no `permissions:` key. Downloading an artifact is documented as needing `Actions: read`, and creating an issue comment as `Issues: write` or `Pull requests: write`. The restricted repository default grants read access to `contents` and `packages` only, and the workflow permissions reference says the effective token starts from that default and changes only through a `permissions:` key. So a reader who copies the example into a repository on the restricted default gets a workflow that can do neither. On a permissive default it works. That is why the gap is easy to miss.

The surrounding section is about handling a potentially untrusted triggering workflow, and the example already carries a security comment about not extracting into the workspace directory. That makes it the example a reader is most likely to copy verbatim and least likely to widen by hand.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

A job-level `permissions:` block on the `download` job:

```yaml
permissions:
  actions: read
  issues: write
```

`pull-requests: write` is the documented alternative to `issues: write` here, not a third permission. Nothing else in the example changes.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.

I am not GitHub staff, so I left the SME box for a maintainer. The reasoning, the pages I read for the two requirements and the three things that would make the report wrong are in #45520.