### PR TITLE
Update file creation guidelines in documentation

### DIFF
--- a/content/repositories/working-with-files/managing-files/creating-new-files.md
+++ b/content/repositories/working-with-files/managing-files/creating-new-files.md
@@ -15,7 +15,6 @@ category:
 When creating a file on {% data variables.product.github %}, consider the following:
 
 * If you try to create a new file in a repository that you don’t have access to, we will fork the project to your personal account and help you send [a pull request](/pull-requests/reference/pull-requests) to the original repository after you commit your change.
-* File names created via the web interface can only contain alphanumeric characters and hyphens (`-`). To use other characters, [create and commit the files locally, then push them to the repository on {% data variables.product.github %}](/repositories/working-with-files/managing-files/adding-a-file-to-a-repository).
 * {% data reusables.repositories.rulesets-push-rules-general-info-for-related-articles %}
 
 {% data reusables.repositories.sensitive-info-warning %}


### PR DESCRIPTION
Clarified restrictions on file names created via the web interface.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #45716

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

**Removed the outdated file name restriction guidance for files created via the web interface.**

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
