### PR TITLE
docs: correct what is editable on an immutable release

### DIFF
--- a/content/code-security/concepts/supply-chain-security/immutable-releases.md
+++ b/content/code-security/concepts/supply-chain-security/immutable-releases.md
@@ -22,16 +22,14 @@ When you enable immutable releases, the following protections are enforced:
 * **Git tags cannot be moved**: Once an immutable release is published, its associated Git tag is locked to a specific commit, cannot be changed, and cannot be deleted while the release exists. If you delete the immutable release, you can delete the tag, but you cannot reuse the same tag name.
 * **Release assets cannot be modified or deleted**: All files attached to the release (such as binaries and archives) are protected from modification or deletion.
 
+Only the assets and tag are locked. You can still edit the title and release notes of a published immutable release, and change whether it is marked as a pre-release or as the latest release.
+
 Additionally, creating an immutable release automatically generates a **release attestation**, which is a cryptographically verifiable record of a release containing the release tag, commit SHA, and release assets. Consumers can use this attestation to make sure the releases and artifacts they are using exactly match the published {% data variables.product.github %} releases.
 
 > [!NOTE]
 > Immutable releases include protection against repository resurrection attacks. Even if you delete a repository and create a new one with the same name, you cannot reuse tags that were associated with immutable releases in the original repository.
 
 If a release is immutable, you will see {% octicon "lock" aria-hidden="true" %} **Immutable**"  below the title on the release page.
-
-## What you can still change
-
-Immutability protects the assets and Git tag of a release. After an immutable release is published, you can still edit its title and release notes, and change whether it is marked as a pre-release or as the latest release.
 
 ## Best practices for publishing immutable releases
 
@@ -41,9 +39,7 @@ We recommend you use the following workflow for publishing an immutable release.
 1. Attach all associated assets to the draft release.
 1. Publish the draft release.
 
-This ensures that all assets are in place before the release becomes immutable, preventing the need to work around immutability restrictions.
-
-Draft releases are not public, so their assets cannot be downloaded the way consumers download them. To check that path before you promote a release, publish it as a pre-release, verify the published assets, then edit the release to clear **This is a pre-release** and select **Set as latest release**.
+This ensures that all assets are in place before the release becomes immutable, preventing the need to work around immutability restrictions. For more information, see [AUTOTITLE](/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release).
 
 ## Next steps
 

--- a/content/code-security/concepts/supply-chain-security/immutable-releases.md
+++ b/content/code-security/concepts/supply-chain-security/immutable-releases.md
@@ -29,6 +29,10 @@ Additionally, creating an immutable release automatically generates a **release 
 
 If a release is immutable, you will see {% octicon "lock" aria-hidden="true" %} **Immutable**"  below the title on the release page.
 
+## What you can still change
+
+Immutability protects the assets and Git tag of a release. After an immutable release is published, you can still edit its title and release notes, and change whether it is marked as a pre-release or as the latest release.
+
 ## Best practices for publishing immutable releases
 
 We recommend you use the following workflow for publishing an immutable release.
@@ -38,6 +42,8 @@ We recommend you use the following workflow for publishing an immutable release.
 1. Publish the draft release.
 
 This ensures that all assets are in place before the release becomes immutable, preventing the need to work around immutability restrictions.
+
+Draft releases are not public, so their assets cannot be downloaded the way consumers download them. To check that path before you promote a release, publish it as a pre-release, verify the published assets, then edit the release to clear **This is a pre-release** and select **Set as latest release**.
 
 ## Next steps
 

--- a/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
+++ b/content/repositories/releasing-projects-on-github/managing-releases-in-a-repository.md
@@ -81,7 +81,7 @@ If you @mention any {% data variables.product.github %} users in the notes, the 
 {% ifversion immutable-releases %}
 
 > [!NOTE]
-> If you have enabled immutable releases for your repository, you can only edit the title and release notes after a release is published. See [AUTOTITLE](/code-security/concepts/supply-chain-security/immutable-releases).
+> If you have enabled immutable releases for your repository, you cannot add, replace, or delete assets after a release is published, and you cannot move or delete its tag while the release exists. You can still edit the title and release notes, and change whether the release is a pre-release or the latest release. See [AUTOTITLE](/code-security/concepts/supply-chain-security/immutable-releases).
 
 {% endif %}
 


### PR DESCRIPTION
### Why:

Closes: https://github.com/github/docs/issues/45718

"Managing releases in a repository" says that under immutable releases you "can only edit the title and release notes after a release is published." That allowlist is wrong, and it contradicts [Immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), which lists exactly two enforced protections: Git tags cannot be moved, and release assets cannot be modified or deleted.

Measured on a repository with immutable releases enabled, against a published prerelease carrying one asset:

* **Accepted** — editing the title and notes, and `PATCH /repos/{owner}/{repo}/releases/{release_id}` with `prerelease=false` and `make_latest=legacy`; the release stays `"immutable": true`.
* **Rejected** — uploading an asset (422 `Cannot upload assets to an immutable release`), deleting an asset, and moving the tag (push declined by repository rules).

Read literally, the old note also rules out promoting a verified prerelease to latest — a release process immutability actually supports.

### What's being changed:

* `managing-releases-in-a-repository.md` — the note under "Editing a release" becomes a denylist matching the concepts page: no adding, replacing, or deleting assets, and no moving or deleting the tag while the release exists.
* `immutable-releases.md` — a sentence under "What immutable releases protect" bounds those protections to the assets and tag; "Best practices" now links to the release-creation instructions rather than restating them.

Both name the editable fields explicitly rather than as examples of a larger set: `name`, `body`, `prerelease` and `make_latest` were measured; `tag_name`, `target_commitish`, `draft` and `discussion_category_name` were not, so the wording claims nothing about them.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
