### PR TITLE
Update location of conversation resolution setting

### DIFF
--- a/content/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches.md
+++ b/content/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches.md
@@ -48,7 +48,6 @@ By default, the restrictions of a branch protection rule don't apply to people w
 For each branch protection rule, you can choose to enable or disable the following settings.
 * [Require pull request reviews before merging](#require-pull-request-reviews-before-merging)
 * [Require status checks before merging](#require-status-checks-before-merging)
-* [Require conversation resolution before merging](#require-conversation-resolution-before-merging)
 * [Require signed commits](#require-signed-commits)
 * [Require linear history](#require-linear-history)
 * [Require merge queue](#require-merge-queue)
@@ -86,6 +85,8 @@ Optionally, you can choose to require reviews from code owners. If you do, any p
 
 Optionally, you can require that the most recent reviewable push must be approved by someone other than the person who pushed it. This means at least one other authorized reviewer has approved any changes. For example, the "last reviewer" can check that the latest set of changes incorporates feedback from other reviews, and does not add new, unreviewed content.
 
+Optionally, you can select Require conversation resolution before merging to require all comments on the pull request to be resolved before it can be merged into a protected branch. This ensures that all comments are addressed or acknowledged before the pull request is merged.
+
 For complex pull requests that require many reviews, requiring an approval from someone other than the last person to push can be a compromise that avoids the need to dismiss all stale reviews: with this option, "stale" reviews are not dismissed, and the pull request remains approved as long as someone other than the person who made the most recent changes approves it. Users who have already reviewed a pull request can reapprove after the most recent push to meet this requirement. If you are concerned about pull requests being "hijacked" (where unapproved content is added to approved pull requests), it is safer to dismiss stale reviews.
 
 {% data reusables.pull_requests.security-changes-mergeability %}
@@ -109,10 +110,6 @@ You can set up required status checks to either be "loose" or "strict." The type
 | **Disabled** | The **Require status checks to pass before merging** checkbox is **not** checked. | The branch has no merge restrictions. | If required status checks aren't enabled, collaborators can merge the branch at any time, regardless of whether it is up to date with the base branch. This increases the possibility of incompatible changes.
 
 For troubleshooting information, see [AUTOTITLE](/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks).
-
-### Require conversation resolution before merging
-
-Requires all comments on the pull request to be resolved before it can be merged to a protected branch. This ensures that all comments are addressed or acknowledged before merge.
 
 ### Require signed commits
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #45668 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

Updates the [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
documentation to match the current placement of the Require conversation resolution before merging option in the GitHub branch protection settings.

Currently, the documentation describes **Require conversation resolution before merging** as a separate branch protection setting. In the GitHub UI, this option is displayed under Require a pull request before merging.

This PR updates the documentation to reflect the current UI by removing the option as a separate setting and including it with the **Require a pull request before merging** settings.

<img width="1132" height="792" alt="pull request before merging" src="https://github.com/user-attachments/assets/abe24bab-098b-4018-8bbb-078b8de575b5" />


### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
