### PR TITLE
Clarify authentication for data residency API requests

### DIFF
--- a/content/admin/data-residency/feature-overview-for-github-enterprise-cloud-with-data-residency.md
+++ b/content/admin/data-residency/feature-overview-for-github-enterprise-cloud-with-data-residency.md
@@ -53,7 +53,7 @@ The following features are either specific to {% data variables.enterprise.data_
 
 ### API access
 
-{% data reusables.data-residency.data-resident-enterprises-api-access %} You must authenticate all API requests to {% data variables.enterprise.data_residency_site %} with an access token, including requests to endpoints that do not require authentication on {% data variables.product.prodname_dotcom_the_website %}. For more information, see [AUTOTITLE](/admin/data-residency/about-github-enterprise-cloud-with-data-residency#api-access).
+{% data reusables.data-residency.data-resident-enterprises-api-access %} You must authenticate all API requests to {% data variables.enterprise.data_residency_site %} using a credential supported by the endpoint. For endpoints that do not require authentication on {% data variables.product.prodname_dotcom_the_website %}, authenticate with an access token. For more information, see [AUTOTITLE](/admin/data-residency/about-github-enterprise-cloud-with-data-residency#api-access).
 
 ### URL differences
 

--- a/content/admin/data-residency/feature-overview-for-github-enterprise-cloud-with-data-residency.md
+++ b/content/admin/data-residency/feature-overview-for-github-enterprise-cloud-with-data-residency.md
@@ -53,7 +53,7 @@ The following features are either specific to {% data variables.enterprise.data_
 
 ### API access
 
-{% data reusables.data-residency.data-resident-enterprises-api-access %} For more information, see [AUTOTITLE](/admin/data-residency/about-github-enterprise-cloud-with-data-residency#api-access).
+{% data reusables.data-residency.data-resident-enterprises-api-access %} You must authenticate all API requests to {% data variables.enterprise.data_residency_site %} with an access token, including requests to endpoints that do not require authentication on {% data variables.product.prodname_dotcom_the_website %}. For more information, see [AUTOTITLE](/admin/data-residency/about-github-enterprise-cloud-with-data-residency#api-access).
 
 ### URL differences
 


### PR DESCRIPTION
_GitHub Copilot generated this pull request._

## Summary

Clarifies that every API request to GitHub Enterprise Cloud with data residency must be authenticated with an access token, including endpoints that do not require authentication on GitHub.com.

## Validation

- `npm run lint-content -- --precommit --paths content/admin/data-residency/feature-overview-for-github-enterprise-cloud-with-data-residency.md`

Fixes github/api-platform#9973
