### PR TITLE
Fix stray period in Codespaces Quickstart further reading list

### DIFF
--- a/content/codespaces/quickstart.md
+++ b/content/codespaces/quickstart.md
@@ -116,5 +116,5 @@ You've successfully created, personalized, and run your first application within
 * [AUTOTITLE](/codespaces/managing-codespaces-for-your-organization/enabling-or-disabling-github-codespaces-for-your-organization)
 * [AUTOTITLE](/codespaces/developing-in-a-codespace/using-github-codespaces-in-visual-studio-code)
 * [AUTOTITLE](/codespaces/developing-in-a-codespace/using-github-codespaces-with-github-cli)
-* [AUTOTITLE](/codespaces/setting-your-user-preferences/setting-your-default-editor-for-github-codespaces).
+* [AUTOTITLE](/codespaces/setting-your-user-preferences/setting-your-default-editor-for-github-codespaces)
 * [AUTOTITLE](/codespaces/managing-codespaces-for-your-organization/managing-the-cost-of-github-codespaces-in-your-organization)


### PR DESCRIPTION
Fixes #45695

Removes a stray trailing period after one link in the "Further reading" section of the Codespaces Quickstart page. All other items in the list don't have a trailing period — this makes it consistent.