### PR TITLE
Rename section to '/rubber-duck' agent

### DIFF
--- a/content/copilot/how-tos/github-copilot-app/agent-sessions.md
+++ b/content/copilot/how-tos/github-copilot-app/agent-sessions.md
@@ -73,7 +73,7 @@ You can run the `/security-review` slash command in an active agent session to r
 
 This lightweight, on-demand review complements {% data variables.product.github %} {% data variables.product.prodname_code_scanning %}, {% data variables.product.prodname_dependabot %}, and {% data variables.product.prodname_secret_scanning %} by giving you an initial check on your local changes before opening a pull request.
 
-## Using the rubber duck agent
+## Using the `/rubber-duck` agent
 
 The rubber duck agent is a built-in agent that acts as a constructive critic, reviewing your current plan, implementation, or tests and returning concrete feedback. The agent runs on a different model from the one driving your current session.
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: #45754

### What's being changed (if available, include any code snippets, screenshots, or gifs):
This pull request updates documentation to clarify the usage of the `/rubber-duck` agent command. The change improves the accuracy and consistency of the agent's naming in the documentation.

Documentation update:

* Changed the section heading from "Using the rubber duck agent" to "Using the `/rubber-duck` agent" in `agent-sessions.md` to clarify the correct slash command syntax.

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [X] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
