### PR TITLE
Update authenticating-to-the-rest-api-with-an-oauth-app.md

### DIFF
--- a/content/apps/oauth-apps/building-oauth-apps/authenticating-to-the-rest-api-with-an-oauth-app.md
+++ b/content/apps/oauth-apps/building-oauth-apps/authenticating-to-the-rest-api-with-an-oauth-app.md
@@ -261,7 +261,7 @@ CLIENT_SECRET = ENV['GH_BASIC_SECRET_ID']
 use Rack::Session::Pool, :cookie_only => false
 
 def authenticated?
-  session[:access_token]
+  session[:refresh_token]
 end
 
 def authenticate!


### PR DESCRIPTION
The primary check should be for refresh_token, not access_token, since that more closely resembles production environments where the user's access token will expire first. The rest of the code should play out the same, with the subsequent requests failing if the access token is absent or invalid

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:
It initially misled me while I was trying to understand what GitHub's authentication flow with OAuth apps is supposed to be.

<!-- Paste the issue link or number here -->
Closes: https://github.com/github/docs/issues/45671

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Before:
```ruby
def authenticated?
  session[:access_token]
end
```
After:
```ruby
def authenticated?
  session[:refresh_token]
end
```

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [X] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [X] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [X] All CI checks are passing and the changes look good in the review environment.
