### PR TITLE
Update documentation link for GitHub-hosted runners

### DIFF
--- a/content/actions/concepts/runners/github-hosted-runners.md
+++ b/content/actions/concepts/runners/github-hosted-runners.md
@@ -30,6 +30,7 @@ contentType: concepts
 Runners are the machines that execute jobs in a {% data variables.product.prodname_actions %} workflow. For example, a runner can clone your repository locally, install testing software, and then run commands that evaluate your code.
 
 {% data variables.product.prodname_dotcom %} provides runners that you can use to run your jobs, or you can [host your own runners](/actions/concepts/runners/self-hosted-runners). {% data reusables.actions.single-cpu-runners %}
+// Please update % data reusables.actions.single-cpu-runners to use https://docs.github.com/en/actions/reference/runners/github-hosted-runners
 
 Each runner comes with the runner application and other tools preinstalled. {% data variables.product.prodname_dotcom %}-hosted runners are available with Ubuntu Linux, Windows, or macOS operating systems. When you use a {% data variables.product.prodname_dotcom %}-hosted runner, machine maintenance and upgrades are taken care of for you.
 


### PR DESCRIPTION
Updated link to documentation for GitHub-hosted runners. The current link points to https://docs.github.com/en/enterprise-server@3.20/actions/reference/runners/github-hosted-runners#single-cpu-runners, when it should point to https://docs.github.com/en/actions/reference/runners/github-hosted-runners

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

<!-- Paste the issue link or number here -->
Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the review and current production articles. -->

### Check off the following:

- [ ] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [ ] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.
