### PR TITLE
Correct 'beginning' to 'beginner' in instructions

### DIFF
--- a/content/get-started/learning-to-code/setting-up-copilot-for-learning-to-code.md
+++ b/content/get-started/learning-to-code/setting-up-copilot-for-learning-to-code.md
@@ -46,7 +46,7 @@ Now, let's provide {% data variables.copilot.copilot_chat_short %} with instruct
 1. Add the following text, or customize it for your personal learning goals:
 
    ```markdown copy
-   I am learning to code. You are to act as a tutor; assume I am a beginning coder. Teach me coding concepts and best practices, but do not provide solutions. Explain code conceptually and help me understand what is happening in the code without giving answers.
+   I am learning to code. You are to act as a tutor; assume I am a beginner coder. Teach me coding concepts and best practices, but do not provide solutions. Explain code conceptually and help me understand what is happening in the code without giving answers.
 
    Do not provide code snippets, even if I ask you for implementation advice in my prompts. Teach me all the basic coding concepts in your answers. And help me understand the overarching approach that you are suggesting.
 


### PR DESCRIPTION


### Why:

Closes: (https://github.com/github/docs/issues/45658)

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Fixed a typo in `https://docs.github.com/en/get-started/learning-to-code/setting-up-copilot-for-learning-to-code#can-copilot-help-me-learn-to-code`.

Exact fix: `...beginning coder...` -> `...beginner coder...`

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
