### PR TITLE
Add Dependabot ecosystem support for Kotlin Toolchain

### DIFF
--- a/content/code-security/reference/supply-chain-security/dependabot-options-reference.md
+++ b/content/code-security/reference/supply-chain-security/dependabot-options-reference.md
@@ -258,6 +258,9 @@ The table below shows the package managers that support `cooldown`. The `default
 | {% ifversion dependabot-julia-support %} |
 | Julia                 | {% octicon "check" aria-label="Supported" %}              | {% octicon "check" aria-label="Supported" %} |
 | {% endif %} |
+| {% ifversion dependabot-kotlin-toolchain-support %} |
+| Kotlin Toolchain      | {% octicon "check" aria-label="Supported" %}              | {% octicon "check" aria-label="Supported" %} |
+| {% endif %} |
 | Maven                 | {% octicon "check" aria-label="Supported" %}              | {% octicon "check" aria-label="Supported" %} |
 | {% ifversion dependabot-nix-support %} |
 | Nix flakes            | {% octicon "check" aria-label="Supported" %}              | {% octicon "x" aria-label="Not supported" %} |
@@ -309,7 +312,31 @@ If you need to use more than one block in the configuration file to define updat
 
 ## `enable-beta-ecosystems` {% octicon "versions" aria-label="Version updates only" height="24" %}
 
+{% ifversion dependabot-kotlin-toolchain-support %}
+
+By default, {% data variables.product.prodname_dependabot %} updates the dependency manifests and lock files only for fully supported ecosystems. Use the `enable-beta-ecosystems` flag to opt in to updates for ecosystems that are not yet generally available.
+
+Ecosystems currently in {% data variables.release-phases.public_preview %}:
+
+* Kotlin Toolchain (`kotlin-toolchain`)
+
+```yaml copy
+# Configure an ecosystem in public preview
+
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "kotlin-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+{% else %}
+
 Not currently in use.
+
+{% endif %}
 
 ## `groups` {% octicon "versions" aria-label="Version updates" height="24" %} {% octicon "shield-check" aria-label="Security updates" height="24" %}
 
@@ -589,6 +616,9 @@ Package manager | YAML value      | Supported versions |
 | {% data variables.product.prodname_actions %}  | `github-actions` | Not applicable |
 | Go modules     | `gomod`          | v1               |
 | Gradle        | `gradle`         | Not applicable   |
+| {% ifversion dependabot-kotlin-toolchain-support %} |
+| Kotlin Toolchain | `kotlin-toolchain` | >=v0.11   |
+| {% endif %} |
 | Maven      | `maven`          | Not applicable   |
 | {% ifversion dependabot-nix-support %} |
 | Nix flakes | `nix`            | Not applicable   |

--- a/data/features/dependabot-kotlin-toolchain-support.yml
+++ b/data/features/dependabot-kotlin-toolchain-support.yml
@@ -1,0 +1,6 @@
+# Reference: https://github.com/dependabot/dependabot-core/pull/16203
+# Kotlin Toolchain support for Dependabot
+versions:
+  fpt: '*'
+  ghec: '*'
+  ghes: '>3.22'

--- a/data/reusables/dependabot/dependabot-updates-supported-versioning-tags.md
+++ b/data/reusables/dependabot/dependabot-updates-supported-versioning-tags.md
@@ -45,6 +45,9 @@ The `dependabot.yml` file doesn't control the versioning tags that you can use, 
 | {% ifversion dependabot-julia-support %} |
 | Julia               | `julia`        | Any SemVer prerelease identifier (commonly `rc`, `DEV`, `beta`) | `HTTP@1.10.0-rc1`, `Plots@2.0.0-DEV`, `DataFrames@1.6.0-beta.1` |
 | {% endif %} |
+| {% ifversion dependabot-kotlin-toolchain-support %} |
+| Kotlin Toolchain    | `kotlin-toolchain` | `alpha`, `a`, `beta`, `b`, `milestone`, `m`, `rc`, `cr`, `snapshot`, `ga`, `final`, `release`, `sp` (case-insensitive) | `kotlin-toolchain@0.12.0-dev-4188`, `kotlinx-coroutines-core@1.10.0-RC`, `ktor-server-core@3.0.0-rc-1` |
+| {% endif %} |
 | {% ifversion dependabot-nix-support %} |
 | Nix                 | `nix`          | None—tracks flake input commits (no versioning scheme) | `nixpkgs@a1b2c3d`, `devenv@e4f5a6b`, `flake-utils@c7d8e9f` |
 | {% endif %} |

--- a/data/reusables/dependabot/supported-package-managers.md
+++ b/data/reusables/dependabot/supported-package-managers.md
@@ -29,6 +29,9 @@ git submodule  | `gitsubmodule`   | Not applicable | {% octicon "check" aria-lab
 [{% data variables.product.prodname_actions %}](#github-actions)   | `github-actions` | Not applicable | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | Not applicable |
 Go modules     | `gomod`          | v1               | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} | {% octicon "check" aria-label="Supported" %} |
 [Gradle](#gradle)         | `gradle`         | Not applicable   | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} |
+| {% ifversion dependabot-kotlin-toolchain-support %} |
+[Kotlin Toolchain](#kotlin-toolchain) ({% data variables.release-phases.public_preview %}) | `kotlin-toolchain` | >=v0.11 | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} |
+| {% endif %} |
 [Maven](#maven)       | `maven`          | Not applicable   | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} |
 | {% ifversion dependabot-nix-support %} |
 [Nix](#nix)    | `nix`         | Not applicable               | {% octicon "check" aria-label="Supported" %} | {% octicon "x" aria-label="Not supported" %} | {% octicon "x" aria-label="Not supported" %} | Not applicable | Not applicable |
@@ -162,6 +165,27 @@ For {% data variables.product.prodname_dependabot_security_updates %}, Gradle su
 The `helm-registry` type only supports HTTP Basic Auth and does not support OCI-compliant registries. If you need to access an OCI-compliant registry for Helm charts, configure a `docker-registry` instead. For more information, see [AUTOTITLE](/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/configure-access-to-private-registries#docker-registry).
 
 When configuring {% data variables.product.prodname_dependabot %} for Helm charts, it will also automatically update the Docker images referenced within those charts, ensuring that both the chart versions and their contained images stay up to date.
+
+{% ifversion dependabot-kotlin-toolchain-support %}
+
+### Kotlin Toolchain
+
+{% data variables.product.prodname_dependabot %} support for Kotlin Toolchain is in {% data variables.release-phases.public_preview %}. To enable it, set `enable-beta-ecosystems: true` in your `dependabot.yml` file. For more information, see [`enable-beta-ecosystems`](/code-security/reference/supply-chain-security/dependabot-options-reference#enable-beta-ecosystems-).
+
+{% data variables.product.prodname_dependabot %} reads the toolchain version from the `kotlin` and `kotlin.bat` wrapper scripts in your project. Versions 0.11 and later are supported.
+
+{% data variables.product.prodname_dependabot %} updates Maven dependencies in the following files without running the toolchain:
+
+* `project.yaml`
+* `module.yaml`
+* `*.module-template.yaml`
+* `libs.versions.toml` or `gradle/libs.versions.toml`
+
+{% data variables.product.prodname_dependabot %} also updates the `kotlin` and `kotlin.bat` wrapper scripts when a new toolchain version is available. Kotlin Toolchain projects don't use a lockfile.
+
+Private registry support uses the `maven-repository` type, including `replaces-base`. For more information, see `maven-repository` in [AUTOTITLE](/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/configure-access-to-private-registries#maven-repository).
+
+{% endif %}
 
 ### Maven
 


### PR DESCRIPTION
### Why:

Dependabot is adding support for Kotlin Toolchain (by JetBrains, formerly Amper) as a beta ecosystem, and the docs do not mention it yet.

- Implementation: https://github.com/dependabot/dependabot-core/pull/16203
- Tracking issue: https://github.com/dependabot/dependabot-core/issues/16204

### What's being changed (if available, include any code snippets, screenshots, or gifs):

- Adds the `dependabot-kotlin-toolchain-support` feature flag (`data/features/`).
- Adds a Kotlin Toolchain row and a short "Kotlin Toolchain" section to the supported package managers reusable: YAML value `kotlin-toolchain`, toolchain 0.11 and later, the manifest files it updates (`project.yaml`, `module.yaml`, `*.module-template.yaml`, `libs.versions.toml`), the `kotlin`/`kotlin.bat` wrapper scripts, and `maven-repository` private registries.
- Adds Kotlin Toolchain to the `package-ecosystem` and `cooldown` tables in the Dependabot options reference.
- Documents `enable-beta-ecosystems`, listing Kotlin Toolchain as the ecosystem currently in public preview, with a `dependabot.yml` example. The "Not currently in use." text is kept for versions without the feature flag.
- Adds a Kotlin Toolchain row to the supported versioning tags table. It uses the same Maven-style qualifiers as Gradle.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
