### PR TITLE
docs: specify custom SSH key file in troubleshooting

### DIFF
--- a/content/authentication/troubleshooting-ssh/error-permission-denied-publickey.md
+++ b/content/authentication/troubleshooting-ssh/error-permission-denied-publickey.md
@@ -141,6 +141,12 @@ You can also check that the key is being used by trying to connect to `git@{% da
 ssh -vT git@{% data variables.product.product_url %}
 ```
 
+If you use a private key with a non-default file name, use the `-i` option to specify the path to the key:
+
+```shell copy
+ssh -i ~/.ssh/KEY-FILE -vT git@{% data variables.product.product_url %}
+```
+
 You'll see output like this:
 
 ```shell


### PR DESCRIPTION
## Summary
- document how to specify a non-default private SSH key file when investigating `Permission denied (publickey)`
- add a focused `ssh -i ~/.ssh/KEY-FILE -vT` example to the existing troubleshooting flow

## Testing
- `npm run lint-content -- --paths content/authentication/troubleshooting-ssh/error-permission-denied-publickey.md`
- `git diff --check`

Fixes #42109