### PR TITLE
Clarify instructions for enabling commit signoffs

### DIFF
--- a/content/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository.md
+++ b/content/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository.md
@@ -23,4 +23,4 @@ Organization owners can also enable compulsory commit signoffs at the organizati
 
 {% data reusables.repositories.navigate-to-repo %}
 {% data reusables.repositories.sidebar-settings %}
-1. Select **Require contributors to sign off on web-based commits**.
+1. Under "Commits", Select **Require contributors to sign off on web-based commits**.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #45646

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

Updated the instructions for enabling or disabling compulsory commit signoffs.

<img width="982" height="427" alt="signoff" src="https://github.com/user-attachments/assets/9f537fd1-2e0f-4261-92c6-b28d88b0eb9c" />

Changed:

Select Require contributors to sign off on web-based commits.

to:

Under "Commits", select Require contributors to sign off on web-based commits.

This clarifies where users can find the setting in repository settings.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
