### PR TITLE
fix: prevent install failure when CLI has authenticated with GHE

### DIFF
--- a/content/pull-requests/get-started/stacked-prs-quickstart.md
+++ b/content/pull-requests/get-started/stacked-prs-quickstart.md
@@ -24,14 +24,14 @@ category:
 ## Install the CLI extension
 
 ```shell copy
-gh extension install github/gh-stack
+gh extension install https://github.com/github/gh-stack
 ```
 
 > [!TIP]
 > To use stacked pull requests with AI coding agents, like {% data variables.product.prodname_copilot %}, install the `gh-stack` skill.
 > 
 > ```shell copy
-> gh skill install github/gh-stack
+gh skill install https://github.com/github/gh-stack gh-stack
 > ```
 
 ## Create your first stack

--- a/content/pull-requests/get-started/stacked-prs-quickstart.md
+++ b/content/pull-requests/get-started/stacked-prs-quickstart.md
@@ -31,7 +31,7 @@ gh extension install https://github.com/github/gh-stack
 > To use stacked pull requests with AI coding agents, like {% data variables.product.prodname_copilot %}, install the `gh-stack` skill.
 > 
 > ```shell copy
-gh skill install https://github.com/github/gh-stack gh-stack
+> gh skill install https://github.com/github/gh-stack gh-stack
 > ```
 
 ## Create your first stack


### PR DESCRIPTION
Running shortened installed commands `gh extension install github/gh-stack` and `gh skill install github/gh-stack` will throw errors like `could not resolve version: could not determine default branch: HTTP 404: Not Found (https://api.<company>.ghe.com/repos/github/gh-stack)` when GH CLI is already authenticated with Github Enterprise account.

### Why:

Following current installation instruction will lead to errors when GH CLI is already authenticated with Github Enterprise account.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

Installation commands for gh extension and gh skill.

### Check off the following:

- [x] A subject matter expert (SME) has reviewed the technical accuracy of the content in this PR. In most cases, the author can be the SME. Open source contributions may require an SME review from GitHub staff.
- [x] The changes in this PR meet [the docs fundamentals that are required for all content](http://docs.github.com/en/contributing/writing-for-github-docs/about-githubs-documentation-fundamentals).
- [x] All CI checks are passing and the changes look good in the review environment.
