### PR TITLE
Fix grammar in required profile-name note

### DIFF
--- a/content/account-and-profile/tutorials/personalize-your-profile.md
+++ b/content/account-and-profile/tutorials/personalize-your-profile.md
@@ -25,7 +25,7 @@ category:
 ---
 
 > [!NOTE]
-> Your profile name for your is {% data variables.product.github %} account is **required**. All other profile information described in this article is **optional**.
+> Your profile name for your {% data variables.product.github %} account is **required**. All other profile information described in this article is **optional**.
 
 ## Changing your profile picture
 


### PR DESCRIPTION
### Why:

Fixes a grammar typo that currently renders as “Your profile name for your is GitHub account is required.”

A previous PR (https://github.com/github/docs/pull/40826) targeted this same sentence but was closed as inactive and also included unrelated intro/a11y edits. This PR is the one-line grammar fix only.

Closes: 

<!-- No existing issue. CONTRIBUTING.md accepts typo and grammatical corrections without a new feature request. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

In `content/account-and-profile/tutorials/personalize-your-profile.md`, drop the stray `is` before the Liquid tag.

- Before: `Your profile name for your is {% data variables.product.github %} account is **required**.`
- After: `Your profile name for your {% data variables.product.github %} account is **required**.`

Liquid tags, bold, and surrounding markdown are unchanged.

## Summary
- Fixes a grammar typo in the Personalize your profile tutorial: "for your is GitHub account" → "for your GitHub account".

## Context
A previous PR (https://github.com/github/docs/pull/40826) targeted this same sentence but was closed as inactive and also included unrelated intro/a11y edits. This PR is the one-line grammar fix only.

## Test plan
- [ ] Preview the rendered sentence in `content/account-and-profile/tutorials/personalize-your-profile.md`
- [ ] Confirm the Liquid `{% data variables.product.github %}` tag is unchanged

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [ ] All CI checks are passing and the changes look good in the review environment.

Made with [Cursor](https://cursor.com)