### PR TITLE
Recommend GitHub App authentication in the ARC quickstart

### DIFF
--- a/content/actions/tutorials/use-actions-runner-controller/get-started.md
+++ b/content/actions/tutorials/use-actions-runner-controller/get-started.md
@@ -45,7 +45,7 @@ In order to use ARC, ensure you have the following.
 
     For additional Helm configuration options, see [`values.yaml`](https://github.com/actions/actions-runner-controller/blob/master/charts/gha-runner-scale-set-controller/values.yaml) in the ARC documentation.
 
-1. To enable ARC to authenticate to {% data variables.product.company_short %}, generate a {% data variables.product.pat_v1 %}. For more information, see [AUTOTITLE](/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api#authenticating-arc-with-a-personal-access-token-classic).
+1. To enable ARC to authenticate to {% data variables.product.company_short %}, create credentials using one of the authentication methods described in [AUTOTITLE](/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api). For repository and organization runners, {% data variables.product.company_short %} recommends authenticating with a {% data variables.product.prodname_github_app %}. For runners at the enterprise level, you must use a {% data variables.product.pat_v1 %}. For more information, see [AUTOTITLE](/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api#authenticating-arc-with-a-github-app) and [AUTOTITLE](/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api#authenticating-arc-with-a-personal-access-token-classic).
 
 ## Configuring a runner scale set
 
@@ -66,6 +66,7 @@ In order to use ARC, ensure you have the following.
         > [!NOTE]
         > * {% data reusables.actions.actions-runner-controller-security-practices-namespace %}
         > * {% data reusables.actions.actions-runner-controller-security-practices-secret %} For more information, see [AUTOTITLE](/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets).
+        > * If you authenticate ARC with a {% data variables.product.prodname_github_app %} for repository or organization runners, configure `githubConfigSecret` with the app credentials (`github_app_id`, `github_app_installation_id`, and `github_app_private_key`) instead of `github_token`. For more information, see [AUTOTITLE](/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api#authenticating-arc-with-a-github-app).
 
         ```bash copy
         INSTALLATION_NAME="arc-runner-set"


### PR DESCRIPTION
### Why

The [ARC quickstart](https://github.com/github/docs/blob/main/content/actions/tutorials/use-actions-runner-controller/get-started.md) currently instructs readers to generate a legacy personal access token (classic) as the default way to authenticate ARC to GitHub. For repository and organization runners, GitHub recommends authenticating with a GitHub App instead; a personal access token (classic) is only required for runners at the enterprise level.

### What changed

- The authentication step in the quickstart now points readers to the existing [authentication guidance](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api) and recommends a GitHub App for repository and organization runners, while noting that a personal access token (classic) is required for enterprise-level runners.
- Added a note near the PAT-based example clarifying that readers using a GitHub App should configure \githubConfigSecret\ with the app credentials (\github_app_id\, \github_app_installation_id\, and \github_app_private_key\) instead of \github_token\.

### Verification

- Anchor references in the updated links match existing section headings in the authentication guide.
- No content was removed from the PAT-based example, which remains valid (and required) for enterprise-level configurations.

Closes #37288
